### PR TITLE
Fix Int extraction for boolean values

### DIFF
--- a/Sources/SwiftMCP/Extensions/Dictionary+ParameterExtraction.swift
+++ b/Sources/SwiftMCP/Extensions/Dictionary+ParameterExtraction.swift
@@ -262,6 +262,9 @@ public extension Dictionary where Key == String, Value == Sendable {
     func extractInt(named name: String) throws -> Int {
         if let value = self[name] as? Int {
             return value
+        } else if let boolValue = self[name] as? Bool {
+            // JSON decoding may coerce 0/1 into Bool values, so handle those
+            return boolValue ? 1 : 0
         } else if let doubleValue = self[name] as? Double {
             return Int(doubleValue)
         } else {
@@ -280,6 +283,9 @@ public extension Dictionary where Key == String, Value == Sendable {
     func extractDouble(named name: String) throws -> Double {
         if let value = self[name] as? Double {
             return value
+        } else if let boolValue = self[name] as? Bool {
+            // JSON decoding may coerce 0/1 into Bool values, so handle those
+            return boolValue ? 1 : 0
         } else if let intValue = self[name] as? Int {
             return Double(intValue)
         } else {
@@ -298,6 +304,9 @@ public extension Dictionary where Key == String, Value == Sendable {
     func extractFloat(named name: String) throws -> Float {
         if let value = self[name] as? Float {
             return value
+        } else if let boolValue = self[name] as? Bool {
+            // JSON decoding may coerce 0/1 into Bool values, so handle those
+            return boolValue ? 1 : 0
         } else if let intValue = self[name] as? Int {
             return Float(intValue)
         } else if let doubleValue = self[name] as? Double {

--- a/Tests/SwiftMCPTests/CalculatorTests.swift
+++ b/Tests/SwiftMCPTests/CalculatorTests.swift
@@ -60,4 +60,28 @@ func testInvalidArgumentType() async throws {
     } catch {
         #expect(Bool(false), "Error should be MCPToolError")
     }
-} 
+}
+
+@Test("Bool values should be converted when Int parameters are expected")
+func testBoolToIntConversion() async throws {
+    let calculator = Calculator()
+
+    let result = try await calculator.callTool("add", arguments: [
+        "a": true,
+        "b": false
+    ])
+
+    #expect(result as? Int == 1)
+}
+
+@Test("Bool values should be converted when Double parameters are expected")
+func testBoolToDoubleConversion() async throws {
+    let calculator = Calculator()
+
+    let result = try await calculator.callTool("divide", arguments: [
+        "numerator": true,
+        "denominator": true
+    ])
+
+    #expect(result as? Double == 1.0)
+}


### PR DESCRIPTION
## Summary
- support `Bool` values for `Int` parameters when decoding
- handle booleans when decoding `Double` and `Float`
- test Bool to Int and Bool to Double conversions

## Testing
- `swift test -q`
