### PR TITLE
Implement CID-based binary file upload for HTTP transport

### DIFF
--- a/Sources/SwiftMCP/Client/MCPClientArgumentEncoder.swift
+++ b/Sources/SwiftMCP/Client/MCPClientArgumentEncoder.swift
@@ -22,6 +22,16 @@ public enum MCPClientArgumentEncoder {
         .string(MCPToolArgumentEncoder.encode(value))
     }
 
+    /// Proxy-aware encoding for `Data`: generates CID placeholder if uploads supported, falls back to base64.
+    public static func encode(_ value: Data, proxy: MCPServerProxy) async throws -> JSONValue {
+        if await proxy.supportsFileUpload {
+            let cid = UUID().uuidString
+            await proxy.registerPendingUpload(cid: cid, data: value)
+            return .string("cid:\(cid)")
+        }
+        return .string(MCPToolArgumentEncoder.encode(value))
+    }
+
     public static func encode<T: CaseIterable>(_ value: T) throws -> JSONValue {
         .string(String(describing: value))
     }
@@ -47,6 +57,20 @@ public enum MCPClientArgumentEncoder {
 
     public static func encode(_ values: [Data]) throws -> JSONValue {
         .array(MCPToolArgumentEncoder.encode(values).map(JSONValue.string))
+    }
+
+    /// Proxy-aware encoding for `[Data]`: generates CID placeholders if uploads supported, falls back to base64.
+    public static func encode(_ values: [Data], proxy: MCPServerProxy) async throws -> JSONValue {
+        if await proxy.supportsFileUpload {
+            var results: [JSONValue] = []
+            for value in values {
+                let cid = UUID().uuidString
+                await proxy.registerPendingUpload(cid: cid, data: value)
+                results.append(.string("cid:\(cid)"))
+            }
+            return .array(results)
+        }
+        return .array(MCPToolArgumentEncoder.encode(values).map(JSONValue.string))
     }
 
     public static func encode<T: CaseIterable>(_ values: [T]) throws -> JSONValue {

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -178,6 +178,9 @@ public final actor MCPServerProxy: Sendable {
     private var lineConnection: (any StdioConnection)?
     private var endpointContinuation: CheckedContinuation<URL, Error>?
 
+    /// Pending CID uploads queued during argument encoding, to be uploaded after the tool call is sent.
+    private var pendingUploads: [(cid: String, data: Data)] = []
+
     public init(config: MCPServerConfig, cacheToolsList: Bool = false) {
         self.config = config
         self.service = nil
@@ -306,6 +309,88 @@ public final actor MCPServerProxy: Sendable {
         )
     }
 
+    // MARK: - File Upload
+
+    /// Register a pending upload that will be sent after the tool call request.
+    /// Called by `MCPClientArgumentEncoder.encode(Data, proxy:)`.
+    public func registerPendingUpload(cid: String, data: Data) {
+        pendingUploads.append((cid: cid, data: data))
+    }
+
+    /// Uploads binary data to the server's upload endpoint.
+    ///
+    /// - Parameters:
+    ///   - data: The binary data to upload.
+    ///   - contentType: MIME type of the data (e.g. `"image/png"`).
+    ///   - filename: Optional original filename.
+    ///   - cid: Content ID for CID-targeted uploads.
+    /// - Returns: The CID or URI string from the server response.
+    @discardableResult
+    public func uploadFile(
+        data: Data,
+        contentType: String? = nil,
+        filename: String? = nil,
+        cid: String? = nil
+    ) async throws -> String {
+        var uploadURL = try resolveUploadURL()
+        if let cid {
+            uploadURL = uploadURL.appendingPathComponent(cid)
+        }
+
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = "POST"
+        request.httpBody = data
+        request.setValue(contentType ?? "application/octet-stream", forHTTPHeaderField: "Content-Type")
+
+        if let filename {
+            request.setValue("attachment; filename=\"\(filename)\"", forHTTPHeaderField: "Content-Disposition")
+        }
+        if let sessionID {
+            request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        }
+        if let token = meta["accessToken"]?.stringValue {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...201).contains(httpResponse.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let body = String(data: responseData, encoding: .utf8) ?? "unknown error"
+            throw MCPServerProxyError.communicationError("Upload failed (\(status)): \(body)")
+        }
+
+        let result = try JSONDecoder().decode(JSONDictionary.self, from: responseData)
+        if let uri = result["uri"]?.stringValue { return uri }
+        if let cidValue = result["cid"]?.stringValue { return "cid:\(cidValue)" }
+        throw MCPServerProxyError.communicationError("Upload response missing 'uri' or 'cid'")
+    }
+
+    /// Whether the connected server supports file uploads.
+    public var supportsFileUpload: Bool {
+        serverCapabilities?.experimental["uploads"] != nil
+    }
+
+    /// Maximum upload size advertised by the server, or nil if uploads aren't supported.
+    public var maxUploadSize: Int? {
+        serverCapabilities?.experimental["uploads"]?.dictionaryValue?["maxSize"]?.intValue
+    }
+
+    private func resolveUploadURL() throws -> URL {
+        if case .sse(let sseConfig) = config {
+            var components = URLComponents(url: sseConfig.url, resolvingAgainstBaseURL: false)
+            components?.path = "/mcp/uploads"
+            if let url = components?.url { return url }
+        }
+        if let endpoint = endpointURL {
+            var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)
+            components?.path = "/mcp/uploads"
+            if let url = components?.url { return url }
+        }
+        throw MCPServerProxyError.communicationError("Cannot determine upload URL — only HTTP transports support file upload")
+    }
+
     /// Lists all prompts available from the server.
     public func listPrompts() async throws -> [Prompt] {
         let result: PromptsListResult = try await requestResult(method: "prompts/list", as: PromptsListResult.self)
@@ -349,7 +434,39 @@ public final actor MCPServerProxy: Sendable {
         }
         
         let request = JSONRPCMessage.request(id: requestId, method: "tools/call", params: params)
-        let responseMessage = try await send(request)
+
+        // If there are pending CID uploads, send the tool call and uploads concurrently.
+        // The server blocks the tool call until all CID uploads arrive.
+        let hasPendingUploads = !pendingUploads.isEmpty
+        let responseMessage: JSONRPCMessage
+
+        if hasPendingUploads {
+            let uploads = pendingUploads
+            pendingUploads = []
+
+            responseMessage = try await withThrowingTaskGroup(of: JSONRPCMessage?.self) { group in
+                group.addTask {
+                    return try await self.send(request)
+                }
+                group.addTask {
+                    for upload in uploads {
+                        try await self.uploadFile(data: upload.data, cid: upload.cid)
+                    }
+                    return nil
+                }
+
+                var result: JSONRPCMessage?
+                for try await value in group {
+                    if let value { result = value }
+                }
+                guard let result else {
+                    throw MCPServerProxyError.communicationError("No response received from tool call")
+                }
+                return result
+            }
+        } else {
+            responseMessage = try await send(request)
+        }
 
         let result: JSONDictionary
         switch responseMessage {

--- a/Sources/SwiftMCP/Protocols/MCPFileUploadHandling.swift
+++ b/Sources/SwiftMCP/Protocols/MCPFileUploadHandling.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Opt-in protocol that enables binary file upload support on the HTTP transport.
+///
+/// When your `MCPServer` conforms to this protocol, the transport registers a
+/// `POST /mcp/uploads` endpoint and advertises the `experimental.uploads` capability.
+///
+/// Clients send `cid:` placeholders in tool call arguments for `Data` parameters.
+/// The server blocks the tool call until the corresponding upload arrives at
+/// `POST /mcp/uploads/{cid}`, then delivers the data to the tool function.
+///
+/// ## Example
+/// ```swift
+/// extension MyServer: MCPFileUploadHandling {}
+/// ```
+///
+/// Override `maxUploadSize` to change the default 50 MB limit:
+/// ```swift
+/// extension MyServer: MCPFileUploadHandling {
+///     var maxUploadSize: Int { 100 * 1024 * 1024 }  // 100 MB
+/// }
+/// ```
+public protocol MCPFileUploadHandling {
+    /// Maximum upload size in bytes.
+    var maxUploadSize: Int { get }
+}
+
+extension MCPFileUploadHandling {
+    /// Default maximum upload size: 50 MB.
+    public var maxUploadSize: Int { 50 * 1024 * 1024 }
+}

--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -233,7 +233,26 @@ public extension MCPServer {
             }
         }
         
-        return createInitializeResponse(id: request.id)
+        var response = createInitializeResponse(id: request.id)
+
+        // Conditionally advertise upload capability only on HTTP transports
+        if let uploadHandler = self as? MCPFileUploadHandling,
+           let transport = await Session.current?.transport,
+           transport is HTTPSSETransport {
+            if case .response(var responseData) = response,
+               var result = responseData.result {
+                var experimental = result["experimental"]?.dictionaryValue ?? [:]
+                experimental["uploads"] = .object([
+                    "endpoint": .string("/mcp/uploads"),
+                    "maxSize": .integer(uploadHandler.maxUploadSize)
+                ])
+                result["experimental"] = .object(experimental)
+                responseData.result = result
+                response = .response(responseData)
+            }
+        }
+
+        return response
     }
 
 /**
@@ -311,7 +330,29 @@ public extension MCPServer {
         }
 
         // Extract arguments from the request
-        let arguments = params["arguments"]?.dictionaryValue ?? [:]
+        var arguments = params["arguments"]?.dictionaryValue ?? [:]
+
+        // Extract progress token for upload progress notifications
+        let progressToken = params["_meta"]?.dictionaryValue?["progressToken"]
+
+        // Resolve any cid: placeholders by waiting for uploads
+        if let pendingStore = PendingUploadResolver.current {
+            do {
+                if let resolved = try await Self.resolveCIDPlaceholders(
+                    in: arguments,
+                    sessionID: Session.current?.id ?? UUID(),
+                    progressToken: progressToken,
+                    pendingStore: pendingStore
+                ) {
+                    arguments = resolved
+                }
+            } catch {
+                return JSONRPCMessage.errorResponse(
+                    id: request.id,
+                    error: .init(code: -32603, message: "Upload resolution failed: \(error.localizedDescription)")
+                )
+            }
+        }
 
         let metadata = mcpToolMetadata(for: toolName)
 
@@ -730,6 +771,62 @@ public extension MCPServer {
 
         // Return empty result for success
         return JSONRPCMessage.response(id: request.id, result: [:])
+    }
+
+    // MARK: - CID Upload Resolution
+
+    /// Scans tool call arguments for `cid:` placeholders and waits for corresponding uploads.
+    /// Returns the arguments with CIDs replaced by base64 data, or nil if no CIDs found.
+    private static func resolveCIDPlaceholders(
+        in arguments: JSONDictionary,
+        sessionID: UUID,
+        progressToken: JSONValue?,
+        pendingStore: PendingUploadStore
+    ) async throws -> JSONDictionary? {
+        var cidEntries: [(key: String, cid: String)] = []
+        for (key, value) in arguments {
+            if let str = value.stringValue, str.hasPrefix("cid:") {
+                cidEntries.append((key: key, cid: String(str.dropFirst(4))))
+            }
+        }
+
+        guard !cidEntries.isEmpty else { return nil }
+
+        var resolved = arguments
+
+        for (index, entry) in cidEntries.enumerated() {
+            if let token = progressToken, let session = Session.current {
+                let total = Double(cidEntries.count)
+                let message = cidEntries.count == 1
+                    ? "Waiting for file upload..."
+                    : "Waiting for file upload \(index + 1) of \(cidEntries.count)..."
+                await session.sendProgressNotification(
+                    progressToken: token,
+                    progress: Double(index),
+                    total: total,
+                    message: message
+                )
+            }
+
+            let data = try await pendingStore.waitForUpload(
+                cid: entry.cid,
+                progressToken: progressToken,
+                sessionID: sessionID
+            )
+
+            resolved[entry.key] = .string(data.base64EncodedString())
+        }
+
+        if let token = progressToken, let session = Session.current {
+            await session.sendProgressNotification(
+                progressToken: token,
+                progress: Double(cidEntries.count),
+                total: Double(cidEntries.count),
+                message: "All uploads received"
+            )
+        }
+
+        return resolved
     }
 
     // MARK: - Resource Subscriptions

--- a/Sources/SwiftMCP/Transport/HTTPHandler.swift
+++ b/Sources/SwiftMCP/Transport/HTTPHandler.swift
@@ -52,8 +52,9 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
 
             // Initial HEAD Received
             case (.head(let head), _):
-                if let contentLength = head.headers.first(name: "content-length"), let length = Int(contentLength), length > transport.maxMessageSize {
-                    logger.warning("Rejecting request with Content-Length \(length) > max \(transport.maxMessageSize)")
+                let sizeLimit = maxBodySize(for: head)
+                if let contentLength = head.headers.first(name: "content-length"), let length = Int(contentLength), length > sizeLimit {
+                    logger.warning("Rejecting request with Content-Length \(length) > max \(sizeLimit)")
                     rejectOversizedRequest(context: context)
                     requestState = .rejected
                     return
@@ -62,8 +63,9 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
 
             // BODY Received after HEAD
 			case (.body(let buffer), .head(let head)):
-                guard buffer.readableBytes <= transport.maxMessageSize else {
-                    logger.warning("Rejecting request: first body chunk size \(buffer.readableBytes) > max \(transport.maxMessageSize)")
+                let sizeLimit = maxBodySize(for: head)
+                guard buffer.readableBytes <= sizeLimit else {
+                    logger.warning("Rejecting request: first body chunk size \(buffer.readableBytes) > max \(sizeLimit)")
                     rejectOversizedRequest(context: context)
                     requestState = .rejected
                     return
@@ -72,9 +74,10 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
 
             // Additional BODY chunks after initial BODY
             case (.body(var newBuffer), .body(let head, var priorBuffer)):
+                let sizeLimit = maxBodySize(for: head)
                 let combinedSize = priorBuffer.readableBytes + newBuffer.readableBytes
-                guard combinedSize <= transport.maxMessageSize else {
-                    logger.warning("Rejecting request: accumulated body size \(combinedSize) > max \(transport.maxMessageSize)")
+                guard combinedSize <= sizeLimit else {
+                    logger.warning("Rejecting request: accumulated body size \(combinedSize) > max \(sizeLimit)")
                     rejectOversizedRequest(context: context)
                     requestState = .rejected
                     return
@@ -112,6 +115,15 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
         context.flush()
     }
     
+    /// Returns the applicable body size limit for a request.
+    private func maxBodySize(for head: HTTPRequestHead) -> Int {
+        if head.uri.hasPrefix("/mcp/uploads"),
+           let uploadHandler = transport.server as? MCPFileUploadHandling {
+            return uploadHandler.maxUploadSize
+        }
+        return transport.maxMessageSize
+    }
+
     private func rejectOversizedRequest(context: ChannelHandlerContext) {
         var headers = HTTPHeaders()
         headers.add(name: "Connection", value: "close")
@@ -134,6 +146,12 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
             // Handle all OPTIONS requests in one case
             case (.OPTIONS, _):
                 handleOPTIONS(channel: channel, head: head)
+
+            // Binary file upload endpoint (POST /mcp/uploads/{cid})
+            case (.POST, let path) where path.hasPrefix("/mcp/uploads"):
+                Task {
+                    await self.handleUpload(channel: channel, head: head, body: body)
+                }
 
             // Streamable HTTP Endpoint
             case (.POST, let path) where path.hasPrefix("/mcp"):
@@ -362,7 +380,10 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
                     }
                 } else {
                     // No SSE connection - use immediate HTTP response
-                    let responses = await transport.server.processBatch(messages, ignoringEmptyResponses: true)
+                    let pending = transport.server is MCPFileUploadHandling ? transport.pendingUploadStore : nil
+                    let responses = await PendingUploadResolver.$current.withValue(pending) {
+                        await transport.server.processBatch(messages, ignoringEmptyResponses: true)
+                    }
 
                     if responses.isEmpty {
                         await self.sendResponseAsync(channel: channel, status: .accepted, headers: responseHeaders)
@@ -622,6 +643,116 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
             let errorBuffer = self.stringBuffer("Internal Server Error encoding response", allocator: channel.allocator)
             await self.sendResponseAsync(channel: channel, status: .internalServerError, body: errorBuffer)
         }
+    }
+
+    // MARK: - File Upload
+
+    private func handleUpload(channel: Channel, head: HTTPRequestHead, body: ByteBuffer?) async {
+        guard transport.server is MCPFileUploadHandling else {
+            let buffer = channel.allocator.buffer(string: "File uploads not supported by this server.")
+            await sendResponseAsync(channel: channel, status: .notFound, body: buffer)
+            return
+        }
+
+        let sessionID = UUID(uuidString: head.headers["Mcp-Session-Id"].first ?? "") ?? UUID()
+
+        // Authorization
+        var token: String?
+        if let authHeader = head.headers["Authorization"].first {
+            let parts = authHeader.split(separator: " ")
+            if parts.count == 2 && parts[0].lowercased() == "bearer" {
+                token = String(parts[1])
+            }
+        }
+
+        let authResult = await transport.authorize(token, sessionID: sessionID)
+        switch authResult {
+        case .unauthorized(let message):
+            let buffer = channel.allocator.buffer(string: "Unauthorized: \(message)")
+            await sendResponseAsync(channel: channel, status: .unauthorized, body: buffer)
+            return
+        case .jweNotSupported(let message):
+            let buffer = channel.allocator.buffer(string: message)
+            await sendResponseAsync(channel: channel, status: .forbidden, body: buffer)
+            return
+        case .authorized:
+            break
+        }
+
+        guard var body = body, let data = body.readData(length: body.readableBytes) else {
+            let buffer = channel.allocator.buffer(string: "Request body required.")
+            await sendResponseAsync(channel: channel, status: .badRequest, body: buffer)
+            return
+        }
+
+        // Extract CID from path: /mcp/uploads/{cid}
+        let pathComponents = head.uri.split(separator: "/")
+        guard pathComponents.count == 3,
+              pathComponents[0] == "mcp",
+              pathComponents[1] == "uploads",
+              let cid = String(pathComponents[2]).removingPercentEncoding else {
+            let buffer = channel.allocator.buffer(string: "Missing CID in upload path. Use POST /mcp/uploads/{cid}")
+            await sendResponseAsync(channel: channel, status: .badRequest, body: buffer)
+            return
+        }
+
+        guard await transport.pendingUploadStore.isExpected(cid: cid) else {
+            let buffer = channel.allocator.buffer(string: "No pending upload expected for CID: \(cid)")
+            await sendResponseAsync(channel: channel, status: .notFound, body: buffer)
+            return
+        }
+
+        // Send upload progress notification
+        if let progressToken = await transport.pendingUploadStore.progressToken(for: cid) {
+            let session = await transport.sessionManager.session(id: sessionID)
+            await session.work { session in
+                await session.sendProgressNotification(
+                    progressToken: progressToken,
+                    progress: Double(data.count),
+                    total: Double(data.count),
+                    message: "Upload received (\(data.count) bytes)"
+                )
+            }
+        }
+
+        // Fulfill the pending upload — this resumes the tool call
+        await transport.pendingUploadStore.fulfill(cid: cid, data: data)
+
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "application/json")
+        headers.add(name: "Access-Control-Allow-Origin", value: "*")
+        headers.add(name: "Mcp-Session-Id", value: sessionID.uuidString)
+
+        let responseDict: JSONDictionary = [
+            "cid": .string(cid),
+            "size": .integer(data.count),
+            "status": .string("fulfilled")
+        ]
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        if let jsonData = try? encoder.encode(responseDict) {
+            let buffer = channel.allocator.buffer(data: jsonData)
+            await sendResponseAsync(channel: channel, status: .ok, headers: headers, body: buffer)
+        }
+
+        logger.info("CID upload fulfilled: \(cid) (\(data.count) bytes)")
+    }
+
+    /// Parse filename from Content-Disposition header.
+    private static func parseFilename(from header: String?) -> String? {
+        guard let header else { return nil }
+        let parts = header.split(separator: ";").map { $0.trimmingCharacters(in: .whitespaces) }
+        for part in parts {
+            if part.lowercased().hasPrefix("filename=") {
+                var value = String(part.dropFirst("filename=".count))
+                if value.hasPrefix("\"") && value.hasSuffix("\"") {
+                    value = String(value.dropFirst().dropLast())
+                }
+                return value.isEmpty ? nil : value
+            }
+        }
+        return nil
     }
 
     // MARK: - OpenAPI Handlers
@@ -1304,8 +1435,8 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
     private func handleOPTIONS(channel: Channel, head: HTTPRequestHead) {
         logger.info("Handling OPTIONS request for URI: \(head.uri)")
         var headers = HTTPHeaders()
-        headers.add(name: "Access-Control-Allow-Methods", value: "GET, POST, OPTIONS")
-        headers.add(name: "Access-Control-Allow-Headers", value: "Content-Type, Authorization, MCP-Protocol-Version")
+        headers.add(name: "Access-Control-Allow-Methods", value: "GET, POST, DELETE, OPTIONS")
+        headers.add(name: "Access-Control-Allow-Headers", value: "Content-Type, Content-Disposition, Authorization, MCP-Protocol-Version, Mcp-Session-Id")
         sendResponse(channel: channel, status: .ok, headers: headers)
     }
 

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
@@ -36,6 +36,7 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
     private let group: EventLoopGroup
     private var channel: Channel?
     internal lazy var sessionManager = SessionManager(transport: self)
+    internal let pendingUploadStore = PendingUploadStore()
     private var keepAliveTimer: DispatchSourceTimer?
 
     /// Flag to determine whether to serve OpenAPI endpoints.
@@ -342,11 +343,14 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
     /// Handle a JSON-RPC request and send the response through the SSE channels.
     func handleJSONRPCRequest(_ request: JSONRPCMessage, from sessionID: UUID) {
         Task {
-            guard let response = await server.handleMessage(request) else {
-                // No response to send (e.g., notification)
+            let pending = server is MCPFileUploadHandling ? pendingUploadStore : nil
+
+            guard let response = await PendingUploadResolver.$current.withValue(pending, operation: {
+                await server.handleMessage(request)
+            }) else {
                 return
             }
-            
+
             try await send(response)
         }
     }

--- a/Sources/SwiftMCP/Transport/PendingUploadResolver.swift
+++ b/Sources/SwiftMCP/Transport/PendingUploadResolver.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Provides access to the pending upload store during tool call processing.
+///
+/// Set as a task-local on HTTP transports that support file uploads,
+/// allowing `MCPServer.resolveCIDPlaceholders` to access the store.
+enum PendingUploadResolver {
+    @TaskLocal
+    static var current: PendingUploadStore?
+}

--- a/Sources/SwiftMCP/Transport/PendingUploadStore.swift
+++ b/Sources/SwiftMCP/Transport/PendingUploadStore.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Tracks pending content-ID uploads for a session.
+///
+/// When a tool call contains `cid:` placeholders for Data parameters,
+/// the server registers expectations here. The upload endpoint fulfills
+/// them, resuming the tool call's parameter extraction.
+actor PendingUploadStore {
+
+    struct Expectation {
+        let continuation: CheckedContinuation<Data, Error>
+        let progressToken: JSONValue?
+        let sessionID: UUID
+    }
+
+    private var expectations: [String: Expectation] = [:]  // cid → expectation
+
+    /// Register a pending upload. Returns when the data arrives or the caller cancels.
+    func waitForUpload(
+        cid: String,
+        progressToken: JSONValue?,
+        sessionID: UUID
+    ) async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            expectations[cid] = Expectation(
+                continuation: continuation,
+                progressToken: progressToken,
+                sessionID: sessionID
+            )
+        }
+    }
+
+    /// Fulfill a pending upload. Called by the upload endpoint.
+    /// Returns the progress token associated with this CID (for progress notifications).
+    @discardableResult
+    func fulfill(cid: String, data: Data) -> JSONValue? {
+        guard let expectation = expectations.removeValue(forKey: cid) else {
+            return nil
+        }
+        expectation.continuation.resume(returning: data)
+        return expectation.progressToken
+    }
+
+    /// Fail a pending upload (e.g. on cancellation or timeout).
+    func fail(cid: String, error: Error) {
+        guard let expectation = expectations.removeValue(forKey: cid) else {
+            return
+        }
+        expectation.continuation.resume(throwing: error)
+    }
+
+    /// Cancel all pending uploads for a session.
+    func cancelAll(sessionID: UUID, error: Error) {
+        let matching = expectations.filter { $0.value.sessionID == sessionID }
+        for (cid, expectation) in matching {
+            expectations.removeValue(forKey: cid)
+            expectation.continuation.resume(throwing: error)
+        }
+    }
+
+    /// Check if a CID is expected.
+    func isExpected(cid: String) -> Bool {
+        expectations[cid] != nil
+    }
+
+    /// Get the progress token for a CID (for sending progress notifications during upload).
+    func progressToken(for cid: String) -> JSONValue? {
+        expectations[cid]?.progressToken
+    }
+}

--- a/Sources/SwiftMCPMacros/MCPServerMacro.swift
+++ b/Sources/SwiftMCPMacros/MCPServerMacro.swift
@@ -972,10 +972,20 @@ public func callPrompt(_ name: String, arguments: JSONDictionary) async throws -
         guard !parameters.isEmpty else { return [] }
         var lines = ["\(indent)var \(variableName): JSONDictionary = [:]"]
         for parameter in parameters {
-            if parameter.isOptional {
-                lines.append("\(indent)if let \(parameter.name) { \(variableName)[\"\(parameter.name)\"] = try MCPClientArgumentEncoder.encode(\(parameter.name)) }")
+            let isDataType = parameter.typeString == "Data"
+                || parameter.typeString == "Data?"
+                || parameter.typeString == "[Data]"
+                || parameter.typeString == "[Data]?"
+            let encodeCall: String
+            if isDataType {
+                encodeCall = "try await MCPClientArgumentEncoder.encode(\(parameter.name), proxy: proxy)"
             } else {
-                lines.append("\(indent)\(variableName)[\"\(parameter.name)\"] = try MCPClientArgumentEncoder.encode(\(parameter.name))")
+                encodeCall = "try MCPClientArgumentEncoder.encode(\(parameter.name))"
+            }
+            if parameter.isOptional {
+                lines.append("\(indent)if let \(parameter.name) { \(variableName)[\"\(parameter.name)\"] = \(encodeCall) }")
+            } else {
+                lines.append("\(indent)\(variableName)[\"\(parameter.name)\"] = \(encodeCall)")
             }
         }
         return lines


### PR DESCRIPTION
Fixes #73. Replaces #83.

## Design

Binary uploads use **Content-ID placeholders** — the tool call and file upload happen concurrently, with the server delivering MCP progress notifications.

### Flow
```
Client                                    Server
  │ encode(imageData, proxy: proxy)         │
  │ → generates "cid:abc123"                │
  │                                         │
  │ tools/call processImage                 │
  │ {"image":"cid:abc123","title":"Hi",     │
  │  "_meta":{"progressToken":"t1"}}        │ ← server blocks
  │                                         │
  │ ← notifications/progress                │
  │   token:t1, "Waiting for upload…"       │
  │                                         │
  │ POST /mcp/uploads/abc123  ────────────► │ ← concurrent
  │ [binary data]                           │
  │                                         │
  │ ← notifications/progress                │
  │   token:t1, "Upload received"           │
  │                                         │
  │ (resolves cid → Data, calls function)   │
  │ ← tools/call response                   │
```

### Server opt-in
```swift
extension MyServer: MCPFileUploadHandling {}
```

One line. `maxUploadSize` defaults to 50 MB.

### Tool author sees nothing
```swift
@MCPTool
func processImage(image: Data, title: String) -> String { ... }
```

### New files
- `MCPFileUploadHandling` — marker protocol
- `PendingUploadStore` — actor tracking CID → continuation mappings
- `PendingUploadResolver` — task-local for accessing store during tool calls

### Modified files
- `HTTPHandler` — `/mcp/uploads/{cid}` route, size limit per-request
- `HTTPSSETransport` — owns `PendingUploadStore`, sets task-local
- `MCPServer` — CID resolution + progress in `handleToolCall`, capability advertisement gated on HTTP
- `MCPServerProxy` — `uploadFile`, `registerPendingUpload`, concurrent upload in `callTool`
- `MCPClientArgumentEncoder` — async `encode(Data, proxy:)` overloads
- `MCPServerMacro` — generates `encode(data, proxy:)` for Data parameters

### Key properties
- ✅ Server-side MCP progress notifications during upload
- ✅ Cancellation works (pending CID continuation fails)
- ✅ Falls back to base64 when server doesn't support uploads
- ✅ Capability only advertised on HTTP transports
- ✅ Upload size limit separate from JSON message size limit

## Testing
- 307 tests pass ✅