### PR TITLE
Retry Bonjour listener on mDNSResponder restart

### DIFF
--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
@@ -63,9 +63,13 @@ public final class TCPBonjourTransport: Transport, @unchecked Sendable {
             }
         }
 
-        func replaceListener(_ listener: NWListener) {
+        /// Replaces the current listener if the transport is still running.
+        /// Returns `false` when stopped — the caller must cancel the orphaned listener.
+        func replaceListenerIfRunning(_ newListener: NWListener) -> Bool {
+            guard isRunning else { return false }
             self.listener?.cancel()
-            self.listener = listener
+            self.listener = newListener
+            return true
         }
 
         func scheduleRetry(block: @Sendable @escaping () async -> Void) {
@@ -252,7 +256,10 @@ public final class TCPBonjourTransport: Transport, @unchecked Sendable {
 
                     do {
                         let newListener = try self.createListener()
-                        await self.state.replaceListener(newListener)
+                        guard await self.state.replaceListenerIfRunning(newListener) else {
+                            newListener.cancel()
+                            return
+                        }
                         newListener.start(queue: self.queue)
                         self.logger.info("Bonjour listener re-created, waiting for it to become ready.")
                         return


### PR DESCRIPTION
## Summary

- Detect Bonjour listener failure due to DNS error -65563 (`kDNSServiceErr_ServiceNotRunning`), which occurs when mDNSResponder restarts (e.g. wake from sleep)
- Instead of logging and leaving the transport dead, retry listener registration with exponential backoff (1s → 2s → 4s → … → 60s max)
- Log warning on each failure and info on successful recovery
- Cancel pending retries on `stop()`

## Implementation

- Extracted `createListener()` from `start()` so it can be reused during retries
- Added `replaceListener()` and `setRetryTask()` to `TransportState` actor for safe state management
- `isServiceNotRunning(_:)` checks for the specific `NWError.dns(-65563)` pattern
- `scheduleListenerRetry()` runs an async task with exponential backoff; each successful re-creation hands the new listener back to the state actor

Fixes #77

## Test plan

- [x] All 295 existing tests pass
- [ ] Manual: run a TCP+Bonjour demo, `sudo killall -STOP mDNSResponder && sudo killall -CONT mDNSResponder`, verify retry logs and recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)