### PR TITLE
Refine HTTPHandler aggregation

### DIFF
--- a/Tests/SwiftMCPTests/HTTPHandlerTests.swift
+++ b/Tests/SwiftMCPTests/HTTPHandlerTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
+@testable import SwiftMCP
+
+@MCPServer(name: "HandlerTestServer", version: "1.0")
+final class HandlerTestServer {
+    @MCPTool(description: "Echo input")
+    func echo(message: String) -> String {
+        message
+    }
+}
+
+@Suite("HTTPHandler chunked body handling", .tags(.unit))
+struct HTTPHandlerChunkedBodyTests {
+
+    @Test("Aggregates multi-chunk bodies before decoding")
+    func aggregatesChunkedRequestBodies() async throws {
+        let server = HandlerTestServer()
+        let transport = HTTPSSETransport(server: server)
+
+        let handler = TestHTTPHandler(transport: transport)
+
+        let channel = EmbeddedChannel(handler: handler)
+        defer { _ = try? channel.finish() }
+
+        let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+
+        let firstChunk = channel.allocator.buffer(string: "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{")
+        let secondChunk = channel.allocator.buffer(string: "\"name\":\"TestClient\",\"version\":\"1.0\"}}}")
+
+        try channel.writeInbound(HTTPServerRequestPart.body(firstChunk))
+        try channel.writeInbound(HTTPServerRequestPart.body(secondChunk))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(handler.capturedBody?.contains("\"jsonrpc\":\"2.0\"") == true)
+    }
+}
+
+final class TestHTTPHandler: HTTPHandler, @unchecked Sendable {
+
+    private(set) var capturedBody: String?
+
+    override func processRequest(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?) {
+        capturedBody = body?.getString(at: body?.readerIndex ?? 0, length: body?.readableBytes ?? 0)
+    }
+}


### PR DESCRIPTION
## Summary
- aggregate HTTP request bodies without changing HTTPHandler initialization
- expose request processing override via subclassing and update chunked-body test accordingly
- keep full payload dispatch until request end to avoid partial handling

## Testing
- swift test --filter HTTPHandlerChunkedBodyTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69368f7b508883268555da4ce1644154)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aggregate multi-chunk HTTP request bodies and add an overridable `processRequest` in `HTTPHandler`, with a unit test verifying chunk aggregation.
> 
> - **Transport (`Sources/SwiftMCP/Transport/HTTPHandler.swift`)**:
>   - Aggregate multi-chunk request bodies by copying initial buffer and appending subsequent chunks before processing.
>   - Add `processRequest(context:head:body:)` and call it on `.end`; keep `handleRequest` and delegate from `processRequest`.
>   - Change `HTTPHandler` from `final` to `class` to enable subclassing.
> - **Tests (`Tests/SwiftMCPTests/HTTPHandlerTests.swift`)**:
>   - Add `HTTPHandlerChunkedBodyTests` using `EmbeddedChannel` and a `TestHTTPHandler` subclass overriding `processRequest` to assert body aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8553e35d7e2e366108a9234a158bda64eee09b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->