### PR TITLE
Fix Int extraction for boolean values

### DIFF
--- a/Sources/SwiftMCP/Extensions/Dictionary+ParameterExtraction.swift
+++ b/Sources/SwiftMCP/Extensions/Dictionary+ParameterExtraction.swift
@@ -262,6 +262,9 @@ public extension Dictionary where Key == String, Value == Sendable {
     func extractInt(named name: String) throws -> Int {
         if let value = self[name] as? Int {
             return value
+        } else if let boolValue = self[name] as? Bool {
+            // JSON decoding may coerce 0/1 into Bool values, so handle those
+            return boolValue ? 1 : 0
         } else if let doubleValue = self[name] as? Double {
             return Int(doubleValue)
         } else {


### PR DESCRIPTION
## Summary
- support `Bool` values for `Int` parameters when decoding

## Testing
- `swift test -q`