### PR TITLE
[codex] Enforce MCP session rules across transports

### DIFF
--- a/Sources/SwiftMCP/Client/InProcessStdioBridge.swift
+++ b/Sources/SwiftMCP/Client/InProcessStdioBridge.swift
@@ -74,7 +74,11 @@ final class InProcessStdioBridge: StdioConnection, @unchecked Sendable {
         do {
             let messages = try JSONRPCMessage.decodeMessages(from: lineData)
             let responses = await session.work { _ in
-                await server.processBatch(messages)
+                if await SessionInitializationGate.shouldReject(messages, for: session) {
+                    return SessionInitializationGate.rejectionResponses(for: messages)
+                }
+
+                return await server.processBatch(messages)
             }
             guard !responses.isEmpty else { return }
 

--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -216,6 +216,7 @@ public extension MCPServer {
      - Returns: A JSON-RPC message containing the initialization response
      */
     private func handleInitializeRequest(_ request: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage? {
+        await Session.current?.markInitializeRequestReceived()
         await extractAndStoreCapabilities(request)
         await extractAndStoreClientInfo(request)
         // Extract and store authentication metadata from _meta

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
@@ -89,8 +89,7 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
         }
         
         // 1. If we have a session ID, check token against session-stored value
-        if let id = sessionID {
-            let session = await sessionManager.session(id: id)
+        if let id = sessionID, let session = await sessionManager.existingSession(id: id) {
             if let stored = await session.accessToken {
                 if stored == token, (await session.accessTokenExpiry ?? Date.distantFuture) > Date() {
                     return .authorized

--- a/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
@@ -63,7 +63,7 @@ extension HTTPSSETransport {
 
 		do {
 			let messages = try JSONRPCMessage.decodeMessages(from: body)
-			if await sessionNeedsInitialize(sessionID), !batchStartsWithInitialize(messages) {
+			if await sessionNeedsInitialize(sessionID), !SessionInitializationGate.batchStartsWithInitialize(messages) {
 				logger.warning("Rejected legacy SSE request for uninitialized session \(sessionID)")
 				return textResponse(
 					status: .badRequest,

--- a/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
@@ -37,6 +37,11 @@ extension HTTPSSETransport {
 			return RouteResponse(status: .badRequest)
 		}
 
+		guard await sessionManager.hasSession(id: sessionID) else {
+			logger.warning("Rejected message for unknown legacy SSE session \(sessionID)")
+			return textResponse(status: .notFound, body: "Unknown session. Connect to /sse first.")
+		}
+
 		// Check authorization
 		let token = request.bearerToken
 
@@ -58,6 +63,14 @@ extension HTTPSSETransport {
 
 		do {
 			let messages = try JSONRPCMessage.decodeMessages(from: body)
+			if await sessionNeedsInitialize(sessionID), !batchStartsWithInitialize(messages) {
+				logger.warning("Rejected legacy SSE request for uninitialized session \(sessionID)")
+				return textResponse(
+					status: .badRequest,
+					body: "Session not initialized. Send initialize first.",
+					sessionID: sessionID
+				)
+			}
 
 			await sessionManager.session(id: sessionID).work { session in
 				for message in messages {

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -55,14 +55,14 @@ extension HTTPSSETransport {
 			let authSessionID: UUID?
 
 				if case .missing = sessionHeader {
-					guard batchStartsWithInitialize(messages) else {
+					guard SessionInitializationGate.batchStartsWithInitialize(messages) else {
 						logger.warning("Rejected request without session ID before initialize")
 						return textResponse(status: .badRequest, body: "Missing Mcp-Session-Id. Send initialize first.")
 					}
 					sessionID = UUID()
 					authSessionID = nil
 				} else if case .existing(let existingSessionID) = sessionHeader {
-					if await sessionNeedsInitialize(existingSessionID), !batchStartsWithInitialize(messages) {
+					if await sessionNeedsInitialize(existingSessionID), !SessionInitializationGate.batchStartsWithInitialize(messages) {
 						logger.warning("Rejected request for uninitialized session \(existingSessionID)")
 						return textResponse(
 							status: .badRequest,

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -22,15 +22,15 @@ extension HTTPSSETransport {
 
 	/// Handle POST /mcp — streamable HTTP endpoint.
 	func handleStreamableHTTP(request: HTTPRouteRequest<Data?>) async throws -> RouteResponse {
-
-		// Extract or generate session ID
-		let sessionID = UUID(uuidString: request.sessionID ?? "") ?? UUID()
-		let sid = sessionID.uuidString
-
-		let baseHeaders: [(String, String)] = [
-			("Content-Type", "application/json"),
-			("Mcp-Session-Id", sid),
-		]
+		let sessionHeader = await resolveSessionHeader(for: request)
+		switch sessionHeader {
+		case .malformed:
+			return textResponse(status: .badRequest, body: "Invalid Mcp-Session-Id header.")
+		case .unknown:
+			return textResponse(status: .notFound, body: "Unknown session. Send initialize first.")
+		case .missing, .existing:
+			break
+		}
 
 		// Validate Accept header
 		let acceptHeader = request.header("accept") ?? request.header("Accept") ?? ""
@@ -38,34 +38,66 @@ extension HTTPSSETransport {
 			let lower = acceptHeader.lowercased()
 			guard lower.contains("application/json") || lower.contains("*/*") else {
 				logger.warning("Rejected non-json request (Accept: \(acceptHeader))")
-				return RouteResponse(status: .badRequest, headers: baseHeaders, body: Data("Client must accept application/json.".utf8))
+				return textResponse(status: .badRequest, body: "Client must accept application/json.")
 			}
-		}
-
-		// Check authorization
-		let token = request.bearerToken
-
-		let authResult = await authorize(token, sessionID: sessionID)
-		switch authResult {
-		case .unauthorized(let message):
-			let errorMessage = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32000, message: "Unauthorized: \(message)"))
-			return .json(errorMessage, status: .unauthorized, sessionId: sid)
-		case .jweNotSupported(let message):
-			let errorMessage = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32000, message: message))
-			return .json(errorMessage, status: .forbidden, sessionId: sid)
-		case .authorized:
-			break
 		}
 
 		guard let body = request.body else {
 			logger.error("POST /mcp received no body.")
-			return RouteResponse(status: .badRequest, headers: baseHeaders, body: Data("Request body required.".utf8))
+			return textResponse(status: .badRequest, body: "Request body required.")
 		}
 
 		do {
 			let messages = try JSONRPCMessage.decodeMessages(from: body)
+			let token = request.bearerToken
 
-			let result: RouteResponse = await sessionManager.session(id: sessionID).work { session in
+			let sessionID: UUID
+			let authSessionID: UUID?
+
+				if case .missing = sessionHeader {
+					guard batchStartsWithInitialize(messages) else {
+						logger.warning("Rejected request without session ID before initialize")
+						return textResponse(status: .badRequest, body: "Missing Mcp-Session-Id. Send initialize first.")
+					}
+					sessionID = UUID()
+					authSessionID = nil
+				} else if case .existing(let existingSessionID) = sessionHeader {
+					if await sessionNeedsInitialize(existingSessionID), !batchStartsWithInitialize(messages) {
+						logger.warning("Rejected request for uninitialized session \(existingSessionID)")
+						return textResponse(
+							status: .badRequest,
+							body: "Session not initialized. Send initialize first.",
+						sessionID: existingSessionID
+					)
+					}
+					sessionID = existingSessionID
+					authSessionID = existingSessionID
+				} else {
+					return textResponse(status: .internalServerError, body: "Session validation failed.")
+				}
+
+            let authResult = await authorize(token, sessionID: authSessionID)
+            switch authResult {
+                case .unauthorized(let message):
+                    let errorMessage = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32000, message: "Unauthorized: \(message)"))
+                    return .json(errorMessage, status: .unauthorized, sessionId: authSessionID?.uuidString)
+                case .jweNotSupported(let message):
+                    let errorMessage = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32000, message: message))
+                    return .json(errorMessage, status: .forbidden, sessionId: authSessionID?.uuidString)
+                case .authorized:
+                    break
+            }
+
+			let sid = sessionID.uuidString
+			let baseHeaders: [(String, String)] = [
+				("Content-Type", "application/json"),
+				("Mcp-Session-Id", sid),
+			]
+
+			let session = await sessionManager.session(id: sessionID)
+			await bindBearerTokenIfNeeded(token, to: sessionID)
+
+			let result: RouteResponse = await session.work { session in
 
 				if await session.hasActiveConnection {
 					// Process messages and stream responses via SSE
@@ -101,7 +133,13 @@ extension HTTPSSETransport {
 		} catch {
 			logger.error("Failed to decode JSON-RPC message: \(error)")
 			let response = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32700, message: error.localizedDescription))
-			return .json(response, status: .badRequest, sessionId: sid)
+			let sessionID: String? = {
+				if case .existing(let existingSessionID) = sessionHeader {
+					return existingSessionID.uuidString
+				}
+				return nil
+			}()
+			return .json(response, status: .badRequest, sessionId: sessionID)
 		}
 	}
 
@@ -113,7 +151,22 @@ extension HTTPSSETransport {
 	/// stream by `Session.sendSSE`.
 	func handleSSE(request: HTTPRouteRequest<Data?>) async throws -> RouteResponse {
 		let isLegacy = request.path == "/sse"
-		let sessionID = UUID(uuidString: request.sessionID ?? "") ?? UUID()
+		let sessionHeader = await resolveSessionHeader(for: request)
+		let sessionID: UUID
+		let authSessionID: UUID?
+
+        switch sessionHeader {
+            case .missing:
+                sessionID = UUID()
+                authSessionID = nil
+            case .existing(let existingSessionID):
+                sessionID = existingSessionID
+                authSessionID = existingSessionID
+            case .malformed:
+                return textResponse(status: .badRequest, body: "Invalid Mcp-Session-Id header.")
+            case .unknown:
+                return textResponse(status: .notFound, body: "Unknown session. Send initialize first.")
+        }
 
 		// Validate SSE headers
 		let acceptHeader = request.header("accept") ?? request.header("Accept") ?? ""
@@ -135,7 +188,7 @@ extension HTTPSSETransport {
 		// Validate token
 		let token = request.bearerToken
 
-		let authResult = await authorize(token, sessionID: sessionID)
+		let authResult = await authorize(token, sessionID: authSessionID)
 		switch authResult {
 		case .unauthorized(let message):
 			logger.warning("Unauthorized SSE connect: \(message)")
@@ -149,6 +202,7 @@ extension HTTPSSETransport {
 
 		// Create the SSE stream — events will be yielded into it by Session.sendSSE
 		let stream = await prepareSSEStream(sessionID: sessionID)
+		await bindBearerTokenIfNeeded(token, to: sessionID)
 
 		// For the legacy protocol, send the endpoint event as the first stream item
 		if isLegacy {
@@ -182,11 +236,14 @@ extension HTTPSSETransport {
 
 	/// Handle DELETE /mcp — remove a session.
 	func handleDeleteSession(request: HTTPRouteRequest<Data?>) async throws -> RouteResponse {
-		guard let sessionIDHeader = request.sessionID,
-			  let sessionUUID = UUID(uuidString: sessionIDHeader) else {
-			return RouteResponse(status: .badRequest)
+		switch await resolveSessionHeader(for: request) {
+		case .missing, .malformed:
+			return textResponse(status: .badRequest, body: "Valid Mcp-Session-Id header required.")
+		case .unknown:
+			return textResponse(status: .notFound, body: "Unknown session. Send initialize first.")
+		case .existing(let sessionID):
+			await sessionManager.removeSession(id: sessionID)
+			return RouteResponse(status: .noContent)
 		}
-		await sessionManager.removeSession(id: sessionUUID)
-		return RouteResponse(status: .noContent)
 	}
 }

--- a/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
+++ b/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
@@ -24,18 +24,6 @@ extension HTTPSSETransport {
         return .unknown(sessionID)
     }
 
-    func batchStartsWithInitialize(_ messages: [JSONRPCMessage]) -> Bool {
-        guard let first = messages.first else {
-            return false
-        }
-
-        if case .request(let request) = first {
-            return request.method == "initialize"
-        }
-
-        return false
-    }
-
     func sessionNeedsInitialize(_ sessionID: UUID) async -> Bool {
         guard let session = await sessionManager.existingSession(id: sessionID) else {
             return false

--- a/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
+++ b/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+extension HTTPSSETransport {
+    enum SessionHeaderResolution {
+        case missing
+        case malformed(String)
+        case unknown(UUID)
+        case existing(UUID)
+    }
+
+    func resolveSessionHeader<Body: Sendable>(for request: HTTPRouteRequest<Body>) async -> SessionHeaderResolution {
+        guard let rawSessionID = request.sessionID else {
+            return .missing
+        }
+
+        guard let sessionID = UUID(uuidString: rawSessionID) else {
+            return .malformed(rawSessionID)
+        }
+
+        if await sessionManager.hasSession(id: sessionID) {
+            return .existing(sessionID)
+        }
+
+        return .unknown(sessionID)
+    }
+
+    func batchStartsWithInitialize(_ messages: [JSONRPCMessage]) -> Bool {
+        guard let first = messages.first else {
+            return false
+        }
+
+        if case .request(let request) = first {
+            return request.method == "initialize"
+        }
+
+        return false
+    }
+
+    func sessionNeedsInitialize(_ sessionID: UUID) async -> Bool {
+        guard let session = await sessionManager.existingSession(id: sessionID) else {
+            return false
+        }
+
+        return !(await session.hasReceivedInitializeRequest)
+    }
+
+    func bindBearerTokenIfNeeded(_ token: String?, to sessionID: UUID) async {
+        guard let token else {
+            return
+        }
+
+        guard let session = await sessionManager.existingSession(id: sessionID) else {
+            return
+        }
+
+        if let storedToken = await session.accessToken,
+           storedToken == token,
+           (await session.accessTokenExpiry ?? Date.distantFuture) > Date() {
+            return
+        }
+
+        guard await validateNewToken(token) else {
+            return
+        }
+
+        await session.setAccessToken(token)
+        await session.setAccessTokenExpiry(Date().addingTimeInterval(24 * 60 * 60))
+
+        if let oauthConfiguration {
+            await sessionManager.fetchAndStoreUserInfo(for: sessionID, oauthConfiguration: oauthConfiguration)
+        }
+    }
+
+    func textResponse(status: HTTPStatus, body: String, sessionID: UUID? = nil) -> RouteResponse {
+        var headers: [(String, String)] = [
+            ("Content-Type", "text/plain; charset=utf-8")
+        ]
+
+        if let sessionID {
+            headers.append(("Mcp-Session-Id", sessionID.uuidString))
+        }
+
+        return RouteResponse(status: status, headers: headers, body: Data(body.utf8))
+    }
+}

--- a/Sources/SwiftMCP/Transport/Routing/UploadRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/UploadRoutes.swift
@@ -26,7 +26,18 @@ extension HTTPSSETransport {
 			return RouteResponse(status: .notFound, body: Data("File uploads not supported by this server.".utf8))
 		}
 
-		let sessionID = UUID(uuidString: request.sessionID ?? "") ?? UUID()
+		let sessionHeader = await resolveSessionHeader(for: request)
+		let sessionID: UUID
+		switch sessionHeader {
+		case .missing:
+			return textResponse(status: .badRequest, body: "Missing Mcp-Session-Id. Send initialize first.")
+		case .malformed:
+			return textResponse(status: .badRequest, body: "Invalid Mcp-Session-Id header.")
+		case .unknown:
+			return textResponse(status: .notFound, body: "Unknown session. Send initialize first.")
+		case .existing(let existingSessionID):
+			sessionID = existingSessionID
+		}
 
 		let token = request.bearerToken
 
@@ -38,6 +49,14 @@ extension HTTPSSETransport {
 			return RouteResponse(status: .forbidden, body: Data(message.utf8))
 		case .authorized:
 			break
+		}
+
+		if await sessionNeedsInitialize(sessionID) {
+			return textResponse(
+				status: .badRequest,
+				body: "Session not initialized. Send initialize first.",
+				sessionID: sessionID
+			)
 		}
 
 		// Extract CID from path

--- a/Sources/SwiftMCP/Transport/Session.swift
+++ b/Sources/SwiftMCP/Transport/Session.swift
@@ -55,6 +55,9 @@ public actor Session {
     /// Client info received during initialization (if any).
     public var clientInfo: Implementation?
 
+    /// Whether this session has received an MCP initialize request.
+    public var hasReceivedInitializeRequest: Bool = false
+
     /// URIs that this session has subscribed to for resource-updated notifications.
     internal var subscribedResourceURIs: Set<String> = []
 
@@ -146,6 +149,11 @@ public actor Session {
     /// Update the client info stored for this session.
     public func setClientInfo(_ info: Implementation?) {
         self.clientInfo = info
+    }
+
+    /// Mark the session as having received an MCP initialize request.
+    public func markInitializeRequestReceived() {
+        hasReceivedInitializeRequest = true
     }
 
     /// Sends a JSON-RPC message to the client and waits for the response.

--- a/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
+++ b/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+enum SessionInitializationGate {
+    static let rejectionMessage = "Session not initialized. Send initialize first."
+
+    static func batchStartsWithInitialize(_ messages: [JSONRPCMessage]) -> Bool {
+        guard let first = messages.first else {
+            return false
+        }
+
+        if case .request(let request) = first {
+            return request.method == "initialize"
+        }
+
+        return false
+    }
+
+    static func shouldReject(_ messages: [JSONRPCMessage], for session: Session) async -> Bool {
+        !(await session.hasReceivedInitializeRequest) && !batchStartsWithInitialize(messages)
+    }
+
+    static func rejectionResponses(for messages: [JSONRPCMessage]) -> [JSONRPCMessage] {
+        let requestIDs = messages.compactMap { message -> JSONRPCID? in
+            guard case .request(let request) = message else {
+                return nil
+            }
+
+            return request.id
+        }
+
+        if requestIDs.isEmpty {
+            return [
+                .errorResponse(
+                    id: nil,
+                    error: .init(code: -32000, message: rejectionMessage)
+                )
+            ]
+        }
+
+        return requestIDs.map { requestID in
+            .errorResponse(
+                id: requestID,
+                error: .init(code: -32000, message: rejectionMessage)
+            )
+        }
+    }
+}

--- a/Sources/SwiftMCP/Transport/SessionManager.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager.swift
@@ -24,12 +24,27 @@ actor SessionManager {
         }
     }
 
+    /// Check whether a session with the given identifier exists.
+    func hasSession(id: UUID) -> Bool {
+        sessions[id] != nil
+    }
+
+    /// Retrieve an existing session without creating a new one.
+    func existingSession(id: UUID) async -> Session? {
+        guard let existing = sessions[id] else {
+            return nil
+        }
+
+        if await existing.transport == nil {
+            await existing.setTransport(transport)
+        }
+
+        return existing
+    }
+
     /// Retrieve or create a session for the given identifier.
     func session(id: UUID) async -> Session {
-        if let existing = sessions[id] {
-            if await existing.transport == nil {
-                await existing.setTransport(transport)
-            }
+        if let existing = await existingSession(id: id) {
             return existing
         }
 

--- a/Sources/SwiftMCP/Transport/StdioTransport.swift
+++ b/Sources/SwiftMCP/Transport/StdioTransport.swift
@@ -126,7 +126,18 @@ public final class StdioTransport: Transport, @unchecked Sendable {
     func handleReceived(_ data: Data) async throws
     {
         do {
+            guard let session = Session.current else {
+                logger.error("Received stdio data without an active session")
+                return
+            }
+
             let messages = try JSONRPCMessage.decodeMessages(from: data)
+
+            if await SessionInitializationGate.shouldReject(messages, for: session) {
+                logger.warning("Rejected stdio request before initialize")
+                try await send(SessionInitializationGate.rejectionResponses(for: messages))
+                return
+            }
 
             let responses = await server.processBatch(messages)
 

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
@@ -467,6 +467,12 @@ public final class TCPBonjourTransport: Transport, @unchecked Sendable {
         await session.work { _ in
             do {
                 let messages = try JSONRPCMessage.decodeMessages(from: data)
+                if await SessionInitializationGate.shouldReject(messages, for: session) {
+                    logger.warning("Rejected TCP request before initialize (\(session.id))")
+                    try await send(SessionInitializationGate.rejectionResponses(for: messages))
+                    return
+                }
+
                 let responses = await server.processBatch(messages)
                 guard !responses.isEmpty else { return }
                 try await send(responses)
@@ -548,4 +554,3 @@ public final class TCPBonjourTransport: Transport, @unchecked Sendable {
     }
 }
 #endif
-

--- a/Tests/SwiftMCPTests/HTTPTransportTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTests.swift
@@ -5,13 +5,26 @@ import FoundationNetworking
 #endif
 @testable import SwiftMCP
 
+@MCPServer(name: "UploadCapableServer")
+private final class UploadCapableServer {
+	@MCPTool(description: "Health check")
+	func ping() -> String {
+		"pong"
+	}
+}
+
+extension UploadCapableServer: MCPFileUploadHandling {}
 
 @Suite("HTTP Transport Integration")
 struct HTTPTransportTests {
 
 	/// Create a transport, start it, and return the base URL.
 	private func startTransport() async throws -> (HTTPSSETransport, URL) {
-		let server = Calculator()
+		try await startTransport(server: Calculator())
+	}
+
+	/// Create a transport for a specific server, start it, and return the base URL.
+	private func startTransport(server: some MCPServer) async throws -> (HTTPSSETransport, URL) {
 		let transport = HTTPSSETransport(server: server, host: "127.0.0.1", port: 0)
 		try await transport.start()
 		let baseURL = URL(string: "http://127.0.0.1:\(transport.port)")!
@@ -123,6 +136,44 @@ struct HTTPTransportTests {
 		#expect(resp.result != nil) // empty object = pong
 	}
 
+	@Test("POST /mcp: missing session on non-initialize returns 400 without creating a session")
+	func modernNonInitializeWithoutSessionRejected() async throws {
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let session = URLSession(configuration: .ephemeral)
+		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
+		request.httpMethod = "POST"
+		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.setValue("application/json", forHTTPHeaderField: "Accept")
+		request.httpBody = try encode(JSONRPCMessage.request(id: 1, method: "ping"))
+
+		let (_, response) = try await session.data(for: request)
+		let http = response as! HTTPURLResponse
+		#expect(http.statusCode == 400)
+		#expect(http.value(forHTTPHeaderField: "Mcp-Session-Id") == nil)
+		#expect(await transport.sessionManager.sessionIDs.isEmpty)
+	}
+
+	@Test("POST /mcp: unknown session returns 404")
+	func modernUnknownSessionRejected() async throws {
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let session = URLSession(configuration: .ephemeral)
+		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
+		request.httpMethod = "POST"
+		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.setValue("application/json", forHTTPHeaderField: "Accept")
+		request.setValue(UUID().uuidString, forHTTPHeaderField: "Mcp-Session-Id")
+		request.httpBody = try encode(JSONRPCMessage.request(id: 1, method: "ping"))
+
+		let (_, response) = try await session.data(for: request)
+		let http = response as! HTTPURLResponse
+		#expect(http.statusCode == 404)
+		#expect(await transport.sessionManager.sessionIDs.isEmpty)
+	}
+
 	@Test("POST /mcp: session ID is preserved across requests")
 	func sessionIdPreserved() async throws {
 		let (transport, baseURL) = try await startTransport()
@@ -165,6 +216,59 @@ struct HTTPTransportTests {
 		let (_, resp3) = try await session.data(for: req3)
 		let sessionId3 = (resp3 as! HTTPURLResponse).value(forHTTPHeaderField: "Mcp-Session-Id")!
 		#expect(sessionId3 == sessionId, "Session ID changed: \(sessionId) → \(sessionId3)")
+	}
+
+	@Test("POST /mcp: SSE-created session still requires initialize")
+	func modernSSESessionRequiresInitialize() async throws {
+		#if canImport(FoundationNetworking)
+		return
+		#else
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let url = baseURL.appendingPathComponent("mcp")
+		let sessionIDBox = Box<String?>(nil)
+
+		var sseRequest = URLRequest(url: url)
+		sseRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+
+		let sseTask = Task {
+			let session = URLSession(configuration: .ephemeral)
+			let (bytes, response) = try await session.bytes(for: sseRequest)
+			sessionIDBox.value = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Mcp-Session-Id")
+			for try await _ in bytes.lines {
+				// Keep the SSE connection open until the test cancels it.
+			}
+		}
+
+		try await Task.sleep(for: .milliseconds(200))
+		await transport.sessionManager.broadcastSSE(SSEMessage(data: "warmup", eventName: "warmup"))
+
+		let deadline = Date().addingTimeInterval(2)
+		while sessionIDBox.value == nil, Date() < deadline {
+			try await Task.sleep(for: .milliseconds(50))
+		}
+
+		guard let sessionId = sessionIDBox.value else {
+			sseTask.cancel()
+			Issue.record("Expected SSE connection to return a session ID")
+			return
+		}
+
+		var pingRequest = URLRequest(url: url)
+		pingRequest.httpMethod = "POST"
+		pingRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		pingRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+		pingRequest.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
+		pingRequest.httpBody = try encode(JSONRPCMessage.request(id: 1, method: "ping"))
+
+		let (_, response) = try await URLSession(configuration: .ephemeral).data(for: pingRequest)
+		let http = response as! HTTPURLResponse
+		#expect(http.statusCode == 400)
+		#expect(http.value(forHTTPHeaderField: "Mcp-Session-Id") == sessionId)
+
+		sseTask.cancel()
+		#endif
 	}
 
 	@Test("POST /mcp: with active SSE returns 202 and streams response")
@@ -421,6 +525,25 @@ struct HTTPTransportTests {
 		#endif
 	}
 
+	@Test("Legacy SSE: unknown messages session returns 404")
+	func legacySSEUnknownSessionRejected() async throws {
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let session = URLSession(configuration: .ephemeral)
+		let url = baseURL
+			.appendingPathComponent("messages")
+			.appendingPathComponent(UUID().uuidString)
+
+		var request = URLRequest(url: url)
+		request.httpMethod = "POST"
+		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.httpBody = try encode(JSONRPCMessage.request(id: 1, method: "ping"))
+
+		let (_, response) = try await session.data(for: request)
+		#expect((response as! HTTPURLResponse).statusCode == 404)
+	}
+
 	// MARK: - DELETE /mcp
 
 	@Test("DELETE /mcp: removes session")
@@ -448,6 +571,43 @@ struct HTTPTransportTests {
 
 		let (_, deleteResp) = try await session.data(for: deleteReq)
 		#expect((deleteResp as! HTTPURLResponse).statusCode == 204)
+	}
+
+	@Test("DELETE /mcp: unknown session returns 404")
+	func deleteUnknownSession() async throws {
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let session = URLSession(configuration: .ephemeral)
+		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
+		request.httpMethod = "DELETE"
+		request.setValue(UUID().uuidString, forHTTPHeaderField: "Mcp-Session-Id")
+
+		let (_, response) = try await session.data(for: request)
+		#expect((response as! HTTPURLResponse).statusCode == 404)
+	}
+
+	// MARK: - Uploads
+
+	@Test("POST /mcp/uploads/:cid: unknown session returns 404")
+	func uploadUnknownSessionRejected() async throws {
+		let (transport, baseURL) = try await startTransport(server: UploadCapableServer())
+		defer { Task { try? await transport.stop() } }
+
+		let session = URLSession(configuration: .ephemeral)
+		let url = baseURL
+			.appendingPathComponent("mcp")
+			.appendingPathComponent("uploads")
+			.appendingPathComponent("cid-123")
+
+		var request = URLRequest(url: url)
+		request.httpMethod = "POST"
+		request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+		request.setValue(UUID().uuidString, forHTTPHeaderField: "Mcp-Session-Id")
+		request.httpBody = Data("hello".utf8)
+
+		let (_, response) = try await session.data(for: request)
+		#expect((response as! HTTPURLResponse).statusCode == 404)
 	}
 
 	// MARK: - CORS
@@ -584,6 +744,20 @@ struct HTTPTransportTests {
 
 		let (_, response) = try await session.data(for: request)
 		#expect((response as! HTTPURLResponse).statusCode == 400)
+	}
+
+	@Test("GET /mcp: unknown session returns 404")
+	func unknownModernSSESession() async throws {
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let session = URLSession(configuration: .ephemeral)
+		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
+		request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+		request.setValue(UUID().uuidString, forHTTPHeaderField: "Mcp-Session-Id")
+
+		let (_, response) = try await session.data(for: request)
+		#expect((response as! HTTPURLResponse).statusCode == 404)
 	}
 
 	@Test("unknown path returns 404")

--- a/Tests/SwiftMCPTests/LineTransportInitializationTests.swift
+++ b/Tests/SwiftMCPTests/LineTransportInitializationTests.swift
@@ -1,0 +1,136 @@
+import Testing
+import Foundation
+@testable import SwiftMCP
+
+@Suite("Line Transport Initialization")
+struct LineTransportInitializationTests {
+    private func initializeRequest(id: Int = 1) -> JSONRPCMessage {
+        .request(
+            id: id,
+            method: "initialize",
+            params: [
+                "protocolVersion": .string("2025-06-18"),
+                "capabilities": .object([:]),
+                "clientInfo": .object([
+                    "name": .string("TestClient"),
+                    "version": .string("1.0")
+                ])
+            ]
+        )
+    }
+
+    private func encodeLine<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601WithTimeZone
+        encoder.outputFormatting = [.sortedKeys]
+        var data = try encoder.encode(value)
+        data.append(0x0A)
+        return data
+    }
+
+    private func decodeMessages(from line: String) throws -> [JSONRPCMessage] {
+        try JSONRPCMessage.decodeMessages(from: Data(line.utf8))
+    }
+
+    @Test("Uninitialized session rejects non-initialize requests")
+    func uninitializedSessionRejectsNonInitialize() async {
+        let session = Session(id: UUID())
+        let messages = [JSONRPCMessage.request(id: 1, method: "ping")]
+
+        #expect(await SessionInitializationGate.shouldReject(messages, for: session))
+    }
+
+    @Test("Uninitialized session allows batches that start with initialize")
+    func uninitializedSessionAllowsInitializeBatch() async {
+        let session = Session(id: UUID())
+        let messages = [
+            initializeRequest(id: 1),
+            JSONRPCMessage.request(id: 2, method: "ping")
+        ]
+
+        #expect(!(await SessionInitializationGate.shouldReject(messages, for: session)))
+    }
+
+    @Test("Rejection responses preserve request IDs")
+    func rejectionResponsesPreserveRequestIDs() throws {
+        let responses = SessionInitializationGate.rejectionResponses(for: [
+            .request(id: 7, method: "ping"),
+            .notification(method: "notifications/initialized")
+        ])
+
+        #expect(responses.count == 1)
+        guard case .errorResponse(let error) = responses[0] else {
+            Issue.record("Expected error response")
+            return
+        }
+
+        #expect(error.id == .int(7))
+        #expect(error.error.message == SessionInitializationGate.rejectionMessage)
+    }
+
+    @Test("In-process stdio rejects ping before initialize")
+    func inProcessStdioRejectsPingBeforeInitialize() async throws {
+        let bridge = InProcessStdioBridge(server: LocalStdioServer())
+        try await bridge.start()
+        defer { Task { await bridge.stop() } }
+
+        let lines = await bridge.lines()
+        var iterator = lines.makeAsyncIterator()
+
+        await bridge.write(try encodeLine(JSONRPCMessage.request(id: 1, method: "ping")))
+
+        guard let line = try await iterator.next() else {
+            Issue.record("Expected response line")
+            return
+        }
+
+        let messages = try decodeMessages(from: line)
+        #expect(messages.count == 1)
+
+        guard case .errorResponse(let error) = messages[0] else {
+            Issue.record("Expected error response")
+            return
+        }
+
+        #expect(error.id == .int(1))
+        #expect(error.error.message == SessionInitializationGate.rejectionMessage)
+    }
+
+    @Test("In-process stdio accepts batch when initialize comes first")
+    func inProcessStdioAllowsInitializeFirstBatch() async throws {
+        let bridge = InProcessStdioBridge(server: LocalStdioServer())
+        try await bridge.start()
+        defer { Task { await bridge.stop() } }
+
+        let lines = await bridge.lines()
+        var iterator = lines.makeAsyncIterator()
+
+        let batch = [
+            initializeRequest(id: 1),
+            JSONRPCMessage.request(id: 2, method: "ping")
+        ]
+        await bridge.write(try encodeLine(batch))
+
+        guard let line = try await iterator.next() else {
+            Issue.record("Expected response line")
+            return
+        }
+
+        let messages = try decodeMessages(from: line)
+        #expect(messages.count == 2)
+
+        guard case .response(let initializeResponse) = messages[0] else {
+            Issue.record("Expected initialize response")
+            return
+        }
+
+        #expect(initializeResponse.id == .int(1))
+
+        guard case .response(let pingResponse) = messages[1] else {
+            Issue.record("Expected ping response")
+            return
+        }
+
+        #expect(pingResponse.id == .int(2))
+    }
+}


### PR DESCRIPTION
## Summary

Supersedes #108.

This replaces the earlier narrow `POST /mcp` header check with transport-wide MCP session enforcement.

The implementation now applies the same initialize-first gating model across:
- streamable HTTP routes
- legacy SSE message routes
- stdio transport
- TCP transport
- the in-process stdio bridge used by client-side tests

## Why

PR #108 addressed the main `POST /mcp` path, but there were still session side effects and protocol bypasses:
- authorizing against a generated UUID could materialize a session before request validation
- `GET /mcp`, legacy `/messages/:sessionID`, and `/mcp/uploads/:cid` could still bootstrap or use sessions outside the intended initialize flow
- stdio and TCP sessions tracked state implicitly but did not reject pre-`initialize` traffic

This version makes initialization state explicit on the session and uses shared gating helpers so every transport enforces the same rule: a session is not usable until it has actually received `initialize`.

## What changed

- added non-side-effecting session lookup helpers and explicit session initialization state
- prevented auth checks from creating sessions implicitly
- enforced initialization ordering on HTTP/SSE routes and legacy `/messages/:sessionID`
- added a shared line-transport initialization gate for stdio and TCP transports
- applied the same gate to the in-process stdio bridge so client-side tests exercise the real behavior
- added focused tests for line-transport gating, plus the broader HTTP transport coverage from the earlier change

## Impact

Clients can now only obtain a usable session through the intended initialize handshake.

That means:
- creating an SSE session alone does not make it valid for normal MCP requests
- unknown UUIDs are rejected consistently on the HTTP surface
- stdio and TCP clients cannot send normal requests before initialize and still be accepted implicitly

## Validation

- `swift test --filter LineTransportInitializationTests`
- `swift test --filter HTTPTransportTests`
- `swift test`
