### PR TITLE
Add Last-Event-ID resumption for SSE streams

### DIFF
--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -150,6 +150,14 @@ extension HTTPSSETransport {
 		// Create the SSE stream — events will be yielded into it by Session.sendSSE
 		let stream = await prepareSSEStream(sessionID: sessionID)
 
+		// Last-Event-ID resumption: replay any buffered events the client missed
+		let lastEventId = request.header("Last-Event-ID") ?? request.header("last-event-id")
+		if let lastEventId, !isLegacy {
+			let session = await sessionManager.session(id: sessionID)
+			await session.replayEvents(after: lastEventId)
+			logger.info("Replayed events after Last-Event-ID: \(lastEventId)")
+		}
+
 		// For the legacy protocol, send the endpoint event as the first stream item
 		if isLegacy {
 			if let endpointUrl = endpointUrl(from: request, sessionID: sessionID) {

--- a/Sources/SwiftMCP/Transport/SSEMessage.swift
+++ b/Sources/SwiftMCP/Transport/SSEMessage.swift
@@ -3,25 +3,32 @@ import Foundation
 /// A Server-Sent Events (SSE) message
 struct SSEMessage: LosslessStringConvertible {
     let event: SSEEvent
-    
-    init(event: SSEEvent) {
+
+    /// Optional event ID for Last-Event-ID resumption (MCP 2025-03-26 spec).
+    var id: String?
+
+    init(event: SSEEvent, id: String? = nil) {
         self.event = event
+        self.id = id
     }
-    
+
     /// Creates an SSE data message
     /// - Parameters:
     ///   - data: The data content
     ///   - eventName: Optional event name
-    init(data: String, eventName: String? = nil) {
+    ///   - id: Optional event ID for resumption
+    init(data: String, eventName: String? = nil, id: String? = nil) {
         self.event = .field(name: "data", value: data, eventName: eventName)
+        self.id = id
     }
-    
+
     /// Creates an SSE comment message
     /// - Parameter comment: The comment text (without the leading colon)
     init(comment: String) {
         self.event = .comment(comment)
+        self.id = nil
     }
-    
+
     /// Creates an SSE field message
     /// - Parameters:
     ///   - name: The field name
@@ -29,6 +36,7 @@ struct SSEMessage: LosslessStringConvertible {
     ///   - eventName: Optional event name
     init(field name: String, value: String, eventName: String? = nil) {
         self.event = .field(name: name, value: value, eventName: eventName)
+        self.id = nil
     }
     
     /// Creates an SSE message from a string representation
@@ -36,25 +44,27 @@ struct SSEMessage: LosslessStringConvertible {
     /// [event: name\n]
     /// data: content\n\n
     init?(_ description: String) {
-        // Split the message into lines
         let lines = description.split(separator: "\n", omittingEmptySubsequences: false)
         var eventName: String? = nil
         var data: String? = nil
+        var parsedId: String? = nil
 
         for line in lines {
-            if line.starts(with: "event:") {
+            if line.starts(with: "id:") {
+                parsedId = String(line.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+            } else if line.starts(with: "event:") {
                 eventName = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
             } else if line.starts(with: "data:") {
                 data = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
             }
         }
 
-        // Data field is required
         guard let data = data else {
             return nil
         }
 
         self.event = .field(name: "data", value: data, eventName: eventName)
+        self.id = parsedId
     }
 
     /// Returns the string representation of the message in SSE format
@@ -64,6 +74,9 @@ struct SSEMessage: LosslessStringConvertible {
             return ": \(comment)\n"
         case .field(let name, let value, let eventName):
             var message = ""
+            if let id = id {
+                message += "id: \(id)\n"
+            }
             if let eventName = eventName {
                 message += "event: \(eventName)\n"
             }

--- a/Sources/SwiftMCP/Transport/Session.swift
+++ b/Sources/SwiftMCP/Transport/Session.swift
@@ -58,6 +58,17 @@ public actor Session {
     /// URIs that this session has subscribed to for resource-updated notifications.
     internal var subscribedResourceURIs: Set<String> = []
 
+    // MARK: - SSE Event Resumption (Last-Event-ID)
+
+    /// Monotonic counter for SSE event IDs within this session.
+    private var nextEventId: Int = 1
+
+    /// Bounded ring buffer of recent SSE events for Last-Event-ID replay.
+    private var eventBuffer: [(id: String, message: SSEMessage)] = []
+
+    /// Maximum events to retain for replay. Older events are evicted.
+    private let eventBufferCapacity = 256
+
     /// Creates a new session.
     /// - Parameters:
     ///   - id: The unique session identifier.
@@ -87,11 +98,39 @@ public actor Session {
     }
 
     /// Send an SSE message through the session's stream continuation.
+    /// Automatically assigns a monotonic event ID for resumption support.
     /// - Parameter message: The message to send.
     func sendSSE(_ message: SSEMessage) {
         guard let sseContinuation else { return }
-        let text = message.description
+
+        var tagged = message
+        // Assign an event ID for data messages (not comments/keepalives)
+        if case .field = message.event, message.id == nil {
+            let eid = String(nextEventId)
+            nextEventId += 1
+            tagged.id = eid
+
+            eventBuffer.append((id: eid, message: tagged))
+            if eventBuffer.count > eventBufferCapacity {
+                eventBuffer.removeFirst(eventBuffer.count - eventBufferCapacity)
+            }
+        }
+
+        let text = tagged.description
         sseContinuation.yield(Data(text.utf8))
+    }
+
+    /// Replay buffered events that were sent after the given event ID.
+    /// Used for Last-Event-ID resumption on SSE reconnect.
+    /// - Parameter lastEventId: The last event ID the client received.
+    func replayEvents(after lastEventId: String) {
+        guard let sseContinuation else { return }
+        guard let idx = eventBuffer.firstIndex(where: { $0.id == lastEventId }) else { return }
+        let toReplay = eventBuffer[(idx + 1)...]
+        for entry in toReplay {
+            let text = entry.message.description
+            sseContinuation.yield(Data(text.utf8))
+        }
     }
 
     /// Set the SSE stream continuation for this session.


### PR DESCRIPTION
## Summary

Implements SSE event ID tracking and `Last-Event-ID` resumption per the [MCP 2025-03-26 streamable-HTTP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports).

Previously, SSE events had no `id:` field. A client reconnecting after a dropped connection would miss all events sent during the gap — effectively starting a new session.

## Changes

- **SSEMessage**: add optional `id` field. Serialized as `id: <value>\n` before event/data lines. The string-based initializer also parses `id:` lines.
- **Session**: monotonic event counter auto-assigns IDs to data events (not comments/keepalives). A bounded ring buffer (256 entries) retains recent events for replay. New `replayEvents(after:)` method yields missed events into the SSE continuation.
- **MCPRoutes.handleSSE**: reads `Last-Event-ID` header on `GET /mcp`. If present and the ID is found in the buffer, replays all subsequent events before resuming normal streaming. Legacy `/sse` connections are unaffected.

## Design decisions

- **Buffer size (256)**: conservative default. Covers typical burst scenarios (a few hundred notifications during a brief disconnect). Configurable via `eventBufferCapacity` on Session if needed later.
- **ID format**: simple monotonic integers per session. No need for global uniqueness since IDs are scoped to a session.
- **Comments/keepalives excluded**: only `field` events (data messages) get IDs and buffering. SSE comments (`:keepalive`) are transient by nature.

## Test plan

- [ ] SSE events include `id:` field in the wire format
- [ ] SSEMessage string parser round-trips id correctly
- [ ] Client reconnects with `Last-Event-ID: N` → receives events N+1, N+2, ...
- [ ] Client reconnects with unknown `Last-Event-ID` → no replay, normal streaming
- [ ] Buffer eviction: after 257 events, event 1 is no longer replayable
- [ ] Legacy `/sse` connections unaffected (no replay attempted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)