### PR TITLE
Fix the errors in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,15 @@ The `--openapi` option enables OpenAPI endpoints for AI plugin integration. When
 
 To implement your own MCP server:
 
-1. Create a class conforming to `MCPServer`
+1. Attach the `@MCPServer` macro to a reference type like class or actor
 2. Define your tools using `@MCPTool` attribute
 3. Choose and configure a transport
 
 Example:
 
 ```swift
-class MyServer: MCPServer {
+@MCPServer
+class MyServer {
     @MCPTool
     func add(a: Int, b: Int) -> Int {
         return a + b


### PR DESCRIPTION
Update the Readme to reflect the correct usage of the `@MCPServer` macro.

* Change the instruction to attach the `@MCPServer` macro to a reference type like class or actor.
* Update the example to show attaching the `@MCPServer` macro to a class.
* Remove the incorrect instruction to "Create a class conforming to `MCPServer`".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Cocoanetics/SwiftMCP/pull/6?shareId=361edea0-5e15-49b4-b05f-10e6ec1f054a).