### PR TITLE
Update documentation for server utilities and client features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,28 @@ A Swift implementation of the MCP (Model Context Protocol) for JSON-RPC over var
 
 ## Features
 
-- Multiple transport options:
+- Multiple transport options
   - Standard I/O (stdio) for command-line usage
   - HTTP+SSE (Server-Sent Events) for web applications
-- JSON-RPC 2.0 compliant
-- Asynchronous response handling via SSE
-- Built-in authorization support
-- Optional OAuth 2.0 validation with well-known endpoints
+- JSON-RPC 2.0 compliant with OpenAPI generation
+- Built-in authorization and optional OAuth validation
+- Transparent OAuth proxy mode for MCP and OpenAPI
 - Cross-platform compatibility
+
+### Server Features
+
+- **Tools** – expose functions with `@MCPTool`
+- **Resources** – publish data with `@MCPResource`
+- **Prompts** – build prompts using `@MCPPrompt`
+- **Utilities**
+  - Progress notifications via `RequestContext.current`
+  - Structured logging streamed through `Session.current`
+  - Completion suggestions for parameters (defaults for `Bool` and `CaseIterable`)
+
+### Client Features
+
+- **Roots** – dynamic filesystem roots announced by the client
+- **Sampling** – request small previews of client files
 
 ## Installation
 
@@ -72,6 +86,14 @@ Validation can use an introspection endpoint or by checking JWT claims against
 the provider's JWKS when introspection is not available. The transport also
 serves metadata at `/.well-known/oauth-authorization-server` and
 `/.well-known/oauth-protected-resource` for discovery by clients.
+
+## Progress, Logging, Roots and Sampling
+
+SwiftMCP can send progress updates while a tool is running, stream structured
+log messages to connected clients, handle dynamic filesystem roots announced
+by the client and request small data samples for preview. See the demo server for
+simple implementations of these features. The <doc:ServerCapabilities> and <doc:Sampling>
+articles describe the APIs in detail.
 
 ## Custom Server Implementation
 

--- a/Sources/SwiftMCP/SwiftMCP.docc/Articles/CoreConcepts.md
+++ b/Sources/SwiftMCP/SwiftMCP.docc/Articles/CoreConcepts.md
@@ -113,6 +113,10 @@ Without proper documentation:
 - Parameters may receive invalid values
 - Return values may be misinterpreted
 
+## Session and Request Context
+
+`Session.current` represents the client connection for the active task and lets you send log messages or other notifications. `RequestContext.current` exists only for the lifetime of a single request and provides the `reportProgress` helper. You can also inspect `Session.current.clientCapabilities` to discover client features such as roots or sampling support. Use these globals anywhere in your tool implementations.
+
 ## Best Practices
 
 1. Always document your server class with:
@@ -135,5 +139,4 @@ Without proper documentation:
 
 - [Swift Documentation Comments Guide](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
 - <doc:GettingStarted>
-- ``MCPServer``
-- ``MCPTool`` 
+- ``MCPServer``- ``MCPTool`` 

--- a/Sources/SwiftMCP/SwiftMCP.docc/Articles/Prompts.md
+++ b/Sources/SwiftMCP/SwiftMCP.docc/Articles/Prompts.md
@@ -1,0 +1,24 @@
+# Prompts
+
+Define reusable prompt builders with the ``MCPPrompt`` macro.
+
+## Overview
+
+A prompt is a function that returns text or ``PromptMessage`` objects for use with
+language models. ``MCPPrompt`` gathers the parameter information so prompts can be
+called through the same JSON-RPC mechanism as tools.
+
+```swift
+@MCPServer
+actor DemoServer {
+    /// Produce a greeting
+    @MCPPrompt()
+    func hello(name: String) -> String {
+        "Hello \(name)!"
+    }
+}
+```
+
+Prompts participate in completion just like tools and resources. ``CaseIterable`` enums
+and ``Bool`` parameters automatically receive sensible completions. Implement
+``MCPCompletionProviding`` to offer suggestions for other parameters.

--- a/Sources/SwiftMCP/SwiftMCP.docc/Articles/Resources.md
+++ b/Sources/SwiftMCP/SwiftMCP.docc/Articles/Resources.md
@@ -1,0 +1,43 @@
+# Resources
+
+Expose read-only data through URI templates using the ``MCPResource`` macro.
+
+## Overview
+
+Resources allow a server to publish structured data that clients can query by URI.
+Functions annotated with ``MCPResource`` describe the URI pattern and return either
+plain values or ``MCPResourceContent`` such as files.
+
+```swift
+@MCPServer
+actor ResourceServer {
+    /// Returns information about the server
+    @MCPResource("server://info")
+    func info() -> String {
+        "Demo server info"
+    }
+}
+```
+
+The macro validates that parameters match the URI placeholders and generates discovery
+metadata. Parameters in the template correspond to function arguments and SwiftMCP automatically converts them from their URI representation to the declared Swift types.
+
+Servers can also provide dynamic resources by implementing ``MCPResourceProviding``.
+The demo server, for example, returns a list of files from the Downloads folder
+via its ``mcpResources`` property:
+
+```swift
+extension DemoServer: MCPResourceProviding {
+    var mcpResources: [any MCPResource] {
+        get async { await getDynamicFileResources() }
+    }
+}
+```
+
+Clients can list available resources from ``MCPServer.mcpResourceTemplates``.
+
+### Completions
+
+When the server conforms to ``MCPCompletionProviding`` it can offer completion
+suggestions for resource parameters. By default ``Bool`` and ``CaseIterable`` enum
+parameters receive sensible completions.

--- a/Sources/SwiftMCP/SwiftMCP.docc/Articles/Sampling.md
+++ b/Sources/SwiftMCP/SwiftMCP.docc/Articles/Sampling.md
@@ -1,0 +1,31 @@
+# Sampling
+
+Request small samples of client data without transferring entire files.
+
+## Overview
+
+SwiftMCP clients can advertise sampling functionality during initialization. When `ClientCapabilities.sampling` is present the server may ask for short snippets of a file instead of the whole resource. The demo server shows how this can be used for quick previews before loading the full content. The capability is available at runtime as `Session.current.clientCapabilities.sampling`.
+
+The capability is defined alongside other client features:
+
+```swift
+public struct ClientCapabilities: Codable, Sendable {
+    /// Present if the client supports sampling functionality.
+    public var sampling: SamplingCapabilities?
+    
+    public struct SamplingCapabilities: Codable, Sendable {
+        /// Whether this client supports sampling functionality.
+        public var enabled: Bool?
+    }
+}
+```
+
+## Requesting Samples
+
+A server can call into `Session.current` to request a sample of a given resource. The client responds with the requested number of bytes which can then be inspected or processed.
+
+```swift
+let preview = try await Session.current?.sample(uri: fileURL, length: 512)
+```
+
+Sampling keeps network usage low and allows tools to operate on very large files efficiently.

--- a/Sources/SwiftMCP/SwiftMCP.docc/Articles/ServerCapabilities.md
+++ b/Sources/SwiftMCP/SwiftMCP.docc/Articles/ServerCapabilities.md
@@ -1,0 +1,47 @@
+# Extra Server Capabilities
+
+SwiftMCP servers can do more than just respond to tool calls.  They can stream log messages, report progress of long running tasks and react to client supplied roots.  This article shows how to use these features.
+
+## Progress Reporting
+
+When a client includes a `progressToken` inside the `_meta` field of a JSON‑RPC request the server can report progress back to the client.  `RequestContext.current` exposes a `reportProgress(_:total:message:)` method which automatically sends a `notifications/progress` message using the session of the current request.
+
+```swift
+@MCPTool(description: "Performs a 30‑second countdown with progress updates")
+func countdown() async -> String {
+    for i in (0...30).reversed() {
+        let done = Double(30 - i) / 30
+        await RequestContext.current?.reportProgress(done, total: 1.0, message: "\(i) seconds remaining")
+        if i > 0 { try? await Task.sleep(nanoseconds: 1_000_000_000) }
+    }
+    return "Countdown completed!"
+}
+```
+
+## Structured Logging
+
+`Session.current` represents the connection of the calling client.  Use `sendLogNotification(_:)` to stream structured log messages while a request is executing.  The demo server sends debug information for almost every tool:
+
+```swift
+await Session.current?.sendLogNotification(LogMessage(level: .info, data: [
+    "function": "add",
+    "arguments": ["a": a, "b": b]
+]))
+```
+
+## Roots Support
+
+If the client announces support for roots, the server can request the list of available filesystem roots and react to changes.  Check `Session.current.clientCapabilities.roots` before issuing requests. The demo server listens for the `roots/list_changed` notification and updates its list:
+
+```swift
+func handleRootsListChanged() async {
+    guard let session = Session.current else { return }
+    let updatedRoots = try? await session.listRoots()
+    await session.sendLogNotification(LogMessage(level: .info, data: [
+        "message": "Roots list updated",
+        "roots": updatedRoots ?? []
+    ]))
+}
+```
+
+These capabilities let SwiftMCP servers provide rich feedback channels for clients and adapt to their environment.

--- a/Sources/SwiftMCP/SwiftMCP.docc/Articles/Tools.md
+++ b/Sources/SwiftMCP/SwiftMCP.docc/Articles/Tools.md
@@ -1,0 +1,35 @@
+# Tools
+
+Learn how to expose functions as MCP tools using the ``MCPTool`` macro.
+
+## Overview
+
+Tools are the primary way to call functionality on a SwiftMCP server. By decorating a
+function with ``MCPTool`` the macro generates the metadata needed for JSON-RPC and
+OpenAPI integration. Documentation comments become the tool description and parameter
+information automatically.
+
+```swift
+@MCPServer
+actor ExampleServer {
+    /// Adds two numbers
+    /// - Parameters:
+    ///   - a: First number
+    ///   - b: Second number
+    /// - Returns: The sum
+    @MCPTool
+    func add(a: Int, b: Int) -> Int {
+        a + b
+    }
+}
+```
+
+Each ``MCPTool`` can be marked as consequential or not using the `isConsequential`
+parameter. This value is exported in the OpenAPI schema and allows clients to decide if
+calling the tool has side effects.
+
+### Completions
+
+Parameter completion values can be provided by conforming your server to
+``MCPCompletionProviding``. If no custom completions are supplied, SwiftMCP provides
+default suggestions for ``Bool`` parameters and any ``CaseIterable`` enum.

--- a/Sources/SwiftMCP/SwiftMCP.docc/SwiftMCP.md
+++ b/Sources/SwiftMCP/SwiftMCP.docc/SwiftMCP.md
@@ -46,6 +46,11 @@ Start with <doc:GettingStarted> to create your first MCP server, then explore <d
 
 - ``MCPServer``
 - ``MCPTool``
+- <doc:Tools>
+- <doc:Resources>
+- <doc:Prompts>
+- <doc:ServerCapabilities>
+- <doc:Sampling>
 
 ### Core Types
 
@@ -66,5 +71,4 @@ struct Calculator {
     func add(a: Double, b: Double) -> Double {
         return a + b
     }
-}
-``` 
+}``` 


### PR DESCRIPTION
## Summary
- restructure README feature list with server and client capabilities
- clarify completion behavior for prompts
- show dynamic resource provider example
- mention client capabilities on `Session.current`
- note roots capability check in extra server features

## Testing
- `swift test --skip-build` *(fails: posix_spawn error)*

------
https://chatgpt.com/codex/tasks/task_b_686e55218a5483268c86226c836e11f7