### PR TITLE
Add customizable completion provider

### DIFF
--- a/Sources/SwiftMCP/Extensions/MCPParameterInfo+Completion.swift
+++ b/Sources/SwiftMCP/Extensions/MCPParameterInfo+Completion.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public extension MCPParameterInfo {
+    /// Provides default completion suggestions for this parameter.
+    /// - Parameter prefix: The prefix already typed by the client.
+    /// - Returns: Completion result based on the parameter's type.
+    func defaultCompletion(prefix: String) -> CompleteResult.Completion {
+        guard let caseType = type as? any CaseIterable.Type else {
+            return CompleteResult.Completion(values: [])
+        }
+
+        let values = caseType.caseLabels.sortedByBestCompletion(prefix: prefix)
+        return CompleteResult.Completion(values: values, total: values.count, hasMore: false)
+    }
+
+    /// Returns enum completions for this parameter if it is CaseIterable.
+    /// - Parameter prefix: The prefix already typed by the client.
+    /// - Returns: Completion result or nil if the parameter isn't an enum.
+    func defaultEnumCompletion(prefix: String) -> CompleteResult.Completion? {
+        guard type is any CaseIterable.Type else { return nil }
+        return defaultCompletion(prefix: prefix)
+    }
+}

--- a/Sources/SwiftMCP/Extensions/String+CompletionSorting.swift
+++ b/Sources/SwiftMCP/Extensions/String+CompletionSorting.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension Array where Element == String {
+    /// Returns the array sorted so that strings with the longest prefix match
+    /// come first. The comparison is case-insensitive.
+    /// - Parameter prefix: The prefix typed by the client.
+    func sortedByBestCompletion(prefix: String) -> [String] {
+        let lower = prefix.lowercased()
+        return self.enumerated().sorted { lhs, rhs in
+            let lMatch = lhs.element.lowercased().commonPrefix(with: lower).count
+            let rMatch = rhs.element.lowercased().commonPrefix(with: lower).count
+            if lMatch == rMatch {
+                return lhs.offset < rhs.offset
+            }
+            return lMatch > rMatch
+        }.map { $0.element }
+    }
+}

--- a/Sources/SwiftMCP/Protocols/MCPCompletionProviding.swift
+++ b/Sources/SwiftMCP/Protocols/MCPCompletionProviding.swift
@@ -1,0 +1,36 @@
+//
+//  MCPCompletionProviding.swift
+//  SwiftMCP
+//
+//  Created by Codex.
+//
+
+import Foundation
+
+/// Describes the context for which completion values should be provided.
+public enum MCPCompletionContext: Sendable {
+    case resource(MCPResourceMetadata)
+    case prompt(MCPPromptMetadata)
+}
+
+/// Protocol for providing completions for argument values.
+public protocol MCPCompletionProviding: MCPService {
+    /// Returns completion values for the given parameter in the provided context.
+    /// - Parameters:
+    ///   - parameter: The parameter for which a completion is requested.
+    ///   - context: The prompt or resource context.
+    ///   - prefix: The prefix string already entered by the client.
+    func completion(for parameter: MCPParameterInfo, in context: MCPCompletionContext, prefix: String) async -> CompleteResult.Completion
+}
+
+public extension MCPCompletionProviding {
+    /// Default implementation that mirrors the behaviour of `MCPParameterInfo.defaultCompletion(prefix:)`.
+    func completion(for parameter: MCPParameterInfo, in context: MCPCompletionContext, prefix: String) async -> CompleteResult.Completion {
+        return parameter.defaultCompletion(prefix: prefix)
+    }
+
+    /// Provides completion values for `CaseIterable` enums.
+    func defaultEnumCompletion(for parameter: MCPParameterInfo, prefix: String) -> CompleteResult.Completion? {
+        return parameter.defaultEnumCompletion(prefix: prefix)
+    }
+}

--- a/Tests/SwiftMCPTests/CompletionTests.swift
+++ b/Tests/SwiftMCPTests/CompletionTests.swift
@@ -21,6 +21,30 @@ class CompletionServer {
     }
 }
 
+@MCPServer
+class CustomCompletionServer: MCPCompletionProviding {
+    enum Color: CaseIterable { case red, green, blue }
+
+    @MCPResource("color://message?color={color}")
+    func getColorMessage(color: Color) -> String {
+        switch color {
+        case .red: return "You selected RED!"
+        case .green: return "You selected GREEN!"
+        case .blue: return "You selected BLUE!"
+        }
+    }
+
+    func completion(for parameter: MCPParameterInfo, in context: MCPCompletionContext, prefix: String) async -> CompleteResult.Completion {
+        if parameter.name == "color" {
+            let defaults = defaultEnumCompletion(for: parameter, prefix: prefix)?.values ?? []
+            let extra = ["ruby", "rose"].filter { $0.hasPrefix(prefix) }.sortedByBestCompletion(prefix: prefix)
+            let all = extra + defaults
+            return CompleteResult.Completion(values: all, total: all.count, hasMore: false)
+        }
+        return defaultEnumCompletion(for: parameter, prefix: prefix) ?? CompleteResult.Completion(values: [])
+    }
+}
+
 @Test("Enum completion returns case labels with prefix match first")
 func testEnumCompletion() async throws {
     let server = CompletionServer()
@@ -45,4 +69,39 @@ func testEnumCompletion() async throws {
     let values = unwrap(comp["values"] as? [String])
 
     #expect(values == ["red", "green", "blue"])
+}
+
+@Test("Custom completion provider returns custom values")
+func testCustomCompletionProvider() async throws {
+    let server = CustomCompletionServer()
+
+    let request = JSONRPCMessage.request(
+        id: 1,
+        method: "completion/complete",
+        params: [
+            "argument": ["name": "color", "value": "r"],
+            "ref": ["type": "ref/resource", "uri": "color://message?color={color}"]
+        ]
+    )
+
+    guard let message = await server.handleMessage(request),
+          case .response(let response) = message else {
+        #expect(Bool(false), "Expected response")
+        return
+    }
+
+    let result = unwrap(response.result)
+    let comp = unwrap(result["completion"]?.value as? [String: Any])
+    let values = unwrap(comp["values"] as? [String])
+
+    #expect(values.first == "ruby")
+    #expect(values.contains("red"))
+    #expect(values.count == 5)
+}
+
+@Test("Completion sorting prefers longer prefix matches")
+func testSortedByBestCompletion() {
+    let sorted = ["red", "green", "blue", "ruby"].sortedByBestCompletion(prefix: "re")
+    #expect(sorted.first == "red")
+    #expect(sorted[1] == "ruby")
 }


### PR DESCRIPTION
## Summary
- enable extensible autocompletion via new `MCPCompletionProviding` protocol
- adjust server completion handling to use the new protocol when available
- add tests covering custom completion behaviour
- improve default completion sorting with `sortedByBestCompletion`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68413d63b13083269485dd6f91562222