### PR TITLE
Support string-based JSON RPC ids

### DIFF
--- a/Sources/SwiftMCP/Models/JSONRPC/JSONRPCID.swift
+++ b/Sources/SwiftMCP/Models/JSONRPC/JSONRPCID.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Represents the identifier for a JSON-RPC message which may be an integer or a string.
+public enum JSONRPCID: Codable, Sendable, Hashable {
+    case int(Int)
+    case string(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let intValue = try? container.decode(Int.self) {
+            self = .int(intValue)
+        } else if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
+        } else {
+            throw DecodingError.typeMismatch(JSONRPCID.self,
+                                             DecodingError.Context(codingPath: decoder.codingPath,
+                                                                  debugDescription: "Expected Int or String for JSON-RPC id"))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .int(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        }
+    }
+}

--- a/Sources/SwiftMCP/Models/JSONRPC/JSONRPCMessage.swift
+++ b/Sources/SwiftMCP/Models/JSONRPC/JSONRPCMessage.swift
@@ -26,7 +26,7 @@ public enum JSONRPCMessage: Codable, Sendable {
         public var jsonrpc: String = "2.0"
 
         /// The unique identifier for the request (non-optional for requests expecting responses)
-        public var id: Int
+        public var id: JSONRPCID
 
         /// The name of the method to be invoked
         public var method: String
@@ -35,7 +35,7 @@ public enum JSONRPCMessage: Codable, Sendable {
         public var params: [String: AnyCodable]?
 
         /// Public initializer
-        public init(jsonrpc: String = "2.0", id: Int, method: String, params: [String : AnyCodable]? = nil) {
+        public init(jsonrpc: String = "2.0", id: JSONRPCID, method: String, params: [String : AnyCodable]? = nil) {
             self.jsonrpc = jsonrpc
             self.id = id
             self.method = method
@@ -68,13 +68,13 @@ public enum JSONRPCMessage: Codable, Sendable {
         public var jsonrpc: String = "2.0"
 
         /// The unique identifier matching the request ID (non-optional for responses)
-        public var id: Int
+        public var id: JSONRPCID
 
         /// The result of the method invocation, as a dictionary of result fields
         public var result: [String: AnyCodable]?
 
         /// Public initializer
-        public init(jsonrpc: String = "2.0", id: Int, result: [String: AnyCodable]? = nil) {
+        public init(jsonrpc: String = "2.0", id: JSONRPCID, result: [String: AnyCodable]? = nil) {
             self.jsonrpc = jsonrpc
             self.id = id
             self.result = result
@@ -102,12 +102,12 @@ public enum JSONRPCMessage: Codable, Sendable {
         public var jsonrpc: String = "2.0"
 
         /// The unique identifier matching the request ID
-        public var id: Int?
+        public var id: JSONRPCID?
 
         /// The error details containing the error code and message
         public var error: ErrorPayload
 
-        public init(jsonrpc: String = "2.0", id: Int?, error: ErrorPayload) {
+        public init(jsonrpc: String = "2.0", id: JSONRPCID?, error: ErrorPayload) {
             self.jsonrpc = jsonrpc
             self.id = id
             self.error = error
@@ -127,7 +127,7 @@ public enum JSONRPCMessage: Codable, Sendable {
     }
 
     /// The unique identifier for the message, used to correlate requests and responses
-    public var id: Int? {
+    public var id: JSONRPCID? {
         switch self {
             case .request(let data): return data.id
             case .response(let data): return data.id
@@ -138,16 +138,40 @@ public enum JSONRPCMessage: Codable, Sendable {
 
     // MARK: - Convenience Initializers
 
-    public static func request(jsonrpc: String = "2.0", id: Int, method: String, params: [String : AnyCodable]? = nil) -> JSONRPCMessage {
+    public static func request(jsonrpc: String = "2.0", id: JSONRPCID, method: String, params: [String : AnyCodable]? = nil) -> JSONRPCMessage {
         return .request(JSONRPCRequestData(jsonrpc: jsonrpc, id: id, method: method, params: params))
     }
 
-    public static func response(jsonrpc: String = "2.0", id: Int, result: [String: AnyCodable]? = nil) -> JSONRPCMessage {
+    public static func request(jsonrpc: String = "2.0", id: Int, method: String, params: [String : AnyCodable]? = nil) -> JSONRPCMessage {
+        request(jsonrpc: jsonrpc, id: .int(id), method: method, params: params)
+    }
+
+    public static func request(jsonrpc: String = "2.0", id: String, method: String, params: [String : AnyCodable]? = nil) -> JSONRPCMessage {
+        request(jsonrpc: jsonrpc, id: .string(id), method: method, params: params)
+    }
+
+    public static func response(jsonrpc: String = "2.0", id: JSONRPCID, result: [String: AnyCodable]? = nil) -> JSONRPCMessage {
         return .response(JSONRPCResponseData(jsonrpc: jsonrpc, id: id, result: result))
     }
 
-    public static func errorResponse(jsonrpc: String = "2.0", id: Int?, error: JSONRPCErrorResponseData.ErrorPayload) -> JSONRPCMessage {
+    public static func response(jsonrpc: String = "2.0", id: Int, result: [String: AnyCodable]? = nil) -> JSONRPCMessage {
+        response(jsonrpc: jsonrpc, id: .int(id), result: result)
+    }
+
+    public static func response(jsonrpc: String = "2.0", id: String, result: [String: AnyCodable]? = nil) -> JSONRPCMessage {
+        response(jsonrpc: jsonrpc, id: .string(id), result: result)
+    }
+
+    public static func errorResponse(jsonrpc: String = "2.0", id: JSONRPCID?, error: JSONRPCErrorResponseData.ErrorPayload) -> JSONRPCMessage {
         return .errorResponse(JSONRPCErrorResponseData(jsonrpc: jsonrpc, id: id, error: error))
+    }
+
+    public static func errorResponse(jsonrpc: String = "2.0", id: Int?, error: JSONRPCErrorResponseData.ErrorPayload) -> JSONRPCMessage {
+        errorResponse(jsonrpc: jsonrpc, id: id.map { .int($0) }, error: error)
+    }
+
+    public static func errorResponse(jsonrpc: String = "2.0", id: String?, error: JSONRPCErrorResponseData.ErrorPayload) -> JSONRPCMessage {
+        errorResponse(jsonrpc: jsonrpc, id: id.map { .string($0) }, error: error)
     }
 
     public static func notification(jsonrpc: String = "2.0", method: String, params: [String : AnyCodable]? = nil) -> JSONRPCMessage {
@@ -169,7 +193,7 @@ public enum JSONRPCMessage: Codable, Sendable {
 
         // All messages must have jsonrpc
         let jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
-        let id = try container.decodeIfPresent(Int.self, forKey: .id)
+        let id = try container.decodeIfPresent(JSONRPCID.self, forKey: .id)
 
         // Determine message type based on available keys
         if container.contains(.method) {

--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -192,7 +192,7 @@ public extension MCPServer {
      - Parameter id: The request ID to include in the response
      - Returns: A JSON-RPC message containing the initialization response
      */
-    func createInitializeResponse(id: Int) -> JSONRPCMessage {
+    func createInitializeResponse(id: JSONRPCID) -> JSONRPCMessage {
         var capabilities = ServerCapabilities()
 
         if self is MCPToolProviding {
@@ -411,7 +411,7 @@ public extension MCPServer {
 	 - Parameter id: The request ID to include in the response
 	 - Returns: A JSON-RPC message containing the tools list
 	 */
-    private func createToolsListResponse(id: Int) -> JSONRPCMessage {
+    private func createToolsListResponse(id: JSONRPCID) -> JSONRPCMessage {
 
         guard let toolProvider = self as? MCPToolProviding else
 		{
@@ -429,7 +429,7 @@ public extension MCPServer {
     }
 
     /// Creates a response listing all available prompts.
-    private func createPromptsListResponse(id: Int) -> JSONRPCMessage {
+    private func createPromptsListResponse(id: JSONRPCID) -> JSONRPCMessage {
         guard let promptProvider = self as? MCPPromptProviding else {
             return JSONRPCMessage.response(id: id, result: [
                 "content": [["type": "text", "text": "Server does not provide any prompts"]],
@@ -447,7 +447,7 @@ public extension MCPServer {
 	 - Parameter id: The request ID to include in the response
 	 - Returns: A JSON-RPC message containing the resources list
 	 */
-    func createResourcesListResponse(id: Int) async -> JSONRPCMessage {
+    func createResourcesListResponse(id: JSONRPCID) async -> JSONRPCMessage {
 
         guard let resourceProvider = self as? MCPResourceProviding else
 		{
@@ -482,7 +482,7 @@ public extension MCPServer {
        - request: The original JSON-RPC request
      - Returns: A JSON-RPC message containing the resource content or an error
      */
-    func createResourcesReadResponse(id: Int, request: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage {
+    func createResourcesReadResponse(id: JSONRPCID, request: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage {
 
         guard let resourceProvider = self as? MCPResourceProviding else
 		{
@@ -521,7 +521,7 @@ public extension MCPServer {
      - Parameter id: The request ID to include in the response
      - Returns: A JSON-RPC response containing the resource templates list
      */
-    func createResourceTemplatesListResponse(id: Int) async -> JSONRPCMessage {
+    func createResourceTemplatesListResponse(id: JSONRPCID) async -> JSONRPCMessage {
 
         guard let resourceProvider = self as? MCPResourceProviding else
 		{
@@ -553,7 +553,7 @@ public extension MCPServer {
      - Parameter id: The request ID to include in the response
      - Returns: A JSON-RPC response for ping
      */
-    func createPingResponse(id: Int) -> JSONRPCMessage {
+    func createPingResponse(id: JSONRPCID) -> JSONRPCMessage {
         return JSONRPCMessage.response(id: id, result: [:])
     }
 

--- a/Tests/SwiftMCPTests/CalculatorMockTests.swift
+++ b/Tests/SwiftMCPTests/CalculatorMockTests.swift
@@ -28,7 +28,7 @@ struct CalculatorMockTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(response.id == 1)
+            #expect(response.id == .int(1))
             let result = try #require(response.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -59,7 +59,7 @@ struct CalculatorMockTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(response.id == 1)
+            #expect(response.id == .int(1))
             let result = try #require(response.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -90,7 +90,7 @@ struct CalculatorMockTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(response.id == 1)
+            #expect(response.id == .int(1))
             let result = try #require(response.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -121,7 +121,7 @@ struct CalculatorMockTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(response.id == 1)
+            #expect(response.id == .int(1))
             let result = try #require(response.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -156,7 +156,7 @@ struct CalculatorMockTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(response.id == 1)
+            #expect(response.id == .int(1))
             let result = try #require(response.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -187,7 +187,7 @@ struct CalculatorMockTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(response.id == 1)
+            #expect(response.id == .int(1))
             let result = try #require(response.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -222,7 +222,7 @@ struct CalculatorMockTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(response.id == 1)
+            #expect(response.id == .int(1))
             let result = try #require(response.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -309,7 +309,7 @@ struct CalculatorMockTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(response.id == 1)
+            #expect(response.id == .int(1))
             let result = try #require(response.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == true)

--- a/Tests/SwiftMCPTests/ComplexTypesTests.swift
+++ b/Tests/SwiftMCPTests/ComplexTypesTests.swift
@@ -226,7 +226,7 @@ func testIntArrayProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
     let result = try #require(response.result)
     let isError = try #require(result["isError"]?.value as? Bool)
     #expect(isError == false)
@@ -257,7 +257,7 @@ func testOptionalIntArrayProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
     let result = try #require(response.result)
     let isError = try #require(result["isError"]?.value as? Bool)
     #expect(isError == false)
@@ -290,7 +290,7 @@ func testStringArrayProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
     let result = try #require(response.result)
     let isError = try #require(result["isError"]?.value as? Bool)
     #expect(isError == false)
@@ -323,7 +323,7 @@ func testDoubleArrayProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
     let result = try #require(response.result)
     let isError = try #require(result["isError"]?.value as? Bool)
     #expect(isError == false)
@@ -356,7 +356,7 @@ func testOptionalDoubleArrayProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
     let result = try #require(response.result)
     let isError = try #require(result["isError"]?.value as? Bool)
     #expect(isError == false)
@@ -389,7 +389,7 @@ func testBooleanArrayProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
     let result = try #require(response.result)
     let isError = try #require(result["isError"]?.value as? Bool)
     #expect(isError == false)
@@ -422,7 +422,7 @@ func testOptionalBooleanArrayProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
     let result = try #require(response.result)
     let isError = try #require(result["isError"]?.value as? Bool)
     #expect(isError == false)
@@ -462,7 +462,7 @@ func testContactInfoProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(createResponse.id == 1)
+    #expect(createResponse.id == .int(1))
     let createResult = try #require(createResponse.result)
     let createIsError = try #require(createResult["isError"]?.value as? Bool)
     #expect(createIsError == false)
@@ -487,7 +487,7 @@ func testContactInfoProcessing() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(processResponse.id == 1)
+    #expect(processResponse.id == .int(1))
     let processResult = try #require(processResponse.result)
     let processIsError = try #require(processResult["isError"]?.value as? Bool)
     #expect(processIsError == false)
@@ -582,7 +582,7 @@ func testProfileCreation() async throws {
         #expect(Bool(false), "Expected response case")
         return
     }
-    #expect(profileResponse.id == 1)
+    #expect(profileResponse.id == .int(1))
     let profileResult = try #require(profileResponse.result)
     let profileIsError = try #require(profileResult["isError"]?.value as? Bool)
     #expect(profileIsError == false)

--- a/Tests/SwiftMCPTests/EnumTests.swift
+++ b/Tests/SwiftMCPTests/EnumTests.swift
@@ -98,7 +98,7 @@ struct EnumTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(responseData.id == 1)
+            #expect(responseData.id == .int(1))
             let result = try #require(responseData.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -129,7 +129,7 @@ struct EnumTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(responseData.id == 2)
+            #expect(responseData.id == .int(2))
             let result = try #require(responseData.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -164,7 +164,7 @@ struct EnumTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(responseData.id == 3)
+            #expect(responseData.id == .int(3))
             let result = try #require(responseData.result)
             let content = try #require(result["content"]?.value as? [[String: String]])
             let firstContent = try #require(content.first)
@@ -197,7 +197,7 @@ struct EnumTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(responseData.id == 4)
+            #expect(responseData.id == .int(4))
             let result = try #require(responseData.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -228,7 +228,7 @@ struct EnumTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(responseData.id == 5)
+            #expect(responseData.id == .int(5))
             let result = try #require(responseData.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)
@@ -257,7 +257,7 @@ struct EnumTests {
                 throw TestError("Expected response case")
             }
             
-            #expect(responseData.id == 6)
+            #expect(responseData.id == .int(6))
             let result = try #require(responseData.result)
             let isError = try #require(result["isError"]?.value as? Bool)
             #expect(isError == false)

--- a/Tests/SwiftMCPTests/JSONRPCRequestTest.swift
+++ b/Tests/SwiftMCPTests/JSONRPCRequestTest.swift
@@ -13,7 +13,7 @@ func testDecodeJSONRPCRequest() throws {
 		throw TestError("Expected request case")
 	}
 	#expect(request.jsonrpc == "2.0")
-	#expect(request.id == 1)
+	#expect(request.id == .int(1))
 	#expect(request.method == "testMethod")
 	#expect(request.params?["foo"]?.value as? Int == 42)
 }
@@ -28,7 +28,7 @@ func testDecodeJSONRPCResponse() throws {
 		throw TestError("Expected response case")
 	}
 	#expect(response.jsonrpc == "2.0")
-	#expect(response.id == 1)
+	#expect(response.id == .int(1))
 	#expect(response.result?["bar"]?.value as? String == "baz")
 }
 
@@ -42,7 +42,7 @@ func testDecodeJSONRPCErrorResponse() throws {
 		throw TestError("Expected errorResponse case")
 	}
 	#expect(error.jsonrpc == "2.0")
-	#expect(error.id == 1)
+	#expect(error.id == .int(1))
 	#expect(error.error.code == -32601)
 	#expect(error.error.message == "Method not found")
 }
@@ -64,7 +64,7 @@ func testDecodeJSONRPCBatch() throws {
 	guard case .request(let request1) = batch[0] else {
 		throw TestError("Expected first message to be request")
 	}
-	#expect(request1.id == 1)
+	#expect(request1.id == .int(1))
 	#expect(request1.method == "ping")
 	
 	// Check second message is a notification
@@ -77,7 +77,7 @@ func testDecodeJSONRPCBatch() throws {
 	guard case .request(let request2) = batch[2] else {
 		throw TestError("Expected third message to be request")
 	}
-	#expect(request2.id == 2)
+	#expect(request2.id == .int(2))
 	#expect(request2.method == "tools/list")
 }
 
@@ -108,13 +108,13 @@ func testHandleBatchRequest() async throws {
 	guard case .response(let response1) = responses[0] else {
 		throw TestError("Expected first response to be response")
 	}
-	#expect(response1.id == 1)
+	#expect(response1.id == .int(1))
 	
 	// Check second response (tools/list)
 	guard case .response(let response2) = responses[1] else {
 		throw TestError("Expected second response to be response")
 	}
-	#expect(response2.id == 2)
+	#expect(response2.id == .int(2))
 }
 
 @Test
@@ -135,11 +135,11 @@ func testEncodeBatchResponse() throws {
 	guard case .response(let response1) = decoded[0] else {
 		throw TestError("Expected first message to be response")
 	}
-	#expect(response1.id == 1)
+	#expect(response1.id == .int(1))
 	
 	// Check second response
 	guard case .response(let response2) = decoded[1] else {
 		throw TestError("Expected second message to be response")
 	}
-	#expect(response2.id == 2)
+	#expect(response2.id == .int(2))
 }

--- a/Tests/SwiftMCPTests/MCPServerTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerTests.swift
@@ -37,7 +37,7 @@ func testInitializeRequest() async throws {
     }
     
     #expect(response.jsonrpc == "2.0")
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
     #expect(response.result != nil)
 
     // Check result contents
@@ -107,7 +107,7 @@ func testToolsListRequest() async throws {
         return
     }
     #expect(response.jsonrpc == "2.0")
-    #expect(response.id == 2)
+    #expect(response.id == .int(2))
     #expect(response.result != nil)
     
     guard let result = response.result else {
@@ -153,7 +153,7 @@ func testToolCallRequest() async throws {
         return
     }
     #expect(response.jsonrpc == "2.0")
-    #expect(response.id == 3)
+    #expect(response.id == .int(3))
     #expect(response.result != nil)
     
     guard let result = response.result else {
@@ -193,7 +193,7 @@ func testToolCallRequestWithError() async throws {
         return
     }
     #expect(response.jsonrpc == "2.0")
-    #expect(response.id == 4)
+    #expect(response.id == .int(4))
     #expect(response.result != nil)
     
     guard let result = response.result else {
@@ -244,7 +244,7 @@ func testToolCallRequestWithInvalidArgument() async throws {
         return
     }
     #expect(response.jsonrpc == "2.0")
-    #expect(response.id == 5)
+    #expect(response.id == .int(5))
     #expect(response.result != nil)
     
     guard let result = response.result else {
@@ -274,7 +274,7 @@ func testCustomNameAndVersion() async throws {
     let calculator = CustomNameCalculator()
     
     // Get the response using our test method
-    let response = calculator.createInitializeResponse(id: 1)
+    let response = calculator.createInitializeResponse(id: .int(1))
 
     // Extract server info from the response using pattern matching
     guard case .response(let responseData) = response else {
@@ -305,7 +305,7 @@ func testDefaultNameAndVersion() async throws {
     let calculator = DefaultNameCalculator()
     
     // Get the response using our test method
-    let response = calculator.createInitializeResponse(id: 1)
+    let response = calculator.createInitializeResponse(id: .int(1))
 
     // Extract server info from the response using pattern matching
     guard case .response(let responseData) = response else {
@@ -351,7 +351,7 @@ func testUnknownMethodReturnsMethodNotFoundError() async throws {
         return
     }
     #expect(response.jsonrpc == "2.0")
-    #expect(response.id == 99)
+    #expect(response.id == .int(99))
     #expect(response.error.code == -32601)
     #expect(response.error.message == "Method not found")
 }

--- a/Tests/SwiftMCPTests/PingTests.swift
+++ b/Tests/SwiftMCPTests/PingTests.swift
@@ -25,5 +25,5 @@ func testPingRequest() async throws {
         return
     }
     
-    #expect(response.id == 1)
+    #expect(response.id == .int(1))
 } 


### PR DESCRIPTION
## Summary
- allow `JSONRPCID` to be an `Int` or `String`
- update JSONRPCMessage and server helpers for the new ID type
- update tests to use `.int` IDs

## Testing
- `swift test -v` *(fails: environment timed out building dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68692da765848326b2454d7edf5e676c