### PR TITLE
Handle request bodies as Data

### DIFF
--- a/Sources/SwiftMCP/Extensions/JSONRPCMessage+Batch.swift
+++ b/Sources/SwiftMCP/Extensions/JSONRPCMessage+Batch.swift
@@ -20,16 +20,9 @@ extension JSONRPCMessage {
     /// - Parameter buffer: Incoming buffer containing JSON data.
     static func decodeMessages(from buffer: ByteBuffer) throws -> [JSONRPCMessage] {
         var copy = buffer
-        if let data = copy.readData(length: copy.readableBytes) {
-            return try decodeMessages(from: data)
+        guard let data = copy.readData(length: copy.readableBytes) else {
+            return []
         }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        if let batch = try? decoder.decode([JSONRPCMessage].self, from: buffer) {
-            return batch
-        } else {
-            let single = try decoder.decode(JSONRPCMessage.self, from: buffer)
-            return [single]
-        }
+        return try decodeMessages(from: data)
     }
 }

--- a/Sources/SwiftMCP/Transport/RequestState.swift
+++ b/Sources/SwiftMCP/Transport/RequestState.swift
@@ -1,3 +1,4 @@
+import Foundation
 import NIOHTTP1
 import NIOCore
 
@@ -5,5 +6,5 @@ import NIOCore
 enum RequestState {
     case idle
     case head(HTTPRequestHead)
-    case body(head: HTTPRequestHead, data: ByteBuffer)
-} 
+    case body(head: HTTPRequestHead, data: Data)
+}


### PR DESCRIPTION
## Summary
- accumulate HTTP request bodies as `Data` instead of `ByteBuffer`
- decode JSON-RPC messages from collected `Data` payloads
- simplify ByteBuffer decoding helper to convert through `Data`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69369e2f794c8326be3967a650716f4f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch HTTP request handling from ByteBuffer to Data, simplifying decoding and updating handlers to process and forward Data bodies.
> 
> - **Transport (HTTPHandler)**:
>   - Accumulates request bodies as `Data` (handles chunked `.body` parts) and updates `RequestState` to store `Data`.
>   - Updates method signatures to accept `Data?` for handlers: `handleRequest`, `handleSimpleResponse`, `handleSSE`, `handleMessagesAsync`, `handleToolCall`/`handleToolCallAsync`, and `handleOAuthProxy`.
>   - Parses JSON arguments and forwards/proxies bodies using `Data`.
> - **JSON-RPC Decoding**:
>   - Simplifies `JSONRPCMessage.decodeMessages(from: ByteBuffer)` to convert to `Data` (returns empty array if no data) and delegate to the `Data`-based decoder.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 934481d957e8f8e1da7700db4d1bdf425fd14410. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->