### PR TITLE
Fix #77: Retry Bonjour listener with generation-based lifecycle

### DIFF
--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
@@ -98,11 +98,12 @@ public final class TCPBonjourTransport: Transport, @unchecked Sendable {
         }
 
         /// Called when the listener reaches `.ready`.
-        /// Resets backoff and clears any pending retry.
-        func listenerReady(generation listenerGen: UInt64) {
-            guard listenerGen == generation, isRunning else { return }
+        /// Resets backoff, clears any pending retry, and returns the bound port (if available).
+        func listenerReady(generation listenerGen: UInt64) -> UInt16? {
+            guard listenerGen == generation, isRunning else { return nil }
             retryAttempt = 0
             cancelRetryTask()
+            return listener?.port?.rawValue
         }
 
         /// Called when the listener fails with a retryable error.
@@ -246,7 +247,9 @@ public final class TCPBonjourTransport: Transport, @unchecked Sendable {
     private func handleListenerState(_ newState: NWListener.State, generation: UInt64) async {
         switch newState {
         case .ready:
-            await state.listenerReady(generation: generation)
+            if let boundPort = await state.listenerReady(generation: generation) {
+                port = boundPort
+            }
             logger.info("TCP+Bonjour transport ready on port \(port.map(String.init) ?? "unknown")")
 
         case .failed(let error):


### PR DESCRIPTION
Fixes #77.

## Problem

When macOS's `mDNSResponder` daemon restarts, `TCPBonjourTransport` terminates because the Bonjour listener fails with `ServiceNotRunning` (-65563) and is never re-established.

## Design

Replaces the ad-hoc retry approach from PR #78 with a **generation-based lifecycle state machine** inside `TransportState`:

### How it works
- Each listener gets a **generation token** from the actor
- `stateUpdateHandler` captures only `[weak self]` + generation (no retain cycle)
- `.ready` → resets backoff to 0, clears retry task, updates bound port
- `.failed(ServiceNotRunning)` → increments backoff attempt, schedules **one** retry task
- Exponential backoff: 1s → 2s → 4s → 8s → 16s → 32s → 60s max
- `stop()` increments generation and cancels everything — authoritative
- Stale generations silently ignored in all state callbacks and retry paths
- Retry task is tracked in state, never orphaned

### What this fixes vs PR #78
| Concern | PR #78 | This PR |
|---------|--------|---------|
| Stop-race (untracked outer Task) | ❌ | ✅ Generation-gated |
| Listener retain cycle | ❌ | ✅ Captures generation, not listener |
| 1s retry spam | ❌ | ✅ Backoff persists in state |
| Port update on ready | ✅ | ✅ `listenerReady` returns bound port |

### Generalizable
The generation + backoff + authoritative-stop pattern is reusable for any listener-based transport that needs recovery.

## Testing
- Full test suite: **295 tests pass** ✅
- Build clean on macOS