### PR TITLE
Fix: Always encode argument description as string (never null) in Pro…

### DIFF
--- a/Demos/SwiftMCPDemo/DemoServer.swift
+++ b/Demos/SwiftMCPDemo/DemoServer.swift
@@ -169,5 +169,32 @@ actor DemoServer {
 				return "You selected BLUE!"
 		}
 	}
+    
+    /// A prompt for saying Hello
+    @MCPPrompt()
+    func helloPrompt(name: String) async throws -> [PromptMessage] {
+        
+        let message = PromptMessage(role: .assistant, content: .init(text: "Hello \(name)!"))
+        return [message]
+    }
+    
+    /// A prompt to get a color description
+    @MCPPrompt()
+    func colorPrompt(color: Color) -> [PromptMessage] {
+        
+        let text: String
+        
+        switch color {
+            case .red:
+                text = "You selected RED!"
+            case .green:
+                text = "You selected GREEN!"
+            case .blue:
+                text = "You selected BLUE!"
+        }
+        
+        let message = PromptMessage(role: .assistant, content: .init(text: text))
+        return [message]
+    }
 }
 

--- a/Sources/SwiftMCP/Models/Prompts/Prompt.swift
+++ b/Sources/SwiftMCP/Models/Prompts/Prompt.swift
@@ -31,7 +31,7 @@ extension Prompt {
         let args: [[String: AnyCodable]] = arguments.map { param in
             [
                 "name": AnyCodable(param.name),
-                "description": AnyCodable(param.description as Any?),
+                "description": AnyCodable(param.description ?? ""),
                 "required": AnyCodable(param.isRequired)
             ]
         }


### PR DESCRIPTION
…mpt, for OpenAPI compatibility.