### PR TITLE
Implement server-side resource subscription handling

### DIFF
--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -117,6 +117,12 @@ public extension MCPServer {
             case "resources/read":
                 return await createResourcesReadResponse(id: requestData.id, request: requestData)
 
+            case "resources/subscribe":
+                return await handleResourceSubscribe(requestData)
+
+            case "resources/unsubscribe":
+                return await handleResourceUnsubscribe(requestData)
+
             case "prompts/list":
                 return createPromptsListResponse(id: requestData.id)
 
@@ -249,7 +255,7 @@ public extension MCPServer {
         }
 
         if self is MCPResourceProviding {
-            capabilities.resources = .init(listChanged: true)
+            capabilities.resources = .init(subscribe: true, listChanged: true)
         }
 
         if self is MCPPromptProviding {
@@ -723,6 +729,48 @@ public extension MCPServer {
         await session.setMinimumLogLevel(level)
 
         // Return empty result for success
+        return JSONRPCMessage.response(id: request.id, result: [:])
+    }
+
+    // MARK: - Resource Subscriptions
+
+    private func handleResourceSubscribe(_ request: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage? {
+        guard let session = Session.current else {
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32603, message: "No session context for resources/subscribe")
+            )
+        }
+
+        guard let params = request.params,
+              let uri = params["uri"]?.stringValue else {
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32602, message: "Invalid parameters: 'uri' parameter is required")
+            )
+        }
+
+        await session.subscribeResource(uri: uri)
+        return JSONRPCMessage.response(id: request.id, result: [:])
+    }
+
+    private func handleResourceUnsubscribe(_ request: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage? {
+        guard let session = Session.current else {
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32603, message: "No session context for resources/unsubscribe")
+            )
+        }
+
+        guard let params = request.params,
+              let uri = params["uri"]?.stringValue else {
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32602, message: "Invalid parameters: 'uri' parameter is required")
+            )
+        }
+
+        await session.unsubscribeResource(uri: uri)
         return JSONRPCMessage.response(id: request.id, result: [:])
     }
 

--- a/Sources/SwiftMCP/Transport/Session.swift
+++ b/Sources/SwiftMCP/Transport/Session.swift
@@ -47,6 +47,9 @@ public actor Session {
     /// Client capabilities received during initialization (if any).
     public var clientCapabilities: ClientCapabilities?
 
+    /// URIs that this session has subscribed to for resource-updated notifications.
+    private var subscribedResourceURIs: Set<String> = []
+
     /// Creates a new session.
     /// - Parameters:
     ///   - id: The unique session identifier.
@@ -289,6 +292,21 @@ extension Session {
     public func sendPromptListChanged() async throws {
         let notification = JSONRPCMessage.notification(method: "notifications/prompts/list_changed")
         try await transport?.send(notification)
+    }
+
+    /// Subscribe this session to resource-updated notifications for a URI.
+    public func subscribeResource(uri: String) {
+        subscribedResourceURIs.insert(uri)
+    }
+
+    /// Unsubscribe this session from resource-updated notifications for a URI.
+    public func unsubscribeResource(uri: String) {
+        subscribedResourceURIs.remove(uri)
+    }
+
+    /// Returns `true` if this session is subscribed to updates for the given URI.
+    public func isSubscribedToResource(uri: String) -> Bool {
+        subscribedResourceURIs.contains(uri)
     }
 
     /// Send a notification that a subscribed resource has been updated.

--- a/Sources/SwiftMCP/Transport/SessionManager.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager.swift
@@ -233,12 +233,16 @@ actor SessionManager {
         }
     }
 
-    /// Broadcast a resource-updated notification to all sessions.
+    /// Send a resource-updated notification to all sessions subscribed to the given URI.
     /// - Parameter uri: The URI of the resource that was updated.
     func broadcastResourceUpdated(uri: URL) async {
+        let uriString = uri.absoluteString
         for session in sessions.values {
-            await session.work { session in
-                try? await session.sendResourceUpdated(uri: uri)
+            let subscribed = await session.isSubscribedToResource(uri: uriString)
+            if subscribed {
+                await session.work { session in
+                    try? await session.sendResourceUpdated(uri: uri)
+                }
             }
         }
     }


### PR DESCRIPTION
Follow-up to #81 (merged before this commit landed).

## What this adds

Completes the server side of the resource subscription flow:

### Request handling
- `resources/subscribe` → stores URI in session's subscription set
- `resources/unsubscribe` → removes URI from session's subscription set

### Subscription-aware notifications
- `broadcastResourceUpdated(uri:)` now only notifies sessions that subscribed to that URI (not all sessions)

### Server capabilities
- `MCPResourceProviding` servers now advertise `subscribe: true` alongside `listChanged: true`

### Session tracking
- `Session.subscribeResource(uri:)` / `unsubscribeResource(uri:)` / `isSubscribedToResource(uri:)`

## Full subscription flow
1. Client installs `resourceNotificationHandler` before `connect()`
2. Client capability advertises `resources.subscribe: true`
3. Client calls `subscribeResource(uri:)`
4. Server stores subscription in session
5. Server calls `transport.broadcastResourceUpdated(uri:)`
6. Only subscribed sessions receive `notifications/resources/updated`
7. Client handler receives the URI

## Testing
- 307 tests pass ✅