### PR TITLE
Fix duplicate default response headers

### DIFF
--- a/Sources/SwiftMCP/Transport/HTTPHandler.swift
+++ b/Sources/SwiftMCP/Transport/HTTPHandler.swift
@@ -241,17 +241,40 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
         nioHeaders.map { ($0.name, $0.value) }
     }
 
-    private func sendResponse(channel: Channel, status: HTTPResponseStatus, headers: HTTPHeaders? = nil, body: ByteBuffer? = nil) {
-        var responseHeaders = headers ?? HTTPHeaders()
-        responseHeaders.add(name: "Access-Control-Allow-Origin", value: "*")
+    static func responseHeadersApplyingDefaults(
+        _ headers: [(String, String)],
+        bodyLength: Int?
+    ) -> [(String, String)] {
+        var responseHeaders = HTTPHeaders()
+        for (name, value) in headers {
+            responseHeaders.add(name: name, value: value)
+        }
 
-        if let body = body {
+        if responseHeaders["Access-Control-Allow-Origin"].isEmpty {
+            responseHeaders.add(name: "Access-Control-Allow-Origin", value: "*")
+        }
+
+        if let bodyLength {
             if responseHeaders["Content-Type"].isEmpty {
                 responseHeaders.add(name: "Content-Type", value: "text/plain; charset=utf-8")
             }
-            responseHeaders.add(name: "Content-Length", value: "\(body.readableBytes)")
-        } else {
+            if responseHeaders["Content-Length"].isEmpty {
+                responseHeaders.add(name: "Content-Length", value: "\(bodyLength)")
+            }
+        } else if responseHeaders["Content-Length"].isEmpty {
             responseHeaders.add(name: "Content-Length", value: "0")
+        }
+
+        return responseHeaders.map { ($0.name, $0.value) }
+    }
+
+    private func sendResponse(channel: Channel, status: HTTPResponseStatus, headers: HTTPHeaders? = nil, body: ByteBuffer? = nil) {
+        let headerPairs = (headers ?? HTTPHeaders()).map { ($0.name, $0.value) }
+        let resolvedHeaders = Self.responseHeadersApplyingDefaults(headerPairs, bodyLength: body?.readableBytes)
+
+        var responseHeaders = HTTPHeaders()
+        for (name, value) in resolvedHeaders {
+            responseHeaders.add(name: name, value: value)
         }
 
         let head = HTTPResponseHead(version: .http1_1, status: status, headers: responseHeaders)

--- a/Tests/SwiftMCPTests/HTTPHandlerHeaderTests.swift
+++ b/Tests/SwiftMCPTests/HTTPHandlerHeaderTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import SwiftMCP
+
+@Suite("HTTP Handler Header Tests")
+struct HTTPHandlerHeaderTests {
+    private func values(named name: String, in headers: [(String, String)]) -> [String] {
+        headers
+            .filter { $0.0.caseInsensitiveCompare(name) == .orderedSame }
+            .map(\.1)
+    }
+
+    @Test("Route-provided CORS and Content-Length headers are not duplicated")
+    func routeHeadersAreNotDuplicated() {
+        let headers = HTTPHandler.responseHeadersApplyingDefaults(
+            [
+                ("Access-Control-Allow-Origin", "https://example.com"),
+                ("Content-Type", "text/plain; charset=utf-8"),
+                ("Content-Length", "5")
+            ],
+            bodyLength: 5
+        )
+
+        #expect(values(named: "Access-Control-Allow-Origin", in: headers) == ["https://example.com"])
+        #expect(values(named: "Content-Length", in: headers) == ["5"])
+        #expect(values(named: "Content-Type", in: headers) == ["text/plain; charset=utf-8"])
+    }
+
+    @Test("Framework defaults are applied once when headers are missing")
+    func frameworkDefaultsAreAppliedWhenMissing() {
+        let headers = HTTPHandler.responseHeadersApplyingDefaults([], bodyLength: 5)
+
+        #expect(values(named: "Access-Control-Allow-Origin", in: headers) == ["*"])
+        #expect(values(named: "Content-Length", in: headers) == ["5"])
+        #expect(values(named: "Content-Type", in: headers) == ["text/plain; charset=utf-8"])
+    }
+
+    @Test("Existing Content-Length is preserved for empty-body responses")
+    func existingContentLengthIsPreservedWithoutBody() {
+        let headers = HTTPHandler.responseHeadersApplyingDefaults(
+            [("Content-Length", "0")],
+            bodyLength: nil
+        )
+
+        #expect(values(named: "Access-Control-Allow-Origin", in: headers) == ["*"])
+        #expect(values(named: "Content-Length", in: headers) == ["0"])
+        #expect(values(named: "Content-Type", in: headers).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- only apply default Access-Control-Allow-Origin when the route did not already set it
- only apply default Content-Length when the route did not already set it
- add regression tests covering duplicate-header prevention and the empty-body Content-Length path

Closes #106