### PR TITLE
Enforce Mcp-Session-Id on post-initialize requests

### DIFF
--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -24,7 +24,24 @@ extension HTTPSSETransport {
 	func handleStreamableHTTP(request: HTTPRouteRequest<Data?>) async throws -> RouteResponse {
 
 		// Extract or generate session ID
-		let sessionID = UUID(uuidString: request.sessionID ?? "") ?? UUID()
+		let clientSessionID = request.sessionID.flatMap { UUID(uuidString: $0) }
+		let sessionID: UUID
+		let isNewSession: Bool
+
+		if let existing = clientSessionID, await sessionManager.hasSession(id: existing) {
+			sessionID = existing
+			isNewSession = false
+		} else if clientSessionID == nil {
+			// No session header — allowed only for initialize requests.
+			// We generate a new ID; if the request isn't initialize, we'll
+			// reject below after parsing the body.
+			sessionID = UUID()
+			isNewSession = true
+		} else {
+			// Client sent an unknown session ID
+			return RouteResponse(status: .notFound, body: Data("Unknown session. Send initialize first.".utf8))
+		}
+
 		let sid = sessionID.uuidString
 
 		let baseHeaders: [(String, String)] = [
@@ -64,6 +81,19 @@ extension HTTPSSETransport {
 
 		do {
 			let messages = try JSONRPCMessage.decodeMessages(from: body)
+
+			// Enforce session ID on non-initialize requests per MCP spec:
+			// after initialize, all requests must carry the assigned Mcp-Session-Id.
+			if isNewSession {
+				let isInitialize = messages.contains { msg in
+					if case .request(let req) = msg, req.method == "initialize" { return true }
+					return false
+				}
+				if !isInitialize {
+					logger.warning("Rejected request without valid session ID (method is not initialize)")
+					return RouteResponse(status: .badRequest, headers: baseHeaders, body: Data("Missing or unknown Mcp-Session-Id. Send initialize first.".utf8))
+				}
+			}
 
 			let result: RouteResponse = await sessionManager.session(id: sessionID).work { session in
 

--- a/Sources/SwiftMCP/Transport/SessionManager.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager.swift
@@ -24,6 +24,11 @@ actor SessionManager {
         }
     }
 
+    /// Check whether a session with the given identifier exists.
+    func hasSession(id: UUID) -> Bool {
+        sessions[id] != nil
+    }
+
     /// Retrieve or create a session for the given identifier.
     func session(id: UUID) async -> Session {
         if let existing = sessions[id] {


### PR DESCRIPTION
## Summary

Per the [MCP 2025-03-26 spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports), after `initialize` the server assigns a session ID via the `Mcp-Session-Id` response header, and the client must include it on every subsequent request. Missing or invalid session IDs should be rejected.

Currently, `handleStreamableHTTP` generates a fresh `UUID()` when the header is absent, silently creating a new session per request for non-compliant clients.

## Changes

- **`MCPRoutes.swift`**: Distinguish between "no header" (new session, only initialize allowed), "known header" (existing session), and "unknown header" (404). Non-initialize requests without a valid session ID get a 400.
- **`SessionManager.swift`**: Add `hasSession(id:)` for checking existence without side-effecting session creation.

## Test plan

- [ ] POST `/mcp` with `initialize` and no session header → 200, response includes `Mcp-Session-Id`
- [ ] POST `/mcp` with `tools/list` and the returned session ID → 200
- [ ] POST `/mcp` with `tools/list` and no session header → 400
- [ ] POST `/mcp` with `tools/list` and a random UUID → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)