### PR TITLE
Use generics for numeric extraction

### DIFF
--- a/Sources/SwiftMCP/Extensions/BinaryFloatingPoint+Conversion.swift
+++ b/Sources/SwiftMCP/Extensions/BinaryFloatingPoint+Conversion.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension BinaryFloatingPoint {
+    /// Attempts to convert the given value to `Self`.
+    /// Returns `nil` if the conversion is not possible.
+    static func convert(from value: Any) -> Self? {
+        if let this = value as? Self {
+            return this
+        }
+        if let boolValue = value as? Bool {
+            return boolValue ? 1 : 0
+        }
+        if let integerValue = value as? any BinaryInteger {
+            return Self(integerValue)
+        }
+        if let floatingValue = value as? any BinaryFloatingPoint {
+            return Self(floatingValue)
+        }
+        return nil
+    }
+}

--- a/Sources/SwiftMCP/Extensions/BinaryInteger+Conversion.swift
+++ b/Sources/SwiftMCP/Extensions/BinaryInteger+Conversion.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension BinaryInteger {
+    /// Attempts to convert the given value to `Self`.
+    /// Returns `nil` if the conversion is not possible.
+    static func convert(from value: Any) -> Self? {
+        if let this = value as? Self {
+            return this
+        }
+        if let boolValue = value as? Bool {
+            return boolValue ? 1 : 0
+        }
+        if let integerValue = value as? any BinaryInteger {
+            return Self(exactly: integerValue)
+        }
+        if let floatingValue = value as? any BinaryFloatingPoint {
+            return Self(exactly: floatingValue)
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary
- refactor numeric helpers into `BinaryInteger`/`BinaryFloatingPoint` extensions
- update dictionary extraction to use new generic conversions

## Testing
- `swift test --enable-code-coverage`
