### PR TITLE
Implement list change notifications

### DIFF
--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -198,15 +198,15 @@ public extension MCPServer {
         var capabilities = ServerCapabilities()
 
         if self is MCPToolProviding {
-            capabilities.tools = .init(listChanged: false)
+            capabilities.tools = .init(listChanged: true)
         }
 
         if self is MCPResourceProviding {
-            capabilities.resources = .init(listChanged: false)
+            capabilities.resources = .init(listChanged: true)
         }
 
         if self is MCPPromptProviding {
-            capabilities.prompts = .init(listChanged: false)
+            capabilities.prompts = .init(listChanged: true)
         }
 
         // Advertise completion support

--- a/Sources/SwiftMCP/Transport/RequestContext.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext.swift
@@ -81,4 +81,19 @@ public final class RequestContext: @unchecked Sendable {
                                                         total: total,
                                                         message: message)
     }
+
+    /// Notify the client that the list of available tools changed.
+    public func sendToolListChanged() async {
+        await Session.current?.sendToolListChanged()
+    }
+
+    /// Notify the client that the list of available resources changed.
+    public func sendResourceListChanged() async {
+        await Session.current?.sendResourceListChanged()
+    }
+
+    /// Notify the client that the list of available prompts changed.
+    public func sendPromptListChanged() async {
+        await Session.current?.sendPromptListChanged()
+    }
 }

--- a/Sources/SwiftMCP/Transport/RequestContext.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext.swift
@@ -96,7 +96,8 @@ public final class RequestContext: @unchecked Sendable {
     /// Notify the client that the list of available prompts changed.
     public func sendPromptListChanged() async {
         await Session.current?.sendPromptListChanged()
-    
+    }
+
     /// Request sampling from the client.
     ///
     /// This method sends a sampling request to the client and returns the generated response.

--- a/Sources/SwiftMCP/Transport/Session.swift
+++ b/Sources/SwiftMCP/Transport/Session.swift
@@ -101,4 +101,37 @@ extension Session {
             // Intentionally ignore send errors in tests
         }
     }
+
+    /// Send a notification that the list of available tools changed.
+    public func sendToolListChanged() async {
+        let notification = JSONRPCMessage.notification(method: "notifications/tools/list_changed",
+                                                       params: [:])
+        do {
+            try await transport?.send(notification)
+        } catch {
+            // Intentionally ignore send errors in tests
+        }
+    }
+
+    /// Send a notification that the list of available resources changed.
+    public func sendResourceListChanged() async {
+        let notification = JSONRPCMessage.notification(method: "notifications/resources/list_changed",
+                                                       params: [:])
+        do {
+            try await transport?.send(notification)
+        } catch {
+            // Intentionally ignore send errors in tests
+        }
+    }
+
+    /// Send a notification that the list of available prompts changed.
+    public func sendPromptListChanged() async {
+        let notification = JSONRPCMessage.notification(method: "notifications/prompts/list_changed",
+                                                       params: [:])
+        do {
+            try await transport?.send(notification)
+        } catch {
+            // Intentionally ignore send errors in tests
+        }
+    }
 }

--- a/Tests/SwiftMCPTests/MCPServerTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerTests.swift
@@ -67,7 +67,7 @@ func testInitializeRequest() async throws {
     guard let listChanged = toolsDict["listChanged"] as? Bool else {
         throw TestError("listChanged not found in tools capabilities")
     }
-    #expect(listChanged == false, "Tools listChanged should be false")
+    #expect(listChanged == true, "Tools listChanged should be true")
 
     // Ensure completion capability is advertised
     #expect(capabilitiesDict["completions"] != nil)

--- a/Tests/SwiftMCPTests/NotificationTests.swift
+++ b/Tests/SwiftMCPTests/NotificationTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import SwiftMCP
+import Logging
+
+/// Simple transport to record sent JSON-RPC messages.
+final class RecordingTransportForNotifications: Transport {
+    let server: MCPServer
+    var sentMessages: [JSONRPCMessage] = []
+    var logger = Logger(label: "RecordingTransport")
+
+    init(server: MCPServer) { self.server = server }
+    func start() async throws {}
+    func run() async throws {}
+    func stop() async throws {}
+    func send(_ data: Data) async throws {
+        if let message = try? JSONDecoder().decode(JSONRPCMessage.self, from: data) {
+            sentMessages.append(message)
+        }
+    }
+}
+
+@Test("Tool list changed notification is sent")
+func testToolListChangedNotification() async throws {
+    let server = Calculator()
+    let transport = RecordingTransportForNotifications(server: server)
+    let session = Session(id: UUID())
+    session.transport = transport
+
+    let message = JSONRPCMessage.notification(method: "dummy")
+    await session.work { _ in
+        let context = RequestContext(message: message)
+        await context.work { ctx in
+            await ctx.sendToolListChanged()
+        }
+    }
+
+    #expect(transport.sentMessages.count == 1)
+    guard case .notification(let data) = transport.sentMessages[0] else {
+        throw TestError("Expected notification")
+    }
+    #expect(data.method == "notifications/tools/list_changed")
+}
+
+@Test("Resource list changed notification is sent")
+func testResourceListChangedNotification() async throws {
+    let server = Calculator()
+    let transport = RecordingTransportForNotifications(server: server)
+    let session = Session(id: UUID())
+    session.transport = transport
+
+    let message = JSONRPCMessage.notification(method: "dummy")
+    await session.work { _ in
+        let context = RequestContext(message: message)
+        await context.work { ctx in
+            await ctx.sendResourceListChanged()
+        }
+    }
+
+    #expect(transport.sentMessages.count == 1)
+    guard case .notification(let data) = transport.sentMessages[0] else {
+        throw TestError("Expected notification")
+    }
+    #expect(data.method == "notifications/resources/list_changed")
+}
+
+@Test("Prompt list changed notification is sent")
+func testPromptListChangedNotification() async throws {
+    let server = Calculator()
+    let transport = RecordingTransportForNotifications(server: server)
+    let session = Session(id: UUID())
+    session.transport = transport
+
+    let message = JSONRPCMessage.notification(method: "dummy")
+    await session.work { _ in
+        let context = RequestContext(message: message)
+        await context.work { ctx in
+            await ctx.sendPromptListChanged()
+        }
+    }
+
+    #expect(transport.sentMessages.count == 1)
+    guard case .notification(let data) = transport.sentMessages[0] else {
+        throw TestError("Expected notification")
+    }
+    #expect(data.method == "notifications/prompts/list_changed")
+}


### PR DESCRIPTION
## Summary
- add methods on `Session` for list change notifications
- expose helper APIs on `RequestContext`
- advertise list change support in `createInitializeResponse`
- expect tools list change capability in tests
- test notifications for tools, resources and prompts

## Testing
- `swift test --skip-build -l` *(fails: Test build artifacts were not found)*
- `swift test -l` *(fails to complete due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686be381b6308326bbd36bc2bc903d6c