### PR TITLE
Add progress context and notification

### DIFF
--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -73,20 +73,22 @@ public extension MCPServer {
      - Returns: A response message if one should be sent, nil otherwise
      */
     func handleMessage(_ message: JSONRPCMessage) async -> JSONRPCMessage? {
+        let context = RequestContext(message: message)
+        return await context.work { _ in
+            // First switch on message type
+            switch message {
+                case .request(let requestData):
+                    return await handleRequest(requestData)
 
-        // First switch on message type
-        switch message {
-            case .request(let requestData):
-                return await handleRequest(requestData)
+                case .notification(let notificationData):
+                    return await handleNotification(notificationData)
 
-            case .notification(let notificationData):
-                return await handleNotification(notificationData)
+                case .response(let responseData):
+                    return await handleResponse(responseData)
 
-            case .response(let responseData):
-                return await handleResponse(responseData)
-
-            case .errorResponse(let errorResponseData):
-                return await handleErrorResponse(errorResponseData)
+                case .errorResponse(let errorResponseData):
+                    return await handleErrorResponse(errorResponseData)
+            }
         }
     }
 

--- a/Sources/SwiftMCP/Transport/RequestContext.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext.swift
@@ -1,0 +1,84 @@
+import Foundation
+import AnyCodable
+
+/// Represents the context of a single JSON-RPC message.
+///
+/// A context tracks the message identifier, method name and optional
+/// metadata like a progress token. It is stored in task local storage so
+/// it can be accessed from anywhere while handling the message.
+public final class RequestContext: @unchecked Sendable {
+    /// Additional metadata sent in the `_meta` field of a request.
+    public struct Meta: @unchecked Sendable {
+        /// Optional progress token for sending progress notifications.
+        public let progressToken: AnyCodable?
+
+        init?(dictionary: [String: Any]) {
+            if let token = dictionary["progressToken"] {
+                self.progressToken = AnyCodable(token)
+            } else {
+                self.progressToken = nil
+            }
+        }
+    }
+
+    /// The identifier of the JSON-RPC message.
+    public let id: JSONRPCID?
+    /// The method of the JSON-RPC message if applicable.
+    public let method: String?
+    /// Optional metadata for the message.
+    public let meta: Meta?
+
+    /// Creates a new request context for the given message.
+    public init(message: JSONRPCMessage) {
+        switch message {
+        case .request(let data):
+            id = data.id
+            method = data.method
+            if let params = data.params,
+               let dict = params["_meta"]?.value as? [String: Any] {
+                meta = Meta(dictionary: dict)
+            } else {
+                meta = nil
+            }
+        case .notification(let data):
+            id = nil
+            method = data.method
+            if let params = data.params,
+               let dict = params["_meta"]?.value as? [String: Any] {
+                meta = Meta(dictionary: dict)
+            } else {
+                meta = nil
+            }
+        case .response(let data):
+            id = data.id
+            method = nil
+            meta = nil
+        case .errorResponse(let data):
+            id = data.id
+            method = nil
+            meta = nil
+        }
+    }
+
+    @TaskLocal
+    private static var taskContext: RequestContext?
+
+    /// Accessor for the current context stored in task local storage.
+    public static var current: RequestContext! { taskContext }
+
+    /// Runs `operation` with this context bound to `RequestContext.current`.
+    public func work<T>(_ operation: (RequestContext) async throws -> T) async rethrows -> T {
+        try await Self.$taskContext.withValue(self) {
+            try await operation(self)
+        }
+    }
+
+    /// Send a progress notification if a progress token was provided.
+    public func reportProgress(_ progress: Double, total: Double? = nil, message: String? = nil) async {
+        guard let progressToken = meta?.progressToken else { return }
+        await Session.current?.sendProgressNotification(progressToken: progressToken,
+                                                        progress: progress,
+                                                        total: total,
+                                                        message: message)
+    }
+}

--- a/Tests/SwiftMCPTests/ProgressTests.swift
+++ b/Tests/SwiftMCPTests/ProgressTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import SwiftMCP
+import Logging
+import AnyCodable
+
+/// Simple transport that records JSON-RPC messages sent through it.
+final class RecordingTransport: Transport {
+    let server: MCPServer
+    var sentMessages: [JSONRPCMessage] = []
+    var logger = Logger(label: "RecordingTransport")
+
+    init(server: MCPServer) {
+        self.server = server
+    }
+
+    func start() async throws {}
+    func run() async throws {}
+    func stop() async throws {}
+
+    func send(_ data: Data) async throws {
+        if let message = try? JSONDecoder().decode(JSONRPCMessage.self, from: data) {
+            sentMessages.append(message)
+        }
+    }
+}
+
+@Test("RequestContext extracts progress token")
+func testContextProgressToken() throws {
+    let message = JSONRPCMessage.request(
+        id: 1,
+        method: "tools/call",
+        params: [
+            "name": AnyCodable("getCurrentDateTime"),
+            "arguments": AnyCodable([:]),
+            "_meta": AnyCodable(["progressToken": 5])
+        ]
+    )
+
+    let context = RequestContext(message: message)
+    #expect(context.id == .int(1))
+    #expect(context.method == "tools/call")
+    #expect(context.meta?.progressToken?.value as? Int == 5)
+}
+
+@Test("Progress notification is sent via session")
+func testProgressNotification() async throws {
+    let server = Calculator()
+    let transport = RecordingTransport(server: server)
+    let session = Session(id: UUID())
+    session.transport = transport
+
+    let message = JSONRPCMessage.request(
+        id: 2,
+        method: "tools/call",
+        params: [
+            "name": AnyCodable("getCurrentDateTime"),
+            "arguments": AnyCodable([:]),
+            "_meta": AnyCodable(["progressToken": "abc"])
+        ]
+    )
+
+    await session.work { _ in
+        let context = RequestContext(message: message)
+        await context.work { ctx in
+            await ctx.reportProgress(0.5, total: 1.0, message: "Halfway")
+        }
+    }
+
+    #expect(transport.sentMessages.count == 1)
+    guard case .notification(let data) = transport.sentMessages[0] else {
+        throw TestError("Expected notification")
+    }
+    #expect(data.method == "notifications/progress")
+    let params = try #require(data.params)
+    #expect(params["progressToken"]?.value as? String == "abc")
+    #expect(params["progress"]?.value as? Double == 0.5)
+    #expect(params["total"]?.value as? Double == 1.0)
+    #expect(params["message"]?.value as? String == "Halfway")
+}

--- a/Tests/SwiftMCPTests/ProgressTests.swift
+++ b/Tests/SwiftMCPTests/ProgressTests.swift
@@ -75,6 +75,6 @@ func testProgressNotification() async throws {
     let params = try #require(data.params)
     #expect(params["progressToken"]?.value as? String == "abc")
     #expect(params["progress"]?.value as? Double == 0.5)
-    #expect(params["total"]?.value as? Double == 1.0)
+    #expect(params["total"]?.value as? Int == 1)
     #expect(params["message"]?.value as? String == "Halfway")
 }


### PR DESCRIPTION
## Summary
- add `RequestContext` to store JSON-RPC message metadata
- provide `sendProgressNotification` on `Session`
- wrap message handling in new context
- track progress token as `AnyCodable`
- add tests for progress context and notification

## Testing
- `swift test --enable-code-coverage` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_b_686b729651dc83269abebf33013ab283