### PR TITLE
Implement MCP 2025-11-25 streamable HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ actor Calculator {
     }
 }
 
-let url = URL(string: "http://localhost:8080/sse")!
+let url = URL(string: "http://localhost:8080/mcp")!
 let config = MCPServerConfig.sse(config: MCPServerSseConfig(url: url))
 let proxy = MCPServerProxy(config: config)
 try await proxy.connect()
@@ -186,6 +186,7 @@ try await proxy.connect()
 Notes:
 - Client generation is opt-in (`generateClient` defaults to `false`).
 - Client methods always `throw` to surface transport or server errors.
+- Prefer the Streamable HTTP `/mcp` endpoint for new clients. The legacy `/sse` endpoint remains available for backwards compatibility.
 
 ## Client Notification Handlers
 
@@ -216,7 +217,7 @@ formats such as `date-time`, `uri`, `uuid`, and `byte` can be mapped to native
 types (`Date`, `URL`, `UUID`, `Data`).
 
 ```bash
-SwiftMCPUtility generate-proxy --sse http://localhost:8080/sse -o ToolsProxy.swift
+SwiftMCPUtility generate-proxy --sse http://localhost:8080/mcp -o ToolsProxy.swift
 ```
 
 All generated methods are `async throws` so transport and server errors are surfaced.
@@ -230,7 +231,7 @@ responses, and uses those types in the proxy's return signatures.
 
 ```bash
 SwiftMCPUtility generate-proxy \
-  --sse http://localhost:8080/sse \
+  --sse http://localhost:8080/mcp \
   --openapi http://localhost:8080/openapi.json \
   -o ToolsProxy.swift
 ```

--- a/Sources/SwiftMCP/Client/AsyncSequence+SSE.swift
+++ b/Sources/SwiftMCP/Client/AsyncSequence+SSE.swift
@@ -8,35 +8,56 @@ struct SSEMessageSequence<Base: AsyncSequence>: AsyncSequence where Base.Element
     struct AsyncIterator: AsyncIteratorProtocol {
         var iterator: Base.AsyncIterator
         var currentEvent: String = ""
-        var currentData: String = ""
+        var currentDataLines: [String] = []
+        var currentID: String?
+        var currentRetry: Int?
+        var hasPendingFields = false
 
         mutating func next() async throws -> SSEClientMessage? {
             while let lineValue = try await iterator.next() {
                 let line = String(lineValue)
                 if line.isEmpty {
-                    if !currentData.isEmpty {
+                    if hasPendingFields {
                         return yieldCurrent()
                     }
                     continue
                 }
 
-                if let range = line.range(of: "event: ") {
-                    currentEvent = String(line[range.upperBound...])
+                if line.hasPrefix(":") {
                     continue
                 }
 
-                if let range = line.range(of: "data: ") {
-                    currentData = String(line[range.upperBound...])
+                let parts = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+                let field = String(parts[0])
+                let rawValue = parts.count > 1 ? String(parts[1]) : ""
+                let value = rawValue.hasPrefix(" ") ? String(rawValue.dropFirst()) : rawValue
 
-                    if currentEvent == "endpoint" || currentData.contains("jsonrpc") {
+                switch field {
+                case "event":
+                    currentEvent = value
+                    hasPendingFields = true
+                    continue
+                case "data":
+                    currentDataLines.append(value)
+                    hasPendingFields = true
+                    if currentEvent == "endpoint" || value.contains("jsonrpc") || (currentID != nil && value.isEmpty) {
                         return yieldCurrent()
                     }
-
+                    continue
+                case "id":
+                    currentID = value
+                    hasPendingFields = true
+                    continue
+                case "retry":
+                    currentRetry = Int(value)
+                    hasPendingFields = true
+                    continue
+                default:
                     continue
                 }
             }
 
-            if !currentData.isEmpty {
+            if hasPendingFields {
                 return yieldCurrent()
             }
 
@@ -44,9 +65,17 @@ struct SSEMessageSequence<Base: AsyncSequence>: AsyncSequence where Base.Element
         }
 
         private mutating func yieldCurrent() -> SSEClientMessage {
-            let message = SSEClientMessage(event: currentEvent, data: currentData)
+            let message = SSEClientMessage(
+                event: currentEvent,
+                data: currentDataLines.joined(separator: "\n"),
+                id: currentID,
+                retry: currentRetry
+            )
             currentEvent = ""
-            currentData = ""
+            currentDataLines = []
+            currentID = nil
+            currentRetry = nil
+            hasPendingFields = false
             return message
         }
     }

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -1636,7 +1636,7 @@ public final actor MCPServerProxy: Sendable {
         var latestEventID = lastEventID
         var retryMilliseconds = retryMilliseconds
 
-        for await message in delegate.lines.sseMessages() {
+        for try await message in delegate.lines.sseMessages() {
             if let id = message.id {
                 latestEventID = id
             }

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -594,6 +594,18 @@ public final actor MCPServerProxy: Sendable {
             }
 
         case .sse(let sseConfig):
+            if isStreamableMCPURL(endpointURL ?? sseConfig.url) {
+#if os(Linux)
+                return try await sendStreamableRequestLinux(message, sseConfig: sseConfig)
+#else
+                if #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, macCatalyst 15.0, *) {
+                    return try await sendStreamableRequestApple(message, sseConfig: sseConfig)
+                } else {
+                    throw MCPServerProxyError.unsupportedPlatform("Streamable HTTP requires macOS 12.0 or newer.")
+                }
+#endif
+            }
+
             guard let endpointURL = endpointURL else {
                 throw MCPServerProxyError.communicationError("Not connected to server")
             }
@@ -745,7 +757,7 @@ public final actor MCPServerProxy: Sendable {
     private func initialize(clientName: String, clientVersion: String) async throws {
         let requestId = nextRequestID()
         var params: JSONDictionary = [
-            "protocolVersion": .string("2025-06-18"),
+            "protocolVersion": .string(HTTPSSETransport.latestProtocolVersion),
             "clientInfo": .object([
                 "name": .string(clientName),
                 "version": .string(clientVersion)
@@ -830,6 +842,10 @@ public final actor MCPServerProxy: Sendable {
     }
 
     private func processIncomingMessage(event: String = "", data: String) async {
+        if data.isEmpty {
+            return
+        }
+
         if event == "endpoint" {
             if case .sse(let sseConfig) = config, isStreamableMCPURL(sseConfig.url) {
                 // Ignore legacy endpoint events for streamable /mcp mode.
@@ -1287,12 +1303,37 @@ public final actor MCPServerProxy: Sendable {
         }
     }
 
+    private func applyStreamableProtocolHeaders(_ request: inout URLRequest) {
+        request.setValue(HTTPSSETransport.latestProtocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
+        if let sessionID {
+            request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        }
+    }
+
     private func configureSSEPOSTRequest(_ request: inout URLRequest, sseConfig: MCPServerSseConfig) {
         applyConfiguredSSEHeaders(&request, sseConfig: sseConfig)
         request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
 
-        if let sessionID {
+        if isStreamableMCPURL(sseConfig.url) {
+            applyStreamableProtocolHeaders(&request)
+        } else if let sessionID {
             request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        }
+    }
+
+    private func configureSSEGETRequest(
+        _ request: inout URLRequest,
+        sseConfig: MCPServerSseConfig,
+        lastEventID: String? = nil
+    ) {
+        applyConfiguredSSEHeaders(&request, sseConfig: sseConfig)
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+
+        if isStreamableMCPURL(sseConfig.url) {
+            applyStreamableProtocolHeaders(&request)
+            if let lastEventID {
+                request.setValue(lastEventID, forHTTPHeaderField: "Last-Event-ID")
+            }
         }
     }
 
@@ -1315,6 +1356,206 @@ public final actor MCPServerProxy: Sendable {
         }
     }
 
+    #if !os(Linux)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, macCatalyst 15.0, *)
+    private func sendStreamableRequestApple(_ message: JSONRPCMessage, sseConfig: MCPServerSseConfig) async throws -> JSONRPCMessage {
+        guard let requestID = message.id else {
+            throw MCPServerProxyError.communicationError("Message must have an ID")
+        }
+        guard let endpointURL = endpointURL ?? (isStreamableMCPURL(sseConfig.url) ? sseConfig.url : nil) else {
+            throw MCPServerProxyError.communicationError("Not connected to server")
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let requestBody = try encoder.encode(message)
+
+        return try await streamableRequestResponseApple(
+            endpointURL: endpointURL,
+            sseConfig: sseConfig,
+            requestID: requestID,
+            requestBody: requestBody,
+            lastEventID: nil,
+            retryMilliseconds: 1000
+        )
+    }
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, macCatalyst 15.0, *)
+    private func streamableRequestResponseApple(
+        endpointURL: URL,
+        sseConfig: MCPServerSseConfig,
+        requestID: JSONRPCID,
+        requestBody: Data?,
+        lastEventID: String?,
+        retryMilliseconds: Int
+    ) async throws -> JSONRPCMessage {
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.timeoutIntervalForRequest = .infinity
+        sessionConfig.timeoutIntervalForResource = .infinity
+
+        let session = URLSession(configuration: sessionConfig)
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = requestBody == nil ? "GET" : "POST"
+
+        if let requestBody {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            configureSSEPOSTRequest(&request, sseConfig: sseConfig)
+            request.httpBody = requestBody
+        } else {
+            configureSSEGETRequest(&request, sseConfig: sseConfig, lastEventID: lastEventID)
+        }
+
+        let (asyncBytes, response) = try await session.bytes(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw MCPServerProxyError.communicationError("Invalid HTTP response")
+        }
+
+        if let updatedSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
+            sessionID = updatedSessionID
+        }
+
+        let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
+        switch httpResponse.statusCode {
+        case 200:
+            if contentType.contains("application/json") {
+                var data = Data()
+                for try await byte in asyncBytes {
+                    data.append(byte)
+                }
+
+                guard let responseMessage = try responseMessage(for: requestID, from: data) else {
+                    throw MCPServerProxyError.communicationError("HTTP 200 did not include JSON-RPC response for request \(requestID.stringValue)")
+                }
+                return responseMessage
+            }
+
+            if contentType.contains("text/event-stream") {
+                return try await readStreamableSSEApple(
+                    asyncBytes: asyncBytes,
+                    endpointURL: endpointURL,
+                    sseConfig: sseConfig,
+                    requestID: requestID,
+                    lastEventID: lastEventID,
+                    retryMilliseconds: retryMilliseconds
+                )
+            }
+
+            throw MCPServerProxyError.communicationError("Unsupported response content type: \(contentType)")
+        case 202:
+            throw MCPServerProxyError.communicationError("Unexpected HTTP 202 for request \(requestID.stringValue)")
+        default:
+            var data = Data()
+            for try await byte in asyncBytes {
+                data.append(byte)
+            }
+            let responseBody = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let details = responseBody.isEmpty ? "" : ": \(responseBody)"
+            throw MCPServerProxyError.communicationError("HTTP error \(httpResponse.statusCode)\(details)")
+        }
+    }
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, macCatalyst 15.0, *)
+    private func readStreamableSSEApple(
+        asyncBytes: URLSession.AsyncBytes,
+        endpointURL: URL,
+        sseConfig: MCPServerSseConfig,
+        requestID: JSONRPCID,
+        lastEventID: String?,
+        retryMilliseconds: Int
+    ) async throws -> JSONRPCMessage {
+        var latestEventID = lastEventID
+        var retryMilliseconds = retryMilliseconds
+
+        do {
+            for try await message in asyncBytes.lines.sseMessages() {
+                if let id = message.id {
+                    latestEventID = id
+                }
+                if let retry = message.retry {
+                    retryMilliseconds = retry
+                }
+
+                if message.data.isEmpty {
+                    continue
+                }
+
+                if let jsonData = message.data.data(using: .utf8),
+                   let decoded = try? JSONDecoder().decode(JSONRPCMessage.self, from: jsonData),
+                   decoded.id == requestID {
+                    switch decoded {
+                    case .response, .errorResponse:
+                        return decoded
+                    case .request, .notification:
+                        break
+                    }
+                }
+
+                await processIncomingMessage(event: message.event, data: message.data)
+            }
+        } catch is CancellationError {
+            throw MCPServerProxyError.communicationError("Request stream cancelled before response was received")
+        } catch {
+            if let latestEventID {
+                try await Task.sleep(nanoseconds: UInt64(retryMilliseconds) * 1_000_000)
+                return try await streamableRequestResponseApple(
+                    endpointURL: endpointURL,
+                    sseConfig: sseConfig,
+                    requestID: requestID,
+                    requestBody: nil,
+                    lastEventID: latestEventID,
+                    retryMilliseconds: retryMilliseconds
+                )
+            }
+            throw MCPServerProxyError.communicationError(error.localizedDescription)
+        }
+
+        if let latestEventID {
+            try await Task.sleep(nanoseconds: UInt64(retryMilliseconds) * 1_000_000)
+            return try await streamableRequestResponseApple(
+                endpointURL: endpointURL,
+                sseConfig: sseConfig,
+                requestID: requestID,
+                requestBody: nil,
+                lastEventID: latestEventID,
+                retryMilliseconds: retryMilliseconds
+            )
+        }
+
+        throw MCPServerProxyError.communicationError("SSE stream closed before response was received")
+    }
+    #endif
+
+    #if os(Linux)
+    private func sendStreamableRequestLinux(_ message: JSONRPCMessage, sseConfig: MCPServerSseConfig) async throws -> JSONRPCMessage {
+        guard let endpointURL = endpointURL ?? (isStreamableMCPURL(sseConfig.url) ? sseConfig.url : nil) else {
+            throw MCPServerProxyError.communicationError("Not connected to server")
+        }
+        guard let requestID = message.id else {
+            throw MCPServerProxyError.communicationError("Message must have an ID")
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try encoder.encode(message)
+        configureSSEPOSTRequest(&request, sseConfig: sseConfig)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let httpResponse = response as? HTTPURLResponse,
+           let updatedSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
+            sessionID = updatedSessionID
+        }
+
+        guard let responseMessage = try responseMessage(for: requestID, from: data) else {
+            throw MCPServerProxyError.communicationError("HTTP response did not include JSON-RPC response for request \(requestID.stringValue)")
+        }
+        return responseMessage
+    }
+    #endif
+
     // MARK: - SSE Connection (Apple platforms)
 
     #if !os(Linux)
@@ -1323,6 +1564,9 @@ public final actor MCPServerProxy: Sendable {
         let isStreamableMCP = isStreamableMCPURL(sseConfig.url)
         if isStreamableMCP {
             endpointURL = sseConfig.url
+            try await initialize(clientName: clientName, clientVersion: clientVersion)
+            startStreamableGeneralSSEApple(sseConfig: sseConfig)
+            return
         }
 
         let sessionConfig = URLSessionConfiguration.default
@@ -1332,8 +1576,7 @@ public final actor MCPServerProxy: Sendable {
         let session = URLSession(configuration: sessionConfig)
         var request = URLRequest(url: sseConfig.url)
         request.httpMethod = "GET"
-        applyConfiguredSSEHeaders(&request, sseConfig: sseConfig)
-        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        configureSSEGETRequest(&request, sseConfig: sseConfig)
 
         streamTask = Task {
             do {
@@ -1368,14 +1611,16 @@ public final actor MCPServerProxy: Sendable {
         let isStreamableMCP = isStreamableMCPURL(sseConfig.url)
         if isStreamableMCP {
             endpointURL = sseConfig.url
+            try await initialize(clientName: clientName, clientVersion: clientVersion)
+            startStreamableGeneralSSELinux(sseConfig: sseConfig)
+            return
         }
 
         let sessionConfig = URLSessionConfiguration.default
 
         var request = URLRequest(url: sseConfig.url)
         request.httpMethod = "GET"
-        applyConfiguredSSEHeaders(&request, sseConfig: sseConfig)
-        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        configureSSEGETRequest(&request, sseConfig: sseConfig)
 
         // Use a streaming delegate since URLSession.bytes is unavailable on Linux
         let proxy = self
@@ -1409,6 +1654,119 @@ public final actor MCPServerProxy: Sendable {
 
         try await waitForEndpointIfNeeded(isStreamableMCP: isStreamableMCP)
         try await initialize(clientName: clientName, clientVersion: clientVersion)
+    }
+    #endif
+
+    #if !os(Linux)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, macCatalyst 15.0, *)
+    private func startStreamableGeneralSSEApple(sseConfig: MCPServerSseConfig) {
+        streamTask = Task {
+            var lastEventID: String?
+            var retryMilliseconds = 1000
+
+            while !self.isDisconnecting {
+                do {
+                    let sessionConfig = URLSessionConfiguration.default
+                    sessionConfig.timeoutIntervalForRequest = .infinity
+                    sessionConfig.timeoutIntervalForResource = .infinity
+
+                    let session = URLSession(configuration: sessionConfig)
+                    var request = URLRequest(url: sseConfig.url)
+                    request.httpMethod = "GET"
+                    self.configureSSEGETRequest(&request, sseConfig: sseConfig, lastEventID: lastEventID)
+
+                    let (asyncBytes, response) = try await session.bytes(for: request)
+                    self.handleSSEResponse(response, sseConfig: sseConfig, isStreamableMCP: true)
+
+                    for try await message in asyncBytes.lines.sseMessages() {
+                        if let id = message.id {
+                            lastEventID = id
+                        }
+                        if let retry = message.retry {
+                            retryMilliseconds = retry
+                        }
+                        await self.processIncomingMessage(event: message.event, data: message.data)
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    if self.isDisconnecting {
+                        return
+                    }
+                    self.logger.error("[MCP DEBUG] Streamable general SSE stream error: \(error)")
+                }
+
+                if self.isDisconnecting {
+                    return
+                }
+
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(retryMilliseconds) * 1_000_000)
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+    #endif
+
+    #if os(Linux)
+    private func startStreamableGeneralSSELinux(sseConfig: MCPServerSseConfig) {
+        streamTask = Task {
+            var lastEventID: String?
+            var retryMilliseconds = 1000
+
+            while !self.isDisconnecting {
+                let sessionConfig = URLSessionConfiguration.default
+                let proxy = self
+                let delegate = SSEStreamingDelegate { response in
+                    Task {
+                        await proxy.handleSSEResponse(response, sseConfig: sseConfig, isStreamableMCP: true)
+                    }
+                }
+
+                var request = URLRequest(url: sseConfig.url)
+                request.httpMethod = "GET"
+                self.configureSSEGETRequest(&request, sseConfig: sseConfig, lastEventID: lastEventID)
+
+                let session = URLSession(configuration: sessionConfig, delegate: delegate, delegateQueue: nil)
+                let task = session.dataTask(with: request)
+                task.resume()
+
+                do {
+                    for try await message in delegate.lines.sseMessages() {
+                        if let id = message.id {
+                            lastEventID = id
+                        }
+                        if let retry = message.retry {
+                            retryMilliseconds = retry
+                        }
+                        await self.processIncomingMessage(event: message.event, data: message.data)
+                    }
+                } catch is CancellationError {
+                    task.cancel()
+                    return
+                } catch {
+                    if self.isDisconnecting {
+                        task.cancel()
+                        return
+                    }
+                    self.logger.error("[MCP DEBUG] Streamable general SSE stream error: \(error)")
+                }
+
+                if self.isDisconnecting {
+                    task.cancel()
+                    return
+                }
+
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(retryMilliseconds) * 1_000_000)
+                } catch {
+                    task.cancel()
+                    return
+                }
+            }
+        }
     }
     #endif
 

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -1527,32 +1527,158 @@ public final actor MCPServerProxy: Sendable {
 
     #if os(Linux)
     private func sendStreamableRequestLinux(_ message: JSONRPCMessage, sseConfig: MCPServerSseConfig) async throws -> JSONRPCMessage {
-        guard let endpointURL = endpointURL ?? (isStreamableMCPURL(sseConfig.url) ? sseConfig.url : nil) else {
-            throw MCPServerProxyError.communicationError("Not connected to server")
-        }
         guard let requestID = message.id else {
             throw MCPServerProxyError.communicationError("Message must have an ID")
+        }
+        guard let endpointURL = endpointURL ?? (isStreamableMCPURL(sseConfig.url) ? sseConfig.url : nil) else {
+            throw MCPServerProxyError.communicationError("Not connected to server")
         }
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
+        let requestBody = try encoder.encode(message)
+
+        return try await streamableRequestResponseLinux(
+            endpointURL: endpointURL,
+            sseConfig: sseConfig,
+            requestID: requestID,
+            requestBody: requestBody,
+            lastEventID: nil,
+            retryMilliseconds: 1000
+        )
+    }
+
+    private func streamableRequestResponseLinux(
+        endpointURL: URL,
+        sseConfig: MCPServerSseConfig,
+        requestID: JSONRPCID,
+        requestBody: Data?,
+        lastEventID: String?,
+        retryMilliseconds: Int
+    ) async throws -> JSONRPCMessage {
+        let delegate = SSEStreamingDelegate { _ in }
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
 
         var request = URLRequest(url: endpointURL)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try encoder.encode(message)
-        configureSSEPOSTRequest(&request, sseConfig: sseConfig)
+        request.httpMethod = requestBody == nil ? "GET" : "POST"
 
-        let (data, response) = try await URLSession.shared.data(for: request)
-        if let httpResponse = response as? HTTPURLResponse,
-           let updatedSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
+        if let requestBody {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = requestBody
+            configureSSEPOSTRequest(&request, sseConfig: sseConfig)
+        } else {
+            configureSSEGETRequest(&request, sseConfig: sseConfig, lastEventID: lastEventID)
+        }
+
+        let task = session.dataTask(with: request)
+        task.resume()
+
+        let response = await delegate.waitForResponse()
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw MCPServerProxyError.communicationError("Invalid HTTP response")
+        }
+
+        if let updatedSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
             sessionID = updatedSessionID
         }
 
-        guard let responseMessage = try responseMessage(for: requestID, from: data) else {
-            throw MCPServerProxyError.communicationError("HTTP response did not include JSON-RPC response for request \(requestID.stringValue)")
+        let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
+
+        switch httpResponse.statusCode {
+        case 200:
+            if contentType.contains("application/json") {
+                var bodyLines: [String] = []
+                for await line in delegate.lines {
+                    bodyLines.append(line)
+                }
+
+                let body = bodyLines.joined(separator: "\n")
+                guard let responseMessage = try responseMessage(for: requestID, from: Data(body.utf8)) else {
+                    throw MCPServerProxyError.communicationError("HTTP 200 did not include JSON-RPC response for request \(requestID.stringValue)")
+                }
+                return responseMessage
+            }
+
+            if contentType.contains("text/event-stream") {
+                return try await readStreamableSSELinux(
+                    delegate: delegate,
+                    endpointURL: endpointURL,
+                    sseConfig: sseConfig,
+                    requestID: requestID,
+                    lastEventID: lastEventID,
+                    retryMilliseconds: retryMilliseconds
+                )
+            }
+
+            throw MCPServerProxyError.communicationError("Unsupported response content type: \(contentType)")
+        case 202:
+            throw MCPServerProxyError.communicationError("Unexpected HTTP 202 for request \(requestID.stringValue)")
+        default:
+            var bodyLines: [String] = []
+            for await line in delegate.lines {
+                bodyLines.append(line)
+            }
+
+            let responseBody = bodyLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            let details = responseBody.isEmpty ? "" : ": \(responseBody)"
+            throw MCPServerProxyError.communicationError("HTTP error \(httpResponse.statusCode)\(details)")
         }
-        return responseMessage
+    }
+
+    private func readStreamableSSELinux(
+        delegate: SSEStreamingDelegate,
+        endpointURL: URL,
+        sseConfig: MCPServerSseConfig,
+        requestID: JSONRPCID,
+        lastEventID: String?,
+        retryMilliseconds: Int
+    ) async throws -> JSONRPCMessage {
+        var latestEventID = lastEventID
+        var retryMilliseconds = retryMilliseconds
+
+        for await message in delegate.lines.sseMessages() {
+            if let id = message.id {
+                latestEventID = id
+            }
+            if let retry = message.retry {
+                retryMilliseconds = retry
+            }
+
+            if message.data.isEmpty {
+                continue
+            }
+
+            if let jsonData = message.data.data(using: .utf8),
+               let decoded = try? JSONDecoder().decode(JSONRPCMessage.self, from: jsonData),
+               decoded.id == requestID {
+                switch decoded {
+                case .response, .errorResponse:
+                    return decoded
+                case .request, .notification:
+                    break
+                }
+            }
+
+            await processIncomingMessage(event: message.event, data: message.data)
+        }
+
+        if let latestEventID {
+            try await Task.sleep(nanoseconds: UInt64(retryMilliseconds) * 1_000_000)
+            return try await streamableRequestResponseLinux(
+                endpointURL: endpointURL,
+                sseConfig: sseConfig,
+                requestID: requestID,
+                requestBody: nil,
+                lastEventID: latestEventID,
+                retryMilliseconds: retryMilliseconds
+            )
+        }
+
+        if let completionError = delegate.completionError {
+            throw MCPServerProxyError.communicationError(completionError.localizedDescription)
+        }
+
+        throw MCPServerProxyError.communicationError("SSE stream closed before response was received")
     }
     #endif
 

--- a/Sources/SwiftMCP/Client/SSEClientMessage.swift
+++ b/Sources/SwiftMCP/Client/SSEClientMessage.swift
@@ -3,4 +3,6 @@ import Foundation
 struct SSEClientMessage {
     let event: String
     let data: String
+    let id: String?
+    let retry: Int?
 }

--- a/Sources/SwiftMCP/Client/SSEStreamingDelegate.swift
+++ b/Sources/SwiftMCP/Client/SSEStreamingDelegate.swift
@@ -9,21 +9,31 @@ final class SSEStreamingDelegate: NSObject, URLSessionDataDelegate, @unchecked S
     private let lineContinuation: AsyncStream<String>.Continuation
     private var buffer = Data()
     private var responseHandler: ((URLResponse) -> Void)?
+    private var responseContinuation: CheckedContinuation<URLResponse, Never>?
 
     /// The async stream of lines received from the SSE connection.
     let lines: AsyncStream<String>
 
     /// The HTTP response, available after the first data callback.
     private(set) var response: URLResponse?
-    private let responseContinuation: CheckedContinuation<URLResponse, Never>?
+    private(set) var completionError: Error?
 
     init(onResponse: @escaping (URLResponse) -> Void) {
         var cont: AsyncStream<String>.Continuation!
         self.lines = AsyncStream<String> { cont = $0 }
         self.lineContinuation = cont
         self.responseHandler = onResponse
-        self.responseContinuation = nil
         super.init()
+    }
+
+    func waitForResponse() async -> URLResponse {
+        if let response {
+            return response
+        }
+
+        return await withCheckedContinuation { continuation in
+            responseContinuation = continuation
+        }
     }
 
     func urlSession(
@@ -35,6 +45,8 @@ final class SSEStreamingDelegate: NSObject, URLSessionDataDelegate, @unchecked S
         self.response = response
         responseHandler?(response)
         responseHandler = nil
+        responseContinuation?.resume(returning: response)
+        responseContinuation = nil
         completionHandler(.allow)
     }
 
@@ -60,6 +72,8 @@ final class SSEStreamingDelegate: NSObject, URLSessionDataDelegate, @unchecked S
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        completionError = error
+
         // Flush any remaining data in buffer as a final line
         if !buffer.isEmpty {
             let line = String(data: buffer, encoding: .utf8) ?? ""

--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -217,7 +217,8 @@ public extension MCPServer {
      */
     private func handleInitializeRequest(_ request: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage? {
         await Session.current?.markInitializeRequestReceived()
-        await Session.current?.setNegotiatedProtocolVersion(HTTPSSETransport.latestProtocolVersion)
+        let negotiatedProtocolVersion = request.params?["protocolVersion"]?.stringValue ?? HTTPSSETransport.latestProtocolVersion
+        await Session.current?.setNegotiatedProtocolVersion(negotiatedProtocolVersion)
         await extractAndStoreCapabilities(request)
         await extractAndStoreClientInfo(request)
         // Extract and store authentication metadata from _meta
@@ -227,7 +228,7 @@ public extension MCPServer {
             }
         }
         
-        var response = createInitializeResponse(id: request.id)
+        var response = createInitializeResponse(id: request.id, protocolVersion: negotiatedProtocolVersion)
 
         // Conditionally advertise upload capability only on HTTP transports
         if let uploadHandler = self as? MCPFileUploadHandling,
@@ -280,7 +281,10 @@ public extension MCPServer {
      - Parameter id: The request ID to include in the response
      - Returns: A JSON-RPC message containing the initialization response
      */
-    func createInitializeResponse(id: JSONRPCID) -> JSONRPCMessage {
+    func createInitializeResponse(
+        id: JSONRPCID,
+        protocolVersion: String = "2025-11-25"
+    ) -> JSONRPCMessage {
         var capabilities = ServerCapabilities()
 
         if self is MCPToolProviding {
@@ -311,7 +315,7 @@ public extension MCPServer {
         )
 
         let result = InitializeResult(
-            protocolVersion: HTTPSSETransport.latestProtocolVersion,
+            protocolVersion: protocolVersion,
             capabilities: capabilities,
             serverInfo: serverInfo
         )

--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -218,6 +218,12 @@ public extension MCPServer {
     private func handleInitializeRequest(_ request: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage? {
         await Session.current?.markInitializeRequestReceived()
         let negotiatedProtocolVersion = request.params?["protocolVersion"]?.stringValue ?? HTTPSSETransport.latestProtocolVersion
+        guard HTTPSSETransport.supportedProtocolVersions.contains(negotiatedProtocolVersion) else {
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32602, message: "Unsupported protocol version: \(negotiatedProtocolVersion)")
+            )
+        }
         await Session.current?.setNegotiatedProtocolVersion(negotiatedProtocolVersion)
         await extractAndStoreCapabilities(request)
         await extractAndStoreClientInfo(request)

--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -217,6 +217,7 @@ public extension MCPServer {
      */
     private func handleInitializeRequest(_ request: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage? {
         await Session.current?.markInitializeRequestReceived()
+        await Session.current?.setNegotiatedProtocolVersion(HTTPSSETransport.latestProtocolVersion)
         await extractAndStoreCapabilities(request)
         await extractAndStoreClientInfo(request)
         // Extract and store authentication metadata from _meta
@@ -310,7 +311,7 @@ public extension MCPServer {
         )
 
         let result = InitializeResult(
-            protocolVersion: "2025-06-18",
+            protocolVersion: HTTPSSETransport.latestProtocolVersion,
             capabilities: capabilities,
             serverInfo: serverInfo
         )

--- a/Sources/SwiftMCP/SwiftMCP.docc/Resources/08-client-connect.swift
+++ b/Sources/SwiftMCP/SwiftMCP.docc/Resources/08-client-connect.swift
@@ -1,6 +1,6 @@
 import SwiftMCP
 
-let url = URL(string: "http://localhost:8080/sse")!
+let url = URL(string: "http://localhost:8080/mcp")!
 let config = MCPServerConfig.sse(config: MCPServerSseConfig(url: url))
 let proxy = MCPServerProxy(config: config)
 try await proxy.connect()

--- a/Sources/SwiftMCP/Transport/HTTPHandler.swift
+++ b/Sources/SwiftMCP/Transport/HTTPHandler.swift
@@ -130,13 +130,13 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
                 let response = try await handler(self.transport, request)
 
                 // For SSE streaming responses, register the NIO channel.
-                // Legacy /sse does not emit Mcp-Session-Id, so prefer the explicit streamSessionID.
                 if response.bodyStream != nil {
-                    if let sessionUUID = response.streamSessionID {
-                        self.transport.registerSSEChannel(channel, id: sessionUUID)
-                    } else if let sessionId = response.headers.first(where: { $0.0.caseInsensitiveCompare("Mcp-Session-Id") == .orderedSame })?.1,
-                              let sessionUUID = UUID(uuidString: sessionId) {
-                        self.transport.registerSSEChannel(channel, id: sessionUUID)
+                    if let streamInfo = response.streamInfo {
+                        self.transport.registerSSEChannel(
+                            channel,
+                            sessionID: streamInfo.sessionID,
+                            streamID: streamInfo.streamID
+                        )
                     }
                 }
 

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
@@ -35,8 +35,13 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
 
     internal let group: EventLoopGroup
     internal var channel: Channel?
-    internal lazy var sessionManager = SessionManager(transport: self)
     internal let pendingUploadStore = PendingUploadStore()
+    public var streamRetentionInterval: TimeInterval = 5 * 60
+    internal lazy var sessionManager = SessionManager(
+        transport: self,
+        pendingUploadStore: pendingUploadStore,
+        retentionInterval: streamRetentionInterval
+    )
     internal var keepAliveTimer: DispatchSourceTimer?
 
     /// The HTTP router that dispatches incoming requests to route handlers.
@@ -207,6 +212,13 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
         get async { await sessionManager.channelCount }
     }
 
+    internal static let latestProtocolVersion = "2025-11-25"
+    internal static let fallbackHTTPProtocolVersion = "2025-03-26"
+    internal static let supportedProtocolVersions: Set<String> = [
+        latestProtocolVersion,
+        fallbackHTTPProtocolVersion,
+    ]
+
 
     // MARK: - Initialization
 
@@ -325,17 +337,21 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
                 case .none:
                     return
                 case .sse:
-                    await self.sessionManager.forEachSession { session in
-                        await session.sendSSE(SSEMessage(comment: "keep-alive"))
+                    let activeStreamIDs = await self.sessionManager.activeStreamIDs()
+                    for streamID in activeStreamIDs {
+                        _ = await self.sessionManager.sendComment("keep-alive", to: streamID)
                     }
                 case .ping:
                     await self.sessionManager.forEachSession { session in
+                        guard await self.sessionManager.hasActivePrimaryGeneralConnection(for: session.id) else {
+                            return
+                        }
+
                         Task {
                             let ping = JSONRPCMessage.request(id: .string(UUID().uuidString), method: "ping")
                             do {
                                 try await session.send(ping)
                             } catch {
-                                // Log error but don't fail the keep-alive cycle
                                 print("Failed to send ping to session \(session.id): \(error)")
                             }
                         }
@@ -344,50 +360,33 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
         }
     }
 
-    // MARK: - Request Handling
-    /// Handle a JSON-RPC request and send the response through the SSE channels.
-    func handleJSONRPCRequest(_ request: JSONRPCMessage, from sessionID: UUID) {
-        Task {
-            let pending = server is MCPFileUploadHandling ? pendingUploadStore : nil
-
-            guard let response = await PendingUploadResolver.$current.withValue(pending, operation: {
-                await server.handleMessage(request)
-            }) else {
-                return
-            }
-
-            try await send(response)
-        }
-    }
-
     // MARK: - Handling SSE Connections
 
-    /// Prepare an SSE session: create the stream, store the continuation,
-    /// and return the `AsyncStream<Data>` for the route handler to include
-    /// in its response. Does **not** touch the NIO channel.
-    func prepareSSEStream(sessionID: UUID) async -> AsyncStream<Data> {
-        let (stream, continuation) = AsyncStream<Data>.makeStream()
-        let session = await sessionManager.session(id: sessionID)
-        await session.setSSEContinuation(continuation)
-        return stream
+    func createSSEStream(sessionID: UUID, kind: SSEStreamKind) async -> (AsyncStream<Data>, StreamRouteResponseInfo) {
+        await sessionManager.createStream(sessionID: sessionID, kind: kind)
     }
 
-    /// Register the NIO channel for an SSE session and set up close handling.
+    func resumeSSEStream(sessionID: UUID, lastEventID: String) async throws -> (AsyncStream<Data>, StreamRouteResponseInfo) {
+        try await sessionManager.resumeStream(sessionID: sessionID, after: lastEventID)
+    }
+
+    /// Register the NIO channel for an SSE stream and set up close handling.
     /// Called by `HTTPHandler` after the route handler returns a streaming response.
-    func registerSSEChannel(_ channel: Channel, id: UUID) {
+    func registerSSEChannel(_ channel: Channel, sessionID: UUID, streamID: UUID) {
         Task {
-            await sessionManager.register(channel: channel, id: id)
+            guard let connectionToken = await sessionManager.register(channel: channel, sessionID: sessionID, streamID: streamID) else {
+                return
+            }
             let count = await sessionManager.channelCount
             logger.info("New SSE channel registered (total: \(count))")
-        }
 
-        channel.closeFuture.whenComplete { [weak self] _ in
-            guard let self = self else { return }
-            Task {
-                // Remove the entire session when the channel closes
-                await self.sessionManager.removeSession(id: id)
-                let count = await self.sessionManager.channelCount
-                self.logger.info("SSE channel removed (remaining: \(count))")
+            channel.closeFuture.whenComplete { [weak self] _ in
+                guard let self = self else { return }
+                Task {
+                    await self.sessionManager.markStreamDisconnected(streamID: streamID, connectionToken: connectionToken)
+                    let count = await self.sessionManager.channelCount
+                    self.logger.info("SSE channel removed (remaining: \(count))")
+                }
             }
         }
     }
@@ -395,9 +394,22 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
     /// Send a message to a specific client.
     func sendSSE(_ message: SSEMessage, to sessionID: UUID) {
         Task {
-            let session = await sessionManager.session(id: sessionID)
-            await session.sendSSE(message)
+            _ = await sessionManager.routeSSEMessage(message, sessionID: sessionID, preferredStreamID: nil)
         }
+    }
+
+    @discardableResult
+    func routeSSEMessage(_ message: SSEMessage, sessionID: UUID, preferredStreamID: UUID?) async -> Bool {
+        await sessionManager.routeSSEMessage(message, sessionID: sessionID, preferredStreamID: preferredStreamID)
+    }
+
+    @discardableResult
+    func sendJSONRPC(_ message: JSONRPCMessage, to streamID: UUID) async throws -> Bool {
+        try await sessionManager.sendJSONRPC(message, to: streamID)
+    }
+
+    func finishSSEStream(_ streamID: UUID) async {
+        await sessionManager.finishStream(streamID: streamID)
     }
 
     /// Broadcast a log message to all connected clients.
@@ -438,7 +450,14 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
 
         let string = String(data: data, encoding: .utf8) ?? ""
         let message = SSEMessage(data: string)
-        await session.sendSSE(message)
+        let routed = await sessionManager.routeSSEMessage(
+            message,
+            sessionID: session.id,
+            preferredStreamID: Session.currentStreamContext?.streamID
+        )
+        if !routed {
+            throw TransportError.bindingFailed("No routable SSE stream for session \(session.id)")
+        }
     }
 
     // MARK: - Route Registration

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
@@ -213,9 +213,11 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
     }
 
     internal static let latestProtocolVersion = "2025-11-25"
+    internal static let intermediateHTTPProtocolVersion = "2025-06-18"
     internal static let fallbackHTTPProtocolVersion = "2025-03-26"
     internal static let supportedProtocolVersions: Set<String> = [
         latestProtocolVersion,
+        intermediateHTTPProtocolVersion,
         fallbackHTTPProtocolVersion,
     ]
 

--- a/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
@@ -72,14 +72,13 @@ extension HTTPSSETransport {
 				)
 			}
 
-			await sessionManager.session(id: sessionID).work { session in
-				for message in messages {
-					switch message {
-					case .response, .errorResponse:
-						await session.handleResponse(message)
-					default:
-						self.handleJSONRPCRequest(message, from: sessionID)
-					}
+			let responses = await sessionManager.session(id: sessionID).work { _ in
+				await self.server.processBatch(messages, ignoringEmptyResponses: true)
+			}
+
+			if let generalStreamID = await sessionManager.primaryGeneralStreamID(for: sessionID) {
+				for response in responses {
+					_ = try? await self.sendJSONRPC(response, to: generalStreamID)
 				}
 			}
 		} catch {

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -34,12 +34,9 @@ extension HTTPSSETransport {
 
 		// Validate Accept header
 		let acceptHeader = request.header("accept") ?? request.header("Accept") ?? ""
-		if !acceptHeader.isEmpty {
-			let lower = acceptHeader.lowercased()
-			guard lower.contains("application/json") || lower.contains("*/*") else {
-				logger.warning("Rejected non-json request (Accept: \(acceptHeader))")
-				return textResponse(status: .badRequest, body: "Client must accept application/json.")
-			}
+		if !acceptHeader.isEmpty && !("application/json".matchesAcceptHeader(acceptHeader) || "*/*".matchesAcceptHeader(acceptHeader)) {
+			logger.warning("Rejected non-json request (Accept: \(acceptHeader))")
+			return textResponse(status: .badRequest, body: "Client must accept application/json.")
 		}
 
 		guard let body = request.body else {
@@ -53,83 +50,89 @@ extension HTTPSSETransport {
 
 			let sessionID: UUID
 			let authSessionID: UUID?
-
-				if case .missing = sessionHeader {
-					guard SessionInitializationGate.batchStartsWithInitialize(messages) else {
-						logger.warning("Rejected request without session ID before initialize")
-						return textResponse(status: .badRequest, body: "Missing Mcp-Session-Id. Send initialize first.")
-					}
-					sessionID = UUID()
-					authSessionID = nil
-				} else if case .existing(let existingSessionID) = sessionHeader {
-					if await sessionNeedsInitialize(existingSessionID), !SessionInitializationGate.batchStartsWithInitialize(messages) {
-						logger.warning("Rejected request for uninitialized session \(existingSessionID)")
-						return textResponse(
-							status: .badRequest,
-							body: "Session not initialized. Send initialize first.",
+			if case .missing = sessionHeader {
+				guard SessionInitializationGate.batchStartsWithInitialize(messages) else {
+					logger.warning("Rejected request without session ID before initialize")
+					return textResponse(status: .badRequest, body: "Missing Mcp-Session-Id. Send initialize first.")
+				}
+				sessionID = UUID()
+				authSessionID = nil
+			} else if case .existing(let existingSessionID) = sessionHeader {
+				if await sessionNeedsInitialize(existingSessionID), !SessionInitializationGate.batchStartsWithInitialize(messages) {
+					logger.warning("Rejected request for uninitialized session \(existingSessionID)")
+					return textResponse(
+						status: .badRequest,
+						body: "Session not initialized. Send initialize first.",
 						sessionID: existingSessionID
 					)
-					}
-					sessionID = existingSessionID
-					authSessionID = existingSessionID
-				} else {
-					return textResponse(status: .internalServerError, body: "Session validation failed.")
 				}
+				sessionID = existingSessionID
+				authSessionID = existingSessionID
+			} else {
+				return textResponse(status: .internalServerError, body: "Session validation failed.")
+			}
 
-            let authResult = await authorize(token, sessionID: authSessionID)
-            switch authResult {
-                case .unauthorized(let message):
-                    let errorMessage = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32000, message: "Unauthorized: \(message)"))
-                    return .json(errorMessage, status: .unauthorized, sessionId: authSessionID?.uuidString)
-                case .jweNotSupported(let message):
-                    let errorMessage = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32000, message: message))
-                    return .json(errorMessage, status: .forbidden, sessionId: authSessionID?.uuidString)
-                case .authorized:
-                    break
-            }
+			if let errorResponse = await validateHTTPProtocolVersion(for: request, sessionID: authSessionID) {
+				return errorResponse
+			}
+
+			let authResult = await authorize(token, sessionID: authSessionID)
+			switch authResult {
+			case .unauthorized(let message):
+				let errorMessage = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32000, message: "Unauthorized: \(message)"))
+				return .json(errorMessage, status: .unauthorized, sessionId: authSessionID?.uuidString)
+			case .jweNotSupported(let message):
+				let errorMessage = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32000, message: message))
+				return .json(errorMessage, status: .forbidden, sessionId: authSessionID?.uuidString)
+			case .authorized:
+				break
+			}
 
 			let sid = sessionID.uuidString
-			let baseHeaders: [(String, String)] = [
-				("Content-Type", "application/json"),
-				("Mcp-Session-Id", sid),
-			]
-
 			let session = await sessionManager.session(id: sessionID)
 			await bindBearerTokenIfNeeded(token, to: sessionID)
+			let pending = self.server is MCPFileUploadHandling ? self.pendingUploadStore : nil
+			let containsRequests = batchContainsRequests(messages)
 
-			let result: RouteResponse = await session.work { session in
+			if containsRequests {
+				guard "text/event-stream".matchesAcceptHeader(acceptHeader) || "*/*".matchesAcceptHeader(acceptHeader) else {
+					return textResponse(status: .badRequest, body: "Client must accept text/event-stream.", sessionID: sessionID)
+				}
 
-				if await session.hasActiveConnection {
-					// Process messages and stream responses via SSE
-					for message in messages {
-						switch message {
-						case .response, .errorResponse:
-							await session.handleResponse(message)
-						default:
-							self.handleJSONRPCRequest(message, from: sessionID)
+				let (stream, streamInfo) = await createSSEStream(sessionID: sessionID, kind: .request)
+				let streamContext = OutboundStreamContext(streamID: streamInfo.streamID, kind: .request)
+
+				Task {
+					let responses = await session.work(onStream: streamContext) { _ in
+						await PendingUploadResolver.$current.withValue(pending) {
+							await self.server.processBatch(messages, ignoringEmptyResponses: true)
 						}
 					}
 
-					// Send 202 Accepted — no body needed
-					return RouteResponse(status: .accepted, headers: baseHeaders)
-				} else {
-					// No SSE connection - use immediate HTTP response
-					let pending = self.server is MCPFileUploadHandling ? self.pendingUploadStore : nil
-					let responses = await PendingUploadResolver.$current.withValue(pending) {
-						await self.server.processBatch(messages, ignoringEmptyResponses: true)
+					for response in responses {
+						_ = try? await self.sendJSONRPC(response, to: streamInfo.streamID)
 					}
 
-					if responses.isEmpty {
-						return RouteResponse(status: .accepted, headers: baseHeaders)
-					} else if responses.count == 1 {
-						return .json(responses.first!, status: .ok, sessionId: sid)
-					} else {
-						return .json(responses, status: .ok, sessionId: sid)
-					}
+					await self.finishSSEStream(streamInfo.streamID)
+				}
+
+				let headers: [(String, String)] = [
+					("Content-Type", "text/event-stream"),
+					("Cache-Control", "no-cache"),
+					("Connection", "keep-alive"),
+					("Mcp-Session-Id", sid),
+				]
+
+				return RouteResponse(status: .ok, headers: headers, bodyStream: stream, streamInfo: streamInfo)
+			}
+
+			_ = await session.work { _ in
+				await PendingUploadResolver.$current.withValue(pending) {
+					await self.server.processBatch(messages, ignoringEmptyResponses: true)
 				}
 			}
 
-			return result
+			return RouteResponse(status: .accepted, headers: [("Mcp-Session-Id", sid)])
 		} catch {
 			logger.error("Failed to decode JSON-RPC message: \(error)")
 			let response = JSONRPCMessage.errorResponse(id: nil, error: .init(code: -32700, message: error.localizedDescription))
@@ -155,18 +158,26 @@ extension HTTPSSETransport {
 		let sessionID: UUID
 		let authSessionID: UUID?
 
-        switch sessionHeader {
-            case .missing:
-                sessionID = UUID()
-                authSessionID = nil
-            case .existing(let existingSessionID):
-                sessionID = existingSessionID
-                authSessionID = existingSessionID
-            case .malformed:
-                return textResponse(status: .badRequest, body: "Invalid Mcp-Session-Id header.")
-            case .unknown:
-                return textResponse(status: .notFound, body: "Unknown session. Send initialize first.")
-        }
+		switch sessionHeader {
+		case .missing:
+			if isLegacy {
+				sessionID = UUID()
+				authSessionID = nil
+			} else {
+				return textResponse(status: .badRequest, body: "Missing Mcp-Session-Id. Send initialize first.")
+			}
+		case .existing(let existingSessionID):
+			sessionID = existingSessionID
+			authSessionID = existingSessionID
+		case .malformed:
+			return textResponse(status: .badRequest, body: "Invalid Mcp-Session-Id header.")
+		case .unknown:
+			return textResponse(status: .notFound, body: "Unknown session. Send initialize first.")
+		}
+
+		if let errorResponse = await validateHTTPProtocolVersion(for: request, sessionID: authSessionID) {
+			return errorResponse
+		}
 
 		// Validate SSE headers
 		let acceptHeader = request.header("accept") ?? request.header("Accept") ?? ""
@@ -200,9 +211,27 @@ extension HTTPSSETransport {
 			break
 		}
 
-		// Create the SSE stream — events will be yielded into it by Session.sendSSE
-		let stream = await prepareSSEStream(sessionID: sessionID)
 		await bindBearerTokenIfNeeded(token, to: sessionID)
+		let stream: AsyncStream<Data>
+		let streamInfo: StreamRouteResponseInfo
+
+		if isLegacy {
+			(stream, streamInfo) = await createSSEStream(sessionID: sessionID, kind: .legacyGeneral)
+		} else if let lastEventID = request.header("Last-Event-ID") ?? request.header("last-event-id") {
+			do {
+				(stream, streamInfo) = try await resumeSSEStream(sessionID: sessionID, lastEventID: lastEventID)
+			} catch SessionManager.StreamResumeError.malformedEventID {
+				return textResponse(status: .badRequest, body: "Malformed Last-Event-ID header.", sessionID: sessionID)
+			} catch SessionManager.StreamResumeError.sessionMismatch,
+			        SessionManager.StreamResumeError.unknownStream,
+			        SessionManager.StreamResumeError.resumePointUnavailable {
+				return textResponse(status: .notFound, body: "Unknown or expired resumable stream.", sessionID: sessionID)
+			} catch {
+				return textResponse(status: .internalServerError, body: "Failed to resume stream.", sessionID: sessionID)
+			}
+		} else {
+			(stream, streamInfo) = await createSSEStream(sessionID: sessionID, kind: .general)
+		}
 
 		// For the legacy protocol, send the endpoint event as the first stream item
 		if isLegacy {
@@ -231,7 +260,7 @@ extension HTTPSSETransport {
 			headers.append(("Mcp-Session-Id", sessionID.uuidString))
 		}
 
-		return RouteResponse(status: .ok, headers: headers, bodyStream: stream, streamSessionID: sessionID)
+		return RouteResponse(status: .ok, headers: headers, bodyStream: stream, streamInfo: streamInfo)
 	}
 
 	/// Handle DELETE /mcp — remove a session.

--- a/Sources/SwiftMCP/Transport/Routing/RouteResponse.swift
+++ b/Sources/SwiftMCP/Transport/Routing/RouteResponse.swift
@@ -6,23 +6,23 @@ struct RouteResponse: Sendable {
 	var headers: [(String, String)]
 	var body: Data?
 	var bodyStream: AsyncStream<Data>?
-	/// Optional SSE session identifier used to register streaming channels.
-	var streamSessionID: UUID?
+	/// Optional stream registration info used to register SSE channels.
+	var streamInfo: StreamRouteResponseInfo?
 
 	init(status: HTTPStatus, headers: [(String, String)] = [], body: Data? = nil) {
 		self.status = status
 		self.headers = headers
 		self.body = body
 		self.bodyStream = nil
-		self.streamSessionID = nil
+		self.streamInfo = nil
 	}
 
-	init(status: HTTPStatus, headers: [(String, String)] = [], bodyStream: AsyncStream<Data>, streamSessionID: UUID? = nil) {
+	init(status: HTTPStatus, headers: [(String, String)] = [], bodyStream: AsyncStream<Data>, streamInfo: StreamRouteResponseInfo? = nil) {
 		self.status = status
 		self.headers = headers
 		self.body = nil
 		self.bodyStream = bodyStream
-		self.streamSessionID = streamSessionID
+		self.streamInfo = streamInfo
 	}
 
 	init(_ response: HTTPRouteResponse<Data?>) {
@@ -30,7 +30,7 @@ struct RouteResponse: Sendable {
 		self.headers = response.headers
 		self.body = response.body
 		self.bodyStream = nil
-		self.streamSessionID = nil
+		self.streamInfo = nil
 	}
 
 	init(_ response: HTTPRouteResponse<AsyncStream<Data>>) {
@@ -38,7 +38,7 @@ struct RouteResponse: Sendable {
 		self.headers = response.headers
 		self.body = nil
 		self.bodyStream = response.body
-		self.streamSessionID = nil
+		self.streamInfo = nil
 	}
 
 	static func json<T: Encodable>(_ value: T, status: HTTPStatus = .ok, sessionId: String? = nil) -> RouteResponse {

--- a/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
+++ b/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
@@ -32,6 +32,55 @@ extension HTTPSSETransport {
         return !(await session.hasReceivedInitializeRequest)
     }
 
+    func batchContainsRequests(_ messages: [JSONRPCMessage]) -> Bool {
+        messages.contains {
+            if case .request = $0 {
+                return true
+            }
+            return false
+        }
+    }
+
+    func validateHTTPProtocolVersion<Body: Sendable>(
+        for request: HTTPRouteRequest<Body>,
+        sessionID: UUID?
+    ) async -> RouteResponse? {
+        if let headerVersion = request.header("MCP-Protocol-Version") {
+            guard HTTPSSETransport.supportedProtocolVersions.contains(headerVersion) else {
+                return textResponse(status: .badRequest, body: "Invalid or unsupported MCP-Protocol-Version header.")
+            }
+
+            if let sessionID,
+               let session = await sessionManager.existingSession(id: sessionID),
+               let negotiatedVersion = await session.negotiatedProtocolVersion,
+               negotiatedVersion != headerVersion {
+                return textResponse(status: .badRequest, body: "MCP-Protocol-Version does not match the negotiated session version.", sessionID: sessionID)
+            }
+
+            return nil
+        }
+
+        return nil
+    }
+
+    func resolvedHTTPProtocolVersion<Body: Sendable>(
+        for request: HTTPRouteRequest<Body>,
+        sessionID: UUID?
+    ) async -> String {
+        if let headerVersion = request.header("MCP-Protocol-Version"),
+           HTTPSSETransport.supportedProtocolVersions.contains(headerVersion) {
+            return headerVersion
+        }
+
+        if let sessionID,
+           let session = await sessionManager.existingSession(id: sessionID),
+           let negotiatedVersion = await session.negotiatedProtocolVersion {
+            return negotiatedVersion
+        }
+
+        return HTTPSSETransport.fallbackHTTPProtocolVersion
+    }
+
     func bindBearerTokenIfNeeded(_ token: String?, to sessionID: UUID) async {
         guard let token else {
             return

--- a/Sources/SwiftMCP/Transport/SSEMessage.swift
+++ b/Sources/SwiftMCP/Transport/SSEMessage.swift
@@ -3,58 +3,88 @@ import Foundation
 /// A Server-Sent Events (SSE) message
 struct SSEMessage: LosslessStringConvertible {
     let event: SSEEvent
-    
-    init(event: SSEEvent) {
+
+    var id: String?
+    var retry: Int?
+
+    init(event: SSEEvent, id: String? = nil, retry: Int? = nil) {
         self.event = event
+        self.id = id
+        self.retry = retry
     }
-    
+
     /// Creates an SSE data message
     /// - Parameters:
     ///   - data: The data content
     ///   - eventName: Optional event name
-    init(data: String, eventName: String? = nil) {
+    ///   - id: Optional event ID
+    ///   - retry: Optional reconnect delay in milliseconds
+    init(data: String, eventName: String? = nil, id: String? = nil, retry: Int? = nil) {
         self.event = .field(name: "data", value: data, eventName: eventName)
+        self.id = id
+        self.retry = retry
     }
-    
+
     /// Creates an SSE comment message
     /// - Parameter comment: The comment text (without the leading colon)
     init(comment: String) {
         self.event = .comment(comment)
+        self.id = nil
+        self.retry = nil
     }
-    
+
     /// Creates an SSE field message
     /// - Parameters:
     ///   - name: The field name
     ///   - value: The field value
     ///   - eventName: Optional event name
-    init(field name: String, value: String, eventName: String? = nil) {
+    ///   - id: Optional event ID
+    ///   - retry: Optional reconnect delay in milliseconds
+    init(field name: String, value: String, eventName: String? = nil, id: String? = nil, retry: Int? = nil) {
         self.event = .field(name: name, value: value, eventName: eventName)
+        self.id = id
+        self.retry = retry
     }
-    
+
+    var isReplayableDataEvent: Bool {
+        switch event {
+        case .comment:
+            return false
+        case .field(let name, _, _):
+            return name == "data"
+        }
+    }
+
     /// Creates an SSE message from a string representation
     /// Expects format:
     /// [event: name\n]
     /// data: content\n\n
     init?(_ description: String) {
-        // Split the message into lines
         let lines = description.split(separator: "\n", omittingEmptySubsequences: false)
         var eventName: String? = nil
-        var data: String? = nil
+        var dataLines: [String] = []
+        var eventID: String? = nil
+        var retry: Int? = nil
 
         for line in lines {
-            if line.starts(with: "event:") {
+            if line.starts(with: "id:") {
+                eventID = String(line.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+            } else if line.starts(with: "retry:") {
+                retry = Int(String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces))
+            } else if line.starts(with: "event:") {
                 eventName = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
             } else if line.starts(with: "data:") {
-                data = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                dataLines.append(String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces))
             }
         }
 
-        // Data field is required
-        guard let data = data else {
+        guard !dataLines.isEmpty else {
             return nil
         }
 
-        self.event = .field(name: "data", value: data, eventName: eventName)
+        self.event = .field(name: "data", value: dataLines.joined(separator: "\n"), eventName: eventName)
+        self.id = eventID
+        self.retry = retry
     }
 
     /// Returns the string representation of the message in SSE format
@@ -64,10 +94,24 @@ struct SSEMessage: LosslessStringConvertible {
             return ": \(comment)\n"
         case .field(let name, let value, let eventName):
             var message = ""
+            if let id {
+                message += "id: \(id)\n"
+            }
+            if let retry {
+                message += "retry: \(retry)\n"
+            }
             if let eventName = eventName {
                 message += "event: \(eventName)\n"
             }
-            message += "\(name): \(value)\n\n"
+            if value.isEmpty {
+                message += "\(name):\n"
+            } else {
+                let lines = value.split(separator: "\n", omittingEmptySubsequences: false)
+                for line in lines {
+                    message += "\(name): \(line)\n"
+                }
+            }
+            message += "\n"
             return message
         }
     }

--- a/Sources/SwiftMCP/Transport/SSEStreamTypes.swift
+++ b/Sources/SwiftMCP/Transport/SSEStreamTypes.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum SSEStreamKind: Sendable {
+    case legacyGeneral
+    case general
+    case request
+
+    var isGeneral: Bool {
+        switch self {
+        case .legacyGeneral, .general:
+            return true
+        case .request:
+            return false
+        }
+    }
+}
+
+struct OutboundStreamContext: Sendable {
+    let streamID: UUID
+    let kind: SSEStreamKind
+}
+
+struct StreamRouteResponseInfo: Sendable {
+    let sessionID: UUID
+    let streamID: UUID
+}

--- a/Sources/SwiftMCP/Transport/Session.swift
+++ b/Sources/SwiftMCP/Transport/Session.swift
@@ -55,11 +55,20 @@ public actor Session {
     /// Client info received during initialization (if any).
     public var clientInfo: Implementation?
 
+    /// The protocol version negotiated during initialize.
+    public var negotiatedProtocolVersion: String?
+
     /// Whether this session has received an MCP initialize request.
     public var hasReceivedInitializeRequest: Bool = false
 
     /// URIs that this session has subscribed to for resource-updated notifications.
     internal var subscribedResourceURIs: Set<String> = []
+
+    /// Timestamp of the most recent activity associated with this session.
+    public var lastActivityAt: Date = Date()
+
+    /// Optional expiry deadline used for retained sessions after disconnect.
+    public var expiresAt: Date?
 
     /// Creates a new session.
     /// - Parameters:
@@ -72,15 +81,34 @@ public actor Session {
     @TaskLocal
     internal static var taskSession: Session?
 
+    @TaskLocal
+    internal static var taskStreamContext: OutboundStreamContext?
+
     /// Accessor for the current session stored in task local storage.
     public static var current: Session! {
         taskSession
+    }
+
+    internal static var currentStreamContext: OutboundStreamContext? {
+        taskStreamContext
     }
 
     /// Runs `operation` with this session bound to `Session.current`.
     public func work<T: Sendable>(_ operation: @Sendable (Session) async throws -> T) async rethrows -> T {
         try await Self.$taskSession.withValue(self) {
             try await operation(self)
+        }
+    }
+
+    /// Runs `operation` with this session and an outbound stream context bound.
+    internal func work<T: Sendable>(
+        onStream streamContext: OutboundStreamContext?,
+        _ operation: @Sendable (Session) async throws -> T
+    ) async rethrows -> T {
+        try await Self.$taskSession.withValue(self) {
+            try await Self.$taskStreamContext.withValue(streamContext) {
+                try await operation(self)
+            }
         }
     }
 
@@ -91,10 +119,13 @@ public actor Session {
 
     /// Send an SSE message through the session's stream continuation.
     /// - Parameter message: The message to send.
-    func sendSSE(_ message: SSEMessage) {
-        guard let sseContinuation else { return }
-        let text = message.description
-        sseContinuation.yield(Data(text.utf8))
+    func sendSSE(_ message: SSEMessage) async {
+        guard let transport = transport as? HTTPSSETransport else { return }
+        await transport.routeSSEMessage(
+            message,
+            sessionID: id,
+            preferredStreamID: Self.currentStreamContext?.streamID
+        )
     }
 
     /// Set the SSE stream continuation for this session.
@@ -151,9 +182,25 @@ public actor Session {
         self.clientInfo = info
     }
 
+    /// Update the negotiated protocol version for this session.
+    public func setNegotiatedProtocolVersion(_ version: String?) {
+        self.negotiatedProtocolVersion = version
+    }
+
     /// Mark the session as having received an MCP initialize request.
     public func markInitializeRequestReceived() {
         hasReceivedInitializeRequest = true
+    }
+
+    /// Record session activity and clear any pending expiry.
+    public func touchActivity() {
+        lastActivityAt = Date()
+        expiresAt = nil
+    }
+
+    /// Update the expiry deadline used for retained sessions.
+    public func setExpiresAt(_ date: Date?) {
+        expiresAt = date
     }
 
     /// Sends a JSON-RPC message to the client and waits for the response.

--- a/Sources/SwiftMCP/Transport/SessionManager.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager.swift
@@ -2,35 +2,78 @@ import Foundation
 import NIO
 
 actor SessionManager {
+    private struct BufferedEvent {
+        let id: String
+        let payload: Data
+    }
+
+    private struct StreamRecord {
+        let id: UUID
+        let sessionID: UUID
+        let kind: SSEStreamKind
+        var continuation: AsyncStream<Data>.Continuation?
+        var channel: Channel?
+        var connectionToken: UUID?
+        var nextSequence: Int = 1
+        var buffer: [BufferedEvent] = []
+        var isCompleted = false
+        var lastActivityAt = Date()
+        var lastConnectedAt: Date?
+        var expiresAt: Date?
+
+        var isActive: Bool {
+            continuation != nil && (channel?.isActive ?? false)
+        }
+    }
+
+    enum StreamResumeError: Error {
+        case malformedEventID
+        case unknownStream
+        case sessionMismatch
+        case resumePointUnavailable
+    }
+
     internal var sessions: [UUID: Session] = [:]
     internal weak var transport: (any Transport)?
+    internal let pendingUploadStore: PendingUploadStore?
+    internal let retentionInterval: TimeInterval
 
-    // OAuth state management removed - using transparent proxy instead
+    private var streams: [UUID: StreamRecord] = [:]
+    private var sessionStreams: [UUID: Set<UUID>] = [:]
+    private var primaryGeneralStreamIDs: [UUID: UUID] = [:]
+    private let eventBufferCapacity = 256
 
-    init(transport: (any Transport)? = nil) {
+    init(
+        transport: (any Transport)? = nil,
+        pendingUploadStore: PendingUploadStore? = nil,
+        retentionInterval: TimeInterval = 5 * 60
+    ) {
         self.transport = transport
+        self.pendingUploadStore = pendingUploadStore
+        self.retentionInterval = retentionInterval
     }
 
     /// Returns the current number of active SSE channels.
     var channelCount: Int {
         get async {
-            var count = 0
-            for session in sessions.values {
-                if await session.channel != nil {
+            await cleanupExpiredState()
+            return streams.values.reduce(into: 0) { count, record in
+                if record.channel != nil {
                     count += 1
                 }
             }
-            return count
         }
     }
 
     /// Check whether a session with the given identifier exists.
-    func hasSession(id: UUID) -> Bool {
-        sessions[id] != nil
+    func hasSession(id: UUID) async -> Bool {
+        await cleanupExpiredState()
+        return sessions[id] != nil
     }
 
     /// Retrieve an existing session without creating a new one.
     func existingSession(id: UUID) async -> Session? {
+        await cleanupExpiredState()
         guard let existing = sessions[id] else {
             return nil
         }
@@ -44,62 +87,180 @@ actor SessionManager {
 
     /// Retrieve or create a session for the given identifier.
     func session(id: UUID) async -> Session {
+        await cleanupExpiredState()
         if let existing = await existingSession(id: id) {
+            await existing.touchActivity()
             return existing
         }
 
         let session = Session(id: id)
         await session.setTransport(transport)
+        await session.touchActivity()
         sessions[id] = session
         return session
     }
 
-    /// Register a new SSE channel.
-    /// - Parameters:
-    ///   - channel: The channel to register.
-    ///   - id: The unique identifier for the channel.
-    ///   - transport: Transport associated with the session.
-    func register(channel: Channel, id: UUID) async {
-        let session: Session
-        if let existing = sessions[id] {
-            session = existing
-        } else {
-            session = Session(id: id, channel: channel)
+    /// Create a new SSE stream for the given session and return the AsyncStream to write to the response.
+    func createStream(sessionID: UUID, kind: SSEStreamKind) async -> (AsyncStream<Data>, StreamRouteResponseInfo) {
+        await cleanupExpiredState()
+        let session = await session(id: sessionID)
+        await session.touchActivity()
+
+        let streamID = UUID()
+        let (stream, continuation) = AsyncStream<Data>.makeStream()
+
+        var record = StreamRecord(id: streamID, sessionID: sessionID, kind: kind, continuation: continuation)
+        record.lastConnectedAt = Date()
+        streams[streamID] = record
+        sessionStreams[sessionID, default: []].insert(streamID)
+
+        if kind.isGeneral {
+            primaryGeneralStreamIDs[sessionID] = streamID
         }
 
-        await session.setChannel(channel)
-
-        if await session.transport == nil {
-            await session.setTransport(transport)
+        if kind != .legacyGeneral {
+            await sendPrimingEvent(to: streamID)
         }
 
-        sessions[id] = session
+        return (stream, StreamRouteResponseInfo(sessionID: sessionID, streamID: streamID))
     }
 
-    /// Remove an SSE channel.
-    /// - Parameter id: The unique identifier of the channel.
-    /// - Returns: True if a channel was removed.
-    @discardableResult
-    func removeChannel(id: UUID) async -> Bool {
-        if let session = sessions[id] {
-            await session.setChannel(nil)
-            return true
+    /// Resume an existing retained stream from the specified Last-Event-ID.
+    func resumeStream(sessionID: UUID, after lastEventID: String) async throws -> (AsyncStream<Data>, StreamRouteResponseInfo) {
+        await cleanupExpiredState()
+
+        let parsed = try parseEventID(lastEventID)
+        guard var record = streams[parsed.streamID] else {
+            throw StreamResumeError.unknownStream
         }
-        return false
+        guard record.sessionID == sessionID else {
+            throw StreamResumeError.sessionMismatch
+        }
+        guard let replayIndex = record.buffer.firstIndex(where: { $0.id == lastEventID }) else {
+            throw StreamResumeError.resumePointUnavailable
+        }
+
+        record.continuation?.finish()
+
+        let (stream, continuation) = AsyncStream<Data>.makeStream()
+        record.continuation = continuation
+        record.channel = nil
+        record.connectionToken = nil
+        record.expiresAt = nil
+        record.lastConnectedAt = Date()
+        record.lastActivityAt = Date()
+        streams[parsed.streamID] = record
+
+        if let session = sessions[sessionID] {
+            await session.touchActivity()
+        }
+
+        for buffered in record.buffer[(replayIndex + 1)...] {
+            continuation.yield(buffered.payload)
+        }
+
+        if record.isCompleted {
+            continuation.finish()
+            await markStreamDisconnected(streamID: parsed.streamID, connectionToken: nil)
+        }
+
+        return (stream, StreamRouteResponseInfo(sessionID: sessionID, streamID: parsed.streamID))
     }
 
-    /// Broadcast an SSE message to all channels.
+    /// Register a new SSE channel for a specific stream.
+    func register(channel: Channel, sessionID: UUID, streamID: UUID) async -> UUID? {
+        await cleanupExpiredState()
+        guard var record = streams[streamID], record.sessionID == sessionID else {
+            return nil
+        }
+
+        let connectionToken = UUID()
+        record.channel = channel
+        record.connectionToken = connectionToken
+        record.expiresAt = nil
+        record.lastConnectedAt = Date()
+        streams[streamID] = record
+
+        if record.kind.isGeneral {
+            primaryGeneralStreamIDs[sessionID] = streamID
+        }
+
+        if let session = sessions[sessionID] {
+            await session.touchActivity()
+        }
+
+        return connectionToken
+    }
+
+    /// Mark a stream's current connection as closed while retaining its buffer for resume.
+    func markStreamDisconnected(streamID: UUID, connectionToken: UUID?) async {
+        await cleanupExpiredState()
+        guard var record = streams[streamID] else {
+            return
+        }
+        if let connectionToken, record.connectionToken != connectionToken {
+            return
+        }
+
+        record.continuation?.finish()
+        record.continuation = nil
+        record.channel = nil
+        record.connectionToken = nil
+        record.expiresAt = Date().addingTimeInterval(retentionInterval)
+        record.lastActivityAt = Date()
+        streams[streamID] = record
+
+        if record.kind.isGeneral {
+            selectPrimaryGeneralStream(for: record.sessionID, keepRetainedCurrent: true)
+        }
+
+        await updateSessionExpiry(for: record.sessionID)
+    }
+
+    /// Finish a stream after the server has emitted its terminal response.
+    func finishStream(streamID: UUID) async {
+        await cleanupExpiredState()
+        guard var record = streams[streamID] else {
+            return
+        }
+
+        record.isCompleted = true
+        record.expiresAt = Date().addingTimeInterval(retentionInterval)
+        record.lastActivityAt = Date()
+        record.continuation?.finish()
+        record.continuation = nil
+        record.channel = nil
+        record.connectionToken = nil
+        streams[streamID] = record
+
+        if record.kind.isGeneral {
+            selectPrimaryGeneralStream(for: record.sessionID, keepRetainedCurrent: true)
+        }
+
+        await updateSessionExpiry(for: record.sessionID)
+    }
+
+    /// Broadcast an SSE message to all currently active streams.
     /// - Parameter message: The SSE message to send.
     func broadcastSSE(_ message: SSEMessage) async {
-        for session in sessions.values {
-            await session.sendSSE(message)
+        await cleanupExpiredState()
+        let activeStreamIDs = streams.values.filter(\.isActive).map(\.id)
+        for streamID in activeStreamIDs {
+            _ = await sendSSE(message, to: streamID)
         }
+    }
+
+    /// Return all active stream identifiers.
+    func activeStreamIDs() async -> [UUID] {
+        await cleanupExpiredState()
+        return streams.values.filter(\.isActive).map(\.id)
     }
 
     /// Enumerate all sessions and call the provided block for each one.
     /// The session context is activated for each call.
-    /// - Parameter block: The block to call for each session
-    @discardableResult func forEachSession<T: Sendable>(_ block: @Sendable @escaping (Session) async throws -> T) async rethrows -> [T] {
+    @discardableResult
+    func forEachSession<T: Sendable>(_ block: @Sendable @escaping (Session) async throws -> T) async rethrows -> [T] {
+        await cleanupExpiredState()
         var results: [T] = []
         for session in sessions.values {
             let result = try await session.work { session in
@@ -109,77 +270,71 @@ actor SessionManager {
         }
         return results
     }
-    
-    /// Retrieve the channel for a given session identifier.
-    /// - Parameter sessionID: The session identifier.
-    /// - Returns: The channel if found.
+
+    /// Retrieve the primary general channel for a given session identifier.
     func getChannel(for sessionID: UUID) async -> Channel? {
-        return await sessions[sessionID]?.channel
+        await cleanupExpiredState()
+        guard let streamID = primaryGeneralStreamIDs[sessionID] else {
+            return nil
+        }
+        return streams[streamID]?.channel
     }
 
-    /// Close all channels and remove them.
+    /// Close all active channels without removing retained state.
     func stopAllChannels() async {
-        for session in sessions.values {
-            if let channel = await session.channel {
-                channel.close(promise: nil)
-                await session.setChannel(nil)
-            }
+        let activeChannels = streams.values.compactMap(\.channel)
+        for channel in activeChannels {
+            channel.close(promise: nil)
         }
     }
 
-    /// Close all channels and remove all sessions.
+    /// Close all channels and remove all sessions and streams.
     func removeAllSessions() async {
-        for session in sessions.values {
-            if let channel = await session.channel {
-                channel.close(promise: nil)
-            }
-            await session.cancelAllWaitingTasks()
+        let sessionIDs = Array(sessions.keys)
+        for sessionID in sessionIDs {
+            await removeSession(id: sessionID)
         }
-        sessions.removeAll()
     }
 
-    /// Check if there's an active SSE connection for a given session.
-    /// - Parameter sessionID: The session identifier.
-    /// - Returns: `true` if there's an active channel for this session.
+    /// Check if any stream for a session is currently active.
     func hasActiveConnection(for sessionID: UUID) async -> Bool {
-        if let session = sessions[sessionID], let channel = await session.channel {
-            return channel.isActive
+        await cleanupExpiredState()
+        guard let streamIDs = sessionStreams[sessionID] else {
+            return false
         }
-        return false
+        return streamIDs.contains { streams[$0]?.isActive == true }
     }
 
-    /// Remove a session entirely, including closing its channel.
+    /// Check whether the primary general stream is currently active.
+    func hasActivePrimaryGeneralConnection(for sessionID: UUID) async -> Bool {
+        await cleanupExpiredState()
+        guard let streamID = primaryGeneralStreamIDs[sessionID] else {
+            return false
+        }
+        return streams[streamID]?.isActive == true
+    }
+
+    func primaryGeneralStreamID(for sessionID: UUID) async -> UUID? {
+        await cleanupExpiredState()
+        return primaryGeneralStreamIDs[sessionID]
+    }
+
+    /// Remove a session entirely, including all retained streams and pending state.
     func removeSession(id: UUID) async {
-        if let session = sessions[id] {
-            // Cancel all waiting tasks (like ping continuations)
-            await session.cancelAllWaitingTasks()
-
-            // Finish the SSE stream so the response completes
-            await session.sseContinuation?.finish()
-            await session.setSSEContinuation(nil)
-
-            // Close the channel if it exists
-            if let channel = await session.channel {
-                channel.close(promise: nil)
-            }
-
-            // Clear the channel reference
-            await session.setChannel(nil)
-        }
-        sessions.removeValue(forKey: id)
+        await cleanupExpiredState()
+        await destroySession(id: id)
     }
-    
+
     /// Get all session IDs.
     var sessionIDs: [UUID] {
         Array(sessions.keys)
     }
 
-    // MARK: - OAuth State Management (Removed - using transparent proxy)
-
     // MARK: - Token lookup
 
     /// Return the first session whose stored accessToken matches `token` and is not expired.
     func session(forToken token: String) async -> Session? {
+        await cleanupExpiredState()
         for session in sessions.values {
             if let stored = await session.accessToken,
                stored == token,
@@ -191,16 +346,12 @@ actor SessionManager {
     }
 
     /// Fetch and store user info for a session after token validation.
-    /// - Parameters:
-    ///   - sessionID: The session identifier
-    ///   - oauthConfiguration: The OAuth configuration to use for fetching user info
     func fetchAndStoreUserInfo(for sessionID: UUID, oauthConfiguration: OAuthConfiguration) async {
         guard let session = sessions[sessionID],
               let accessToken = await session.accessToken else {
             return
         }
 
-        // Only fetch user info if we don't already have it
         if await session.userInfo == nil {
             if let userInfo = await oauthConfiguration.fetchUserInfo(token: accessToken) {
                 await session.setUserInfo(userInfo)
@@ -209,8 +360,8 @@ actor SessionManager {
     }
 
     /// Broadcast a log message to all sessions, filtered by their minimumLogLevel.
-    /// - Parameter message: The log message to send.
     func broadcastLog(_ message: LogMessage) async {
+        await cleanupExpiredState()
         for session in sessions.values {
             await session.work { session in
                 await session.sendLogNotification(message)
@@ -220,6 +371,7 @@ actor SessionManager {
 
     /// Broadcast a tools list-changed notification to all sessions.
     func broadcastToolsListChanged() async {
+        await cleanupExpiredState()
         for session in sessions.values {
             await session.work { session in
                 try? await session.sendToolListChanged()
@@ -229,6 +381,7 @@ actor SessionManager {
 
     /// Broadcast a resources list-changed notification to all sessions.
     func broadcastResourcesListChanged() async {
+        await cleanupExpiredState()
         for session in sessions.values {
             await session.work { session in
                 try? await session.sendResourceListChanged()
@@ -238,6 +391,7 @@ actor SessionManager {
 
     /// Broadcast a prompts list-changed notification to all sessions.
     func broadcastPromptsListChanged() async {
+        await cleanupExpiredState()
         for session in sessions.values {
             await session.work { session in
                 try? await session.sendPromptListChanged()
@@ -246,8 +400,8 @@ actor SessionManager {
     }
 
     /// Send a resource-updated notification to all sessions subscribed to the given URI.
-    /// - Parameter uri: The URI of the resource that was updated.
     func broadcastResourceUpdated(uri: URL) async {
+        await cleanupExpiredState()
         let uriString = uri.absoluteString
         for session in sessions.values {
             let subscribed = await session.isSubscribedToResource(uri: uriString)
@@ -257,5 +411,225 @@ actor SessionManager {
                 }
             }
         }
+    }
+
+    /// Route an already-encoded JSON-RPC message to a specific stream.
+    @discardableResult
+    func sendJSONRPC(_ message: JSONRPCMessage, to streamID: UUID) async throws -> Bool {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601WithTimeZone
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(message)
+        let text = String(data: data, encoding: .utf8) ?? ""
+        return await sendSSE(SSEMessage(data: text), to: streamID)
+    }
+
+    /// Route an SSE message to a preferred stream or the session's primary general stream.
+    @discardableResult
+    func routeSSEMessage(_ message: SSEMessage, sessionID: UUID, preferredStreamID: UUID?) async -> Bool {
+        await cleanupExpiredState()
+
+        if let preferredStreamID,
+           let record = streams[preferredStreamID],
+           record.sessionID == sessionID {
+            return await sendSSE(message, to: preferredStreamID)
+        }
+
+        guard let primaryStreamID = primaryGeneralStreamIDs[sessionID] else {
+            return false
+        }
+
+        return await sendSSE(message, to: primaryStreamID)
+    }
+
+    @discardableResult
+    func sendComment(_ comment: String, to streamID: UUID) async -> Bool {
+        await sendSSE(SSEMessage(comment: comment), to: streamID)
+    }
+
+    // MARK: - Internal routing helpers
+
+    @discardableResult
+    private func sendSSE(_ message: SSEMessage, to streamID: UUID) async -> Bool {
+        guard var record = streams[streamID] else {
+            return false
+        }
+        guard !record.isCompleted || record.kind.isGeneral else {
+            return false
+        }
+
+        var outbound = message
+        if record.kind != .legacyGeneral, outbound.isReplayableDataEvent {
+            if outbound.id == nil {
+                outbound.id = makeEventID(streamID: streamID, sequence: record.nextSequence)
+                record.nextSequence += 1
+            }
+
+            let payload = Data(outbound.description.utf8)
+            record.buffer.append(BufferedEvent(id: outbound.id!, payload: payload))
+            if record.buffer.count > eventBufferCapacity {
+                record.buffer.removeFirst(record.buffer.count - eventBufferCapacity)
+            }
+            record.continuation?.yield(payload)
+        } else {
+            record.continuation?.yield(Data(outbound.description.utf8))
+        }
+
+        record.lastActivityAt = Date()
+        streams[streamID] = record
+
+        if let session = sessions[record.sessionID] {
+            await session.touchActivity()
+        }
+
+        return true
+    }
+
+    private func sendPrimingEvent(to streamID: UUID) async {
+        guard var record = streams[streamID] else {
+            return
+        }
+
+        let eventID = makeEventID(streamID: streamID, sequence: record.nextSequence)
+        record.nextSequence += 1
+        streams[streamID] = record
+        _ = await sendSSE(SSEMessage(data: "", id: eventID), to: streamID)
+    }
+
+    private func cleanupExpiredState() async {
+        let now = Date()
+
+        let expiredStreamIDs = streams.compactMap { streamID, record in
+            if let expiresAt = record.expiresAt, expiresAt <= now {
+                return streamID
+            }
+            return nil
+        }
+        for streamID in expiredStreamIDs {
+            await removeStream(id: streamID)
+        }
+
+        let expiredSessionIDs = sessions.compactMap { sessionID, session in
+            sessionID
+        }
+        for sessionID in expiredSessionIDs {
+            guard let session = sessions[sessionID] else { continue }
+            if let expiresAt = await session.expiresAt, expiresAt <= now {
+                await destroySession(id: sessionID)
+            }
+        }
+
+        await pendingUploadStore?.expireEarlyArrivals(olderThan: retentionInterval)
+    }
+
+    private func removeStream(id streamID: UUID) async {
+        guard let record = streams.removeValue(forKey: streamID) else {
+            return
+        }
+
+        record.continuation?.finish()
+        if let channel = record.channel, channel.isActive {
+            channel.close(promise: nil)
+        }
+
+        if var streamIDs = sessionStreams[record.sessionID] {
+            streamIDs.remove(streamID)
+            if streamIDs.isEmpty {
+                sessionStreams.removeValue(forKey: record.sessionID)
+            } else {
+                sessionStreams[record.sessionID] = streamIDs
+            }
+        }
+
+        if primaryGeneralStreamIDs[record.sessionID] == streamID {
+            selectPrimaryGeneralStream(for: record.sessionID, keepRetainedCurrent: false)
+        }
+
+        await updateSessionExpiry(for: record.sessionID)
+    }
+
+    private func destroySession(id sessionID: UUID) async {
+        let streamIDs = Array(sessionStreams[sessionID] ?? [])
+        for streamID in streamIDs {
+            await removeStream(id: streamID)
+        }
+
+        if let session = sessions.removeValue(forKey: sessionID) {
+            await session.cancelAllWaitingTasks()
+        }
+
+        await pendingUploadStore?.cancelAll(sessionID: sessionID, error: CancellationError())
+        primaryGeneralStreamIDs.removeValue(forKey: sessionID)
+        sessionStreams.removeValue(forKey: sessionID)
+    }
+
+    private func updateSessionExpiry(for sessionID: UUID) async {
+        guard let session = sessions[sessionID] else {
+            return
+        }
+
+        let streamIDs = sessionStreams[sessionID] ?? []
+        if streamIDs.isEmpty {
+            let lastActivity = await session.lastActivityAt
+            await session.setExpiresAt(lastActivity.addingTimeInterval(retentionInterval))
+            return
+        }
+
+        let activeExists = streamIDs.contains { streams[$0]?.isActive == true }
+        if activeExists {
+            await session.setExpiresAt(nil)
+            return
+        }
+
+        let latestStreamExpiry = streamIDs.compactMap { streams[$0]?.expiresAt }.max()
+        let sessionExpiry = (await session.lastActivityAt).addingTimeInterval(retentionInterval)
+        await session.setExpiresAt(max(sessionExpiry, latestStreamExpiry ?? sessionExpiry))
+    }
+
+    private func selectPrimaryGeneralStream(for sessionID: UUID, keepRetainedCurrent: Bool) {
+        let currentPrimary = primaryGeneralStreamIDs[sessionID]
+        let generalStreams = (sessionStreams[sessionID] ?? [])
+            .compactMap { streams[$0] }
+            .filter { $0.kind.isGeneral }
+
+        let activeGeneral = generalStreams.filter(\.isActive)
+        if let replacement = activeGeneral.max(by: { ($0.lastConnectedAt ?? .distantPast) < ($1.lastConnectedAt ?? .distantPast) }) {
+            primaryGeneralStreamIDs[sessionID] = replacement.id
+            return
+        }
+
+        if keepRetainedCurrent,
+           let currentPrimary,
+           generalStreams.contains(where: { $0.id == currentPrimary }) {
+            primaryGeneralStreamIDs[sessionID] = currentPrimary
+            return
+        }
+
+        if let retained = generalStreams.max(by: { $0.lastActivityAt < $1.lastActivityAt }) {
+            primaryGeneralStreamIDs[sessionID] = retained.id
+        } else {
+            primaryGeneralStreamIDs.removeValue(forKey: sessionID)
+        }
+    }
+
+    private func parseEventID(_ value: String) throws -> (streamID: UUID, sequence: Int) {
+        guard let separatorIndex = value.lastIndex(of: ":") else {
+            throw StreamResumeError.malformedEventID
+        }
+
+        let streamPart = String(value[..<separatorIndex])
+        let sequencePart = String(value[value.index(after: separatorIndex)...])
+
+        guard let streamID = UUID(uuidString: streamPart),
+              let sequence = Int(sequencePart),
+              sequence >= 1 else {
+            throw StreamResumeError.malformedEventID
+        }
+
+        return (streamID, sequence)
+    }
+
+    private func makeEventID(streamID: UUID, sequence: Int) -> String {
+        "\(streamID.uuidString):\(sequence)"
     }
 }

--- a/Tests/SwiftMCPTests/HTTPTransportTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTests.swift
@@ -255,6 +255,47 @@ struct HTTPTransportTests {
 		#endif
 	}
 
+	@Test("POST /mcp: initialize preserves negotiated fallback protocol version")
+	func initializeNegotiatesFallbackProtocolVersion() async throws {
+		#if canImport(FoundationNetworking)
+		return
+		#else
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let request = try streamablePOSTRequest(
+			url: baseURL.appendingPathComponent("mcp"),
+			message: .request(
+				id: 1,
+				method: "initialize",
+				params: [
+					"protocolVersion": .string("2025-03-26"),
+					"capabilities": .object([:]),
+					"clientInfo": .object([
+						"name": .string("TestClient"),
+						"version": .string("1.0")
+					])
+				]
+			),
+			protocolVersion: "2025-03-26"
+		)
+
+		let (response, events) = try await readFiniteSSEResponse(request)
+		#expect(response.statusCode == 200)
+
+		let initEvent = try #require(responseEvent(events, id: 1))
+		let message = try #require(try decodeEventMessage(initEvent))
+		guard case .response(let responseData) = message,
+			  let result = responseData.result,
+			  let protocolVersion = result["protocolVersion"]?.stringValue else {
+			Issue.record("Expected initialize response payload")
+			return
+		}
+
+		#expect(protocolVersion == "2025-03-26")
+		#endif
+	}
+
 	@Test("POST /mcp: request stream returns response for existing session")
 	func modernPing() async throws {
 		#if canImport(FoundationNetworking)

--- a/Tests/SwiftMCPTests/HTTPTransportTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTests.swift
@@ -217,6 +217,16 @@ struct HTTPTransportTests {
 		}
 	}
 
+	private func errorResponseEvent(_ events: [SSEClientMessage], id: Int) -> SSEClientMessage? {
+		events.first { event in
+			guard let message = try? decodeEventMessage(event),
+				  case .errorResponse(let errorResponse) = message else {
+				return false
+			}
+			return errorResponse.id == .int(id)
+		}
+	}
+
 	// MARK: - Modern Streamable HTTP
 
 	@Test("POST /mcp: initialize returns SSE response stream")
@@ -293,6 +303,86 @@ struct HTTPTransportTests {
 		}
 
 		#expect(protocolVersion == "2025-03-26")
+		#endif
+	}
+
+	@Test("POST /mcp: initialize preserves negotiated intermediate protocol version")
+	func initializeNegotiatesIntermediateProtocolVersion() async throws {
+		#if canImport(FoundationNetworking)
+		return
+		#else
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let request = try streamablePOSTRequest(
+			url: baseURL.appendingPathComponent("mcp"),
+			message: .request(
+				id: 1,
+				method: "initialize",
+				params: [
+					"protocolVersion": .string("2025-06-18"),
+					"capabilities": .object([:]),
+					"clientInfo": .object([
+						"name": .string("TestClient"),
+						"version": .string("1.0")
+					])
+				]
+			),
+			protocolVersion: "2025-06-18"
+		)
+
+		let (response, events) = try await readFiniteSSEResponse(request)
+		#expect(response.statusCode == 200)
+
+		let initEvent = try #require(responseEvent(events, id: 1))
+		let message = try #require(try decodeEventMessage(initEvent))
+		guard case .response(let responseData) = message,
+			  let result = responseData.result,
+			  let protocolVersion = result["protocolVersion"]?.stringValue else {
+			Issue.record("Expected initialize response payload")
+			return
+		}
+
+		#expect(protocolVersion == "2025-06-18")
+		#endif
+	}
+
+	@Test("POST /mcp: initialize rejects unsupported protocol version")
+	func initializeRejectsUnsupportedProtocolVersion() async throws {
+		#if canImport(FoundationNetworking)
+		return
+		#else
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let request = try streamablePOSTRequest(
+			url: baseURL.appendingPathComponent("mcp"),
+			message: .request(
+				id: 1,
+				method: "initialize",
+				params: [
+					"protocolVersion": .string("2024-11-05"),
+					"capabilities": .object([:]),
+					"clientInfo": .object([
+						"name": .string("TestClient"),
+						"version": .string("1.0")
+					])
+				]
+			)
+		)
+
+		let (response, events) = try await readFiniteSSEResponse(request)
+		#expect(response.statusCode == 200)
+
+		let initEvent = try #require(errorResponseEvent(events, id: 1))
+		let message = try #require(try decodeEventMessage(initEvent))
+		guard case .errorResponse(let errorData) = message else {
+			Issue.record("Expected initialize error response")
+			return
+		}
+
+		#expect(errorData.error.code == -32602)
+		#expect(errorData.error.message.contains("Unsupported protocol version"))
 		#endif
 	}
 

--- a/Tests/SwiftMCPTests/HTTPTransportTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTests.swift
@@ -15,17 +15,30 @@ private final class UploadCapableServer {
 
 extension UploadCapableServer: MCPFileUploadHandling {}
 
+@MCPServer(name: "ResumableServer")
+private final class ResumableServer {
+	@MCPTool(description: "Emits progress before returning pong")
+	func slowPing() async -> String {
+		await RequestContext.current?.reportProgress(0.2, total: 1.0, message: "starting")
+		try? await Task.sleep(nanoseconds: 150_000_000)
+		await RequestContext.current?.reportProgress(0.6, total: 1.0, message: "middle")
+		try? await Task.sleep(nanoseconds: 150_000_000)
+		return "pong"
+	}
+}
+
 @Suite("HTTP Transport Integration")
 struct HTTPTransportTests {
 
 	/// Create a transport, start it, and return the base URL.
-	private func startTransport() async throws -> (HTTPSSETransport, URL) {
-		try await startTransport(server: Calculator())
-	}
-
-	/// Create a transport for a specific server, start it, and return the base URL.
-	private func startTransport(server: some MCPServer) async throws -> (HTTPSSETransport, URL) {
+	private func startTransport(
+		server: some MCPServer = Calculator(),
+		retentionInterval: TimeInterval? = nil
+	) async throws -> (HTTPSSETransport, URL) {
 		let transport = HTTPSSETransport(server: server, host: "127.0.0.1", port: 0)
+		if let retentionInterval {
+			transport.streamRetentionInterval = retentionInterval
+		}
 		try await transport.start()
 		let baseURL = URL(string: "http://127.0.0.1:\(transport.port)")!
 		return (transport, baseURL)
@@ -47,7 +60,7 @@ struct HTTPTransportTests {
 			id: id,
 			method: "initialize",
 			params: [
-				"protocolVersion": .string("2025-06-18"),
+				"protocolVersion": .string("2025-11-25"),
 				"capabilities": .object([:]),
 				"clientInfo": .object([
 					"name": .string("TestClient"),
@@ -57,83 +70,184 @@ struct HTTPTransportTests {
 		)
 	}
 
-	// MARK: - Modern Streamable HTTP (POST /mcp)
-
-	@Test("POST /mcp: initialize without SSE returns immediate response")
-	func modernInitialize() async throws {
-		let (transport, baseURL) = try await startTransport()
-		defer { Task { try? await transport.stop() } }
-
-		let session = URLSession(configuration: .ephemeral)
-		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
+	private func streamablePOSTRequest(
+		url: URL,
+		message: JSONRPCMessage,
+		sessionID: String? = nil,
+		protocolVersion: String = "2025-11-25"
+	) throws -> URLRequest {
+		var request = URLRequest(url: url)
 		request.httpMethod = "POST"
 		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		request.setValue("application/json", forHTTPHeaderField: "Accept")
-		request.httpBody = try encode(initializeRequest())
-
-		let (data, httpResponse) = try await session.data(for: request)
-		let response = httpResponse as! HTTPURLResponse
-
-		#expect(response.statusCode == 200)
-		#expect(response.value(forHTTPHeaderField: "Mcp-Session-Id") != nil)
-
-		let message = try decode(data)
-		guard case .response(let resp) = message else {
-			Issue.record("Expected response, got \(message)")
-			return
+		request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+		request.setValue(protocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
+		if let sessionID {
+			request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
 		}
-		#expect(resp.id == .int(1))
-
-		guard let result = resp.result,
-			  let protocolVersion = result["protocolVersion"]?.value as? String else {
-			Issue.record("Missing protocolVersion in result")
-			return
-		}
-		#expect(protocolVersion == "2025-06-18")
+		request.httpBody = try encode(message)
+		return request
 	}
 
-	@Test("POST /mcp: ping returns pong")
-	func modernPing() async throws {
+	private func generalSSERequest(
+		url: URL,
+		sessionID: String,
+		lastEventID: String? = nil,
+		protocolVersion: String = "2025-11-25"
+	) -> URLRequest {
+		var request = URLRequest(url: url)
+		request.httpMethod = "GET"
+		request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+		request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+		request.setValue(protocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
+		if let lastEventID {
+			request.setValue(lastEventID, forHTTPHeaderField: "Last-Event-ID")
+		}
+		return request
+	}
+
+	private func readFiniteSSEResponse(_ request: URLRequest) async throws -> (HTTPURLResponse, [SSEClientMessage]) {
+		let session = URLSession(configuration: .ephemeral)
+		let (bytes, response) = try await session.bytes(for: request)
+		guard let httpResponse = response as? HTTPURLResponse else {
+			throw TestError("Expected HTTPURLResponse")
+		}
+
+		var events: [SSEClientMessage] = []
+		for try await message in bytes.lines.sseMessages() {
+			events.append(message)
+		}
+
+		return (httpResponse, events)
+	}
+
+	private func openStreamingRequest(_ request: URLRequest) -> StreamCapture {
+		let responseBox = Box<HTTPURLResponse?>(nil)
+		let eventsBox = Box<[SSEClientMessage]>([])
+
+		let task = Task {
+			let session = URLSession(configuration: .ephemeral)
+			let (bytes, response) = try await session.bytes(for: request)
+			responseBox.value = response as? HTTPURLResponse
+			for try await message in bytes.lines.sseMessages() {
+				eventsBox.value.append(message)
+			}
+		}
+
+		return StreamCapture(response: responseBox, events: eventsBox, task: task)
+	}
+
+	private func waitForCondition(
+		timeoutNanoseconds: UInt64 = 2_000_000_000,
+		pollNanoseconds: UInt64 = 50_000_000,
+		_ condition: @escaping @Sendable () -> Bool
+	) async -> Bool {
+		let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+		while DispatchTime.now().uptimeNanoseconds < deadline {
+			if condition() {
+				return true
+			}
+			try? await Task.sleep(nanoseconds: pollNanoseconds)
+		}
+		return condition()
+	}
+
+	private func initializeSession(url: URL) async throws -> (String, [SSEClientMessage]) {
+		let request = try streamablePOSTRequest(url: url, message: initializeRequest())
+		let (response, events) = try await readFiniteSSEResponse(request)
+		guard let sessionID = response.value(forHTTPHeaderField: "Mcp-Session-Id") else {
+			throw TestError("Expected Mcp-Session-Id header")
+		}
+		return (sessionID, events)
+	}
+
+	private func decodeEventMessage(_ event: SSEClientMessage) throws -> JSONRPCMessage? {
+		guard !event.data.isEmpty else {
+			return nil
+		}
+		return try decode(Data(event.data.utf8))
+	}
+
+	private func responseEvent(_ events: [SSEClientMessage], id: Int) -> SSEClientMessage? {
+		events.first { event in
+			guard let message = try? decodeEventMessage(event),
+				  case .response(let response) = message else {
+				return false
+			}
+			return response.id == .int(id)
+		}
+	}
+
+	private func notificationEvent(_ events: [SSEClientMessage], method: String) -> SSEClientMessage? {
+		events.first { event in
+			guard let message = try? decodeEventMessage(event),
+				  case .notification(let notification) = message else {
+				return false
+			}
+			return notification.method == method
+		}
+	}
+
+	// MARK: - Modern Streamable HTTP
+
+	@Test("POST /mcp: initialize returns SSE response stream")
+	func modernInitialize() async throws {
+		#if canImport(FoundationNetworking)
+		return
+		#else
 		let (transport, baseURL) = try await startTransport()
 		defer { Task { try? await transport.stop() } }
 
-		let session = URLSession(configuration: .ephemeral)
-		let url = baseURL.appendingPathComponent("mcp")
+		let (response, events) = try await readFiniteSSEResponse(
+			try streamablePOSTRequest(
+				url: baseURL.appendingPathComponent("mcp"),
+				message: initializeRequest()
+			)
+		)
 
-		// Initialize first
-		var initReq = URLRequest(url: url)
-		initReq.httpMethod = "POST"
-		initReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		initReq.setValue("application/json", forHTTPHeaderField: "Accept")
-		initReq.httpBody = try encode(initializeRequest())
+		#expect(response.statusCode == 200)
+		#expect(response.value(forHTTPHeaderField: "Content-Type")?.contains("text/event-stream") == true)
+		#expect(response.value(forHTTPHeaderField: "Mcp-Session-Id") != nil)
 
-		let (_, initResp) = try await session.data(for: initReq)
-		let sessionId = (initResp as! HTTPURLResponse).value(forHTTPHeaderField: "Mcp-Session-Id")!
+		let primingEvent = try #require(events.first)
+		#expect(primingEvent.id != nil)
+		#expect(primingEvent.data == "")
 
-		// Ping
-		let pingMessage = JSONRPCMessage.request(id: 2, method: "ping")
-		var pingReq = URLRequest(url: url)
-		pingReq.httpMethod = "POST"
-		pingReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		pingReq.setValue("application/json", forHTTPHeaderField: "Accept")
-		pingReq.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
-		pingReq.httpBody = try encode(pingMessage)
-
-		let (pingData, pingResp) = try await session.data(for: pingReq)
-		let pingHTTP = pingResp as! HTTPURLResponse
-		#expect(pingHTTP.statusCode == 200)
-
-		// Session ID must be preserved across requests
-		let pingSessionId = pingHTTP.value(forHTTPHeaderField: "Mcp-Session-Id")
-		#expect(pingSessionId == sessionId, "Session ID changed between requests")
-
-		let message = try decode(pingData)
-		guard case .response(let resp) = message else {
-			Issue.record("Expected response, got \(message)")
+		let initEvent = try #require(responseEvent(events, id: 1))
+		let message = try #require(try decodeEventMessage(initEvent))
+		guard case .response(let responseData) = message,
+			  let result = responseData.result,
+			  let protocolVersion = result["protocolVersion"]?.stringValue else {
+			Issue.record("Expected initialize response payload")
 			return
 		}
-		#expect(resp.id == .int(2))
-		#expect(resp.result != nil) // empty object = pong
+
+		#expect(protocolVersion == "2025-11-25")
+		#endif
+	}
+
+	@Test("POST /mcp: request stream returns response for existing session")
+	func modernPing() async throws {
+		#if canImport(FoundationNetworking)
+		return
+		#else
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let url = baseURL.appendingPathComponent("mcp")
+		let (sessionID, _) = try await initializeSession(url: url)
+
+		let (response, events) = try await readFiniteSSEResponse(
+			try streamablePOSTRequest(
+				url: url,
+				message: .request(id: 2, method: "ping"),
+				sessionID: sessionID
+			)
+		)
+
+		#expect(response.statusCode == 200)
+		#expect(response.value(forHTTPHeaderField: "Mcp-Session-Id") == sessionID)
+		#expect(responseEvent(events, id: 2) != nil)
+		#endif
 	}
 
 	@Test("POST /mcp: missing session on non-initialize returns 400 without creating a session")
@@ -145,7 +259,7 @@ struct HTTPTransportTests {
 		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
 		request.httpMethod = "POST"
 		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		request.setValue("application/json", forHTTPHeaderField: "Accept")
+		request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
 		request.httpBody = try encode(JSONRPCMessage.request(id: 1, method: "ping"))
 
 		let (_, response) = try await session.data(for: request)
@@ -164,7 +278,7 @@ struct HTTPTransportTests {
 		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
 		request.httpMethod = "POST"
 		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		request.setValue("application/json", forHTTPHeaderField: "Accept")
+		request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
 		request.setValue(UUID().uuidString, forHTTPHeaderField: "Mcp-Session-Id")
 		request.httpBody = try encode(JSONRPCMessage.request(id: 1, method: "ping"))
 
@@ -174,52 +288,35 @@ struct HTTPTransportTests {
 		#expect(await transport.sessionManager.sessionIDs.isEmpty)
 	}
 
-	@Test("POST /mcp: session ID is preserved across requests")
-	func sessionIdPreserved() async throws {
+	@Test("GET /mcp: missing session returns 400")
+	func modernGeneralStreamRequiresSession() async throws {
 		let (transport, baseURL) = try await startTransport()
 		defer { Task { try? await transport.stop() } }
 
 		let session = URLSession(configuration: .ephemeral)
-		let url = baseURL.appendingPathComponent("mcp")
-
-		// Request 1: Initialize
-		var req1 = URLRequest(url: url)
-		req1.httpMethod = "POST"
-		req1.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		req1.setValue("application/json", forHTTPHeaderField: "Accept")
-		req1.httpBody = try encode(initializeRequest())
-
-		let (_, resp1) = try await session.data(for: req1)
-		let sessionId = (resp1 as! HTTPURLResponse).value(forHTTPHeaderField: "Mcp-Session-Id")!
-		#expect(UUID(uuidString: sessionId) != nil, "Session ID is not a valid UUID")
-
-		// Request 2: Ping with same session ID
-		var req2 = URLRequest(url: url)
-		req2.httpMethod = "POST"
-		req2.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		req2.setValue("application/json", forHTTPHeaderField: "Accept")
-		req2.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
-		req2.httpBody = try encode(JSONRPCMessage.request(id: 2, method: "ping"))
-
-		let (_, resp2) = try await session.data(for: req2)
-		let sessionId2 = (resp2 as! HTTPURLResponse).value(forHTTPHeaderField: "Mcp-Session-Id")!
-		#expect(sessionId2 == sessionId, "Session ID changed: \(sessionId) → \(sessionId2)")
-
-		// Request 3: tools/list with same session ID
-		var req3 = URLRequest(url: url)
-		req3.httpMethod = "POST"
-		req3.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		req3.setValue("application/json", forHTTPHeaderField: "Accept")
-		req3.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
-		req3.httpBody = try encode(JSONRPCMessage.request(id: 3, method: "tools/list"))
-
-		let (_, resp3) = try await session.data(for: req3)
-		let sessionId3 = (resp3 as! HTTPURLResponse).value(forHTTPHeaderField: "Mcp-Session-Id")!
-		#expect(sessionId3 == sessionId, "Session ID changed: \(sessionId) → \(sessionId3)")
+		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
+		request.httpMethod = "GET"
+		request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+		let (_, response) = try await session.data(for: request)
+		#expect((response as! HTTPURLResponse).statusCode == 400)
 	}
 
-	@Test("POST /mcp: SSE-created session still requires initialize")
-	func modernSSESessionRequiresInitialize() async throws {
+	@Test("GET /mcp: unknown session returns 404")
+	func unknownModernSSESession() async throws {
+		let (transport, baseURL) = try await startTransport()
+		defer { Task { try? await transport.stop() } }
+
+		let session = URLSession(configuration: .ephemeral)
+		let request = generalSSERequest(
+			url: baseURL.appendingPathComponent("mcp"),
+			sessionID: UUID().uuidString
+		)
+		let (_, response) = try await session.data(for: request)
+		#expect((response as! HTTPURLResponse).statusCode == 404)
+	}
+
+	@Test("GET /mcp: general stream primes and can resume missed notifications")
+	func generalStreamResume() async throws {
 		#if canImport(FoundationNetworking)
 		return
 		#else
@@ -227,301 +324,169 @@ struct HTTPTransportTests {
 		defer { Task { try? await transport.stop() } }
 
 		let url = baseURL.appendingPathComponent("mcp")
-		let sessionIDBox = Box<String?>(nil)
+		let (sessionID, _) = try await initializeSession(url: url)
+		let capture = openStreamingRequest(generalSSERequest(url: url, sessionID: sessionID))
 
-		var sseRequest = URLRequest(url: url)
-		sseRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
-
-		let sseTask = Task {
-			let session = URLSession(configuration: .ephemeral)
-			let (bytes, response) = try await session.bytes(for: sseRequest)
-			sessionIDBox.value = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Mcp-Session-Id")
-			for try await _ in bytes.lines {
-				// Keep the SSE connection open until the test cancels it.
-			}
+		let primed = await waitForCondition {
+			capture.response.value != nil && !capture.events.value.isEmpty
 		}
+		#expect(primed)
 
-		try await Task.sleep(for: .milliseconds(200))
-		await transport.sessionManager.broadcastSSE(SSEMessage(data: "warmup", eventName: "warmup"))
+		let primingEvent = try #require(capture.events.value.first)
+		let primingEventID = try #require(primingEvent.id)
+		capture.task.cancel()
 
-		let deadline = Date().addingTimeInterval(2)
-		while sessionIDBox.value == nil, Date() < deadline {
-			try await Task.sleep(for: .milliseconds(50))
+		try? await Task.sleep(nanoseconds: 100_000_000)
+		await transport.broadcastToolsListChanged()
+		try? await Task.sleep(nanoseconds: 50_000_000)
+
+		let resumed = openStreamingRequest(generalSSERequest(url: url, sessionID: sessionID, lastEventID: primingEventID))
+		let resumedReceived = await waitForCondition {
+			notificationEvent(resumed.events.value, method: "notifications/tools/list_changed") != nil
 		}
+		#expect(resumedReceived)
 
-		guard let sessionId = sessionIDBox.value else {
-			sseTask.cancel()
-			Issue.record("Expected SSE connection to return a session ID")
-			return
-		}
-
-		var pingRequest = URLRequest(url: url)
-		pingRequest.httpMethod = "POST"
-		pingRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		pingRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-		pingRequest.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
-		pingRequest.httpBody = try encode(JSONRPCMessage.request(id: 1, method: "ping"))
-
-		let (_, response) = try await URLSession(configuration: .ephemeral).data(for: pingRequest)
-		let http = response as! HTTPURLResponse
-		#expect(http.statusCode == 400)
-		#expect(http.value(forHTTPHeaderField: "Mcp-Session-Id") == sessionId)
-
-		sseTask.cancel()
+		let notification = try #require(notificationEvent(resumed.events.value, method: "notifications/tools/list_changed"))
+		#expect(notification.id != nil)
+		resumed.task.cancel()
 		#endif
 	}
 
-	@Test("POST /mcp: with active SSE returns 202 and streams response")
-	func modernSSEStreaming() async throws {
+	@Test("POST /mcp: request stream can resume after disconnect")
+	func requestStreamResume() async throws {
 		#if canImport(FoundationNetworking)
-		// URLSession.bytes(for:) is unavailable on Linux FoundationNetworking.
+		return
+		#else
+		let (transport, baseURL) = try await startTransport(server: ResumableServer())
+		defer { Task { try? await transport.stop() } }
+
+		let url = baseURL.appendingPathComponent("mcp")
+		let (sessionID, _) = try await initializeSession(url: url)
+
+		let requestCapture = openStreamingRequest(
+			try streamablePOSTRequest(
+				url: url,
+				message: .request(
+					id: 2,
+					method: "tools/call",
+					params: [
+						"name": .string("slowPing"),
+						"arguments": .object([:]),
+						"_meta": .object([
+							"progressToken": .string("slow-request")
+						])
+					]
+				),
+				sessionID: sessionID
+			)
+		)
+
+		let sawProgress = await waitForCondition {
+			notificationEvent(requestCapture.events.value, method: "notifications/progress") != nil
+		}
+		#expect(sawProgress)
+
+		let lastSeenEventID = try #require(requestCapture.events.value.last?.id)
+		requestCapture.task.cancel()
+
+		try? await Task.sleep(nanoseconds: 500_000_000)
+
+		let resumedRequest = try await readFiniteSSEResponse(
+			generalSSERequest(url: url, sessionID: sessionID, lastEventID: lastSeenEventID)
+		)
+
+		#expect(notificationEvent(resumedRequest.1, method: "notifications/progress") != nil)
+		#expect(responseEvent(resumedRequest.1, id: 2) != nil)
+		#endif
+	}
+
+	@Test("Multiple general streams route unsolicited notifications only to the newest active stream")
+	func multipleGeneralStreamsPrimarySelection() async throws {
+		#if canImport(FoundationNetworking)
 		return
 		#else
 		let (transport, baseURL) = try await startTransport()
 		defer { Task { try? await transport.stop() } }
 
 		let url = baseURL.appendingPathComponent("mcp")
-		let postSession = URLSession(configuration: .ephemeral)
+		let (sessionID, _) = try await initializeSession(url: url)
 
-		// Step 1: Initialize WITHOUT SSE to get a session ID (immediate 200 response)
-		var initReq = URLRequest(url: url)
-		initReq.httpMethod = "POST"
-		initReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		initReq.setValue("application/json", forHTTPHeaderField: "Accept")
-		initReq.httpBody = try encode(initializeRequest())
-
-		let (_, initResp) = try await postSession.data(for: initReq)
-		let sessionId = (initResp as! HTTPURLResponse).value(forHTTPHeaderField: "Mcp-Session-Id")!
-		#expect((initResp as! HTTPURLResponse).statusCode == 200)
-
-		// Step 2: Open SSE connection in background Task
-		// bytes(for:) blocks until first body bytes arrive.
-		let receivedEvents = Box<[SSEClientMessage]>([])
-		var sseReq = URLRequest(url: url)
-		sseReq.setValue("text/event-stream", forHTTPHeaderField: "Accept")
-		sseReq.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
-
-		let sseTask = Task {
-			let session = URLSession(configuration: .ephemeral)
-			let (sseBytes, _) = try await session.bytes(for: sseReq)
-			for try await message in sseBytes.lines.sseMessages() {
-				receivedEvents.value.append(message)
-			}
+		let streamA = openStreamingRequest(generalSSERequest(url: url, sessionID: sessionID))
+		let streamAReady = await waitForCondition {
+			!streamA.events.value.isEmpty
 		}
+		#expect(streamAReady)
 
-		// Wait for SSE channel registration
-		try await Task.sleep(for: .milliseconds(300))
-
-		// Step 3: List tools via POST — should get 202, response via SSE
-		let toolsMessage = JSONRPCMessage.request(id: 2, method: "tools/list")
-		var toolsReq = URLRequest(url: url)
-		toolsReq.httpMethod = "POST"
-		toolsReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		toolsReq.setValue("application/json", forHTTPHeaderField: "Accept")
-		toolsReq.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
-		toolsReq.httpBody = try encode(toolsMessage)
-
-		let (_, toolsResp) = try await postSession.data(for: toolsReq)
-		let toolsHTTP = toolsResp as! HTTPURLResponse
-		#expect(toolsHTTP.statusCode == 202)
-		#expect(toolsHTTP.value(forHTTPHeaderField: "Mcp-Session-Id") == sessionId, "Session ID changed on tools/list")
-
-		try await Task.sleep(for: .milliseconds(500))
-
-		// Step 4: Ping via POST — should get 202
-		let pingMessage = JSONRPCMessage.request(id: 3, method: "ping")
-		var pingReq = URLRequest(url: url)
-		pingReq.httpMethod = "POST"
-		pingReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		pingReq.setValue("application/json", forHTTPHeaderField: "Accept")
-		pingReq.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
-		pingReq.httpBody = try encode(pingMessage)
-
-		let (_, pingResp) = try await postSession.data(for: pingReq)
-		#expect((pingResp as! HTTPURLResponse).statusCode == 202)
-
-		try await Task.sleep(for: .milliseconds(500))
-
-		sseTask.cancel()
-
-		// Verify tools/list response arrived via SSE
-		let toolsEvent = receivedEvents.value.first { event in
-			guard let msg = try? decode(Data(event.data.utf8)),
-				  case .response(let r) = msg, r.id == .int(2) else { return false }
-			return true
+		let streamB = openStreamingRequest(generalSSERequest(url: url, sessionID: sessionID))
+		let streamBReady = await waitForCondition {
+			!streamB.events.value.isEmpty
 		}
-		#expect(toolsEvent != nil, "Expected tools/list response via SSE")
+		#expect(streamBReady)
 
-		if let event = toolsEvent {
-			let message = try decode(Data(event.data.utf8))
-			guard case .response(let resp) = message,
-				  let result = resp.result,
-				  let tools = result["tools"] else {
-				Issue.record("Expected tools in response")
-				return
-			}
-			// Calculator has tools (add, subtract, etc.)
-			guard case .array(let toolArray) = tools else {
-				Issue.record("Expected tools array")
-				return
-			}
-			#expect(!toolArray.isEmpty, "Calculator should have tools")
+		await transport.broadcastPromptsListChanged()
+		let received = await waitForCondition {
+			notificationEvent(streamB.events.value, method: "notifications/prompts/list_changed") != nil
 		}
+		#expect(received)
+		#expect(notificationEvent(streamA.events.value, method: "notifications/prompts/list_changed") == nil)
 
-		// Verify ping response arrived via SSE
-		let pingEvent = receivedEvents.value.first { event in
-			guard let msg = try? decode(Data(event.data.utf8)),
-				  case .response(let r) = msg, r.id == .int(3) else { return false }
-			return true
-		}
-		#expect(pingEvent != nil, "Expected ping response via SSE")
+		streamA.task.cancel()
+		streamB.task.cancel()
 		#endif
 	}
 
-	// MARK: - Legacy SSE Protocol (GET /sse + POST /messages)
+	// MARK: - Legacy SSE Protocol
 
 	@Test("Legacy SSE: connect, get endpoint, initialize, ping")
 	func legacySSEFullFlow() async throws {
 		#if canImport(FoundationNetworking)
-		// URLSession.bytes(for:) is unavailable on Linux FoundationNetworking.
 		return
 		#else
 		let (transport, baseURL) = try await startTransport()
 		defer { Task { try? await transport.stop() } }
 
-		let receivedEvents = Box<[SSEClientMessage]>([])
+		let capture = openStreamingRequest({
+			var request = URLRequest(url: baseURL.appendingPathComponent("sse"))
+			request.httpMethod = "GET"
+			request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+			return request
+		}())
 
-		// bytes(for:) blocks until first body bytes arrive,
-		// so the SSE connection must be opened in a background Task.
-		var sseReq = URLRequest(url: baseURL.appendingPathComponent("sse"))
-		sseReq.setValue("text/event-stream", forHTTPHeaderField: "Accept")
-
-		let sseTask = Task {
-			let session = URLSession(configuration: .ephemeral)
-			let (sseBytes, _) = try await session.bytes(for: sseReq)
-			for try await message in sseBytes.lines.sseMessages() {
-				receivedEvents.value.append(message)
-			}
+		let hasEndpoint = await waitForCondition {
+			notificationEvent(capture.events.value, method: "endpoint") != nil || capture.events.value.contains { $0.event == "endpoint" }
 		}
 
-		// Wait for endpoint event (legacy SSE sends it immediately)
-		try await Task.sleep(for: .milliseconds(500))
-
-		let endpointEvent = receivedEvents.value.first { $0.event == "endpoint" }
-		guard let endpointData = endpointEvent?.data,
-			  let messagesURL = URL(string: endpointData) else {
-			sseTask.cancel()
-			Issue.record("Never received endpoint event. Events: \(receivedEvents.value.map { "[\($0.event)] \($0.data)" })")
-			return
-		}
-
+		let endpointEvent = try #require(capture.events.value.first(where: { $0.event == "endpoint" }))
+		let messagesURL = try #require(URL(string: endpointEvent.data))
+		#expect(hasEndpoint)
 		#expect(messagesURL.path.hasPrefix("/messages/"))
 
-		// Extract the session ID from the endpoint URL — must be a valid UUID
-		let legacySessionId = messagesURL.lastPathComponent
-		#expect(UUID(uuidString: legacySessionId) != nil, "Endpoint session ID is not a valid UUID: \(legacySessionId)")
-
-		// Initialize via POST to the messages endpoint
 		let postSession = URLSession(configuration: .ephemeral)
-		var initReq = URLRequest(url: messagesURL)
-		initReq.httpMethod = "POST"
-		initReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		initReq.httpBody = try encode(initializeRequest())
+		var initRequest = URLRequest(url: messagesURL)
+		initRequest.httpMethod = "POST"
+		initRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		initRequest.httpBody = try encode(initializeRequest())
+		let (_, initResponse) = try await postSession.data(for: initRequest)
+		#expect((initResponse as! HTTPURLResponse).statusCode == 202)
 
-		let (_, initResp) = try await postSession.data(for: initReq)
-		#expect((initResp as! HTTPURLResponse).statusCode == 202)
-
-		// Wait for SSE to deliver the initialize response.
-		// Ignore later notifications like ping; explicitly look for the response with id 1.
-		let deadline = Date().addingTimeInterval(2)
-		var initResponse: JSONRPCMessage.JSONRPCResponseData?
-		while Date() < deadline, initResponse == nil {
-			for event in receivedEvents.value where event.event != "endpoint" {
-				let message = try decode(Data(event.data.utf8))
-				if case .response(let resp) = message, resp.id == .int(1) {
-					initResponse = resp
-					break
-				}
-			}
-			if initResponse == nil {
-				try await Task.sleep(for: .milliseconds(100))
-			}
+		let initDelivered = await waitForCondition {
+			responseEvent(capture.events.value, id: 1) != nil
 		}
+		#expect(initDelivered)
 
-		guard let initResponse else {
-			Issue.record("Expected initialize response via SSE. All events: \(receivedEvents.value.map { "[\($0.event)] \($0.data.prefix(80))" })")
-			sseTask.cancel()
-			return
+		var pingRequest = URLRequest(url: messagesURL)
+		pingRequest.httpMethod = "POST"
+		pingRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		pingRequest.httpBody = try encode(JSONRPCMessage.request(id: 3, method: "ping"))
+		let (_, pingResponse) = try await postSession.data(for: pingRequest)
+		#expect((pingResponse as! HTTPURLResponse).statusCode == 202)
+
+		let pingDelivered = await waitForCondition {
+			responseEvent(capture.events.value, id: 3) != nil
 		}
-		#expect(initResponse.id == .int(1))
+		#expect(pingDelivered)
 
-		// Send initialized notification
-		let initializedNotification = JSONRPCMessage.notification(method: "notifications/initialized")
-		var notifReq = URLRequest(url: messagesURL)
-		notifReq.httpMethod = "POST"
-		notifReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		notifReq.httpBody = try encode(initializedNotification)
-
-		let (_, notifResp) = try await postSession.data(for: notifReq)
-		#expect((notifResp as! HTTPURLResponse).statusCode == 202)
-
-		// List tools
-		let toolsMessage = JSONRPCMessage.request(id: 2, method: "tools/list")
-		var toolsReq = URLRequest(url: messagesURL)
-		toolsReq.httpMethod = "POST"
-		toolsReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		toolsReq.httpBody = try encode(toolsMessage)
-
-		let (_, toolsResp) = try await postSession.data(for: toolsReq)
-		#expect((toolsResp as! HTTPURLResponse).statusCode == 202)
-
-		try await Task.sleep(for: .milliseconds(500))
-
-		// Ping
-		let pingMessage = JSONRPCMessage.request(id: 3, method: "ping")
-		var pingReq = URLRequest(url: messagesURL)
-		pingReq.httpMethod = "POST"
-		pingReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		pingReq.httpBody = try encode(pingMessage)
-
-		let (_, pingResp) = try await postSession.data(for: pingReq)
-		#expect((pingResp as! HTTPURLResponse).statusCode == 202)
-
-		try await Task.sleep(for: .milliseconds(500))
-
-		sseTask.cancel()
-
-		// Verify tools/list response
-		let allDataEvents = receivedEvents.value.filter { $0.event != "endpoint" }
-		let toolsEvent = allDataEvents.first { event in
-			guard let msg = try? decode(Data(event.data.utf8)),
-				  case .response(let r) = msg, r.id == .int(2) else { return false }
-			return true
-		}
-		#expect(toolsEvent != nil, "Expected tools/list response via SSE")
-
-		if let event = toolsEvent {
-			let message = try decode(Data(event.data.utf8))
-			guard case .response(let resp) = message,
-				  let result = resp.result,
-				  let tools = result["tools"] else {
-				Issue.record("Expected tools in response")
-				return
-			}
-			guard case .array(let toolArray) = tools else {
-				Issue.record("Expected tools array")
-				return
-			}
-			#expect(!toolArray.isEmpty, "Calculator should have tools")
-		}
-
-		// Verify ping response
-		let pingEvent = allDataEvents.first { event in
-			guard let msg = try? decode(Data(event.data.utf8)),
-				  case .response(let r) = msg, r.id == .int(3) else { return false }
-			return true
-		}
-		#expect(pingEvent != nil, "Expected ping response via SSE")
+		capture.task.cancel()
 		#endif
 	}
 
@@ -551,23 +516,12 @@ struct HTTPTransportTests {
 		let (transport, baseURL) = try await startTransport()
 		defer { Task { try? await transport.stop() } }
 
+		let (sessionID, _) = try await initializeSession(url: baseURL.appendingPathComponent("mcp"))
 		let session = URLSession(configuration: .ephemeral)
-		let url = baseURL.appendingPathComponent("mcp")
 
-		// Initialize to create a session
-		var initReq = URLRequest(url: url)
-		initReq.httpMethod = "POST"
-		initReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		initReq.setValue("application/json", forHTTPHeaderField: "Accept")
-		initReq.httpBody = try encode(initializeRequest())
-
-		let (_, initResp) = try await session.data(for: initReq)
-		let sessionId = (initResp as! HTTPURLResponse).value(forHTTPHeaderField: "Mcp-Session-Id")!
-
-		// DELETE /mcp to remove the session
-		var deleteReq = URLRequest(url: url)
+		var deleteReq = URLRequest(url: baseURL.appendingPathComponent("mcp"))
 		deleteReq.httpMethod = "DELETE"
-		deleteReq.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
+		deleteReq.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
 
 		let (_, deleteResp) = try await session.data(for: deleteReq)
 		#expect((deleteResp as! HTTPURLResponse).statusCode == 204)
@@ -585,6 +539,50 @@ struct HTTPTransportTests {
 
 		let (_, response) = try await session.data(for: request)
 		#expect((response as! HTTPURLResponse).statusCode == 404)
+	}
+
+	@Test("Resumable request streams expire after the retention interval")
+	func expiredRequestStreamResume() async throws {
+		#if canImport(FoundationNetworking)
+		return
+		#else
+		let (transport, baseURL) = try await startTransport(server: ResumableServer(), retentionInterval: 0.2)
+		defer { Task { try? await transport.stop() } }
+
+		let url = baseURL.appendingPathComponent("mcp")
+		let (sessionID, _) = try await initializeSession(url: url)
+
+		let capture = openStreamingRequest(
+			try streamablePOSTRequest(
+				url: url,
+				message: .request(
+					id: 9,
+					method: "tools/call",
+					params: [
+						"name": .string("slowPing"),
+						"arguments": .object([:]),
+						"_meta": .object([
+							"progressToken": .string("expiring-request")
+						])
+					]
+				),
+				sessionID: sessionID
+			)
+		)
+
+		let sawProgress = await waitForCondition {
+			notificationEvent(capture.events.value, method: "notifications/progress") != nil
+		}
+		#expect(sawProgress)
+		let lastEventID = try #require(capture.events.value.last?.id)
+		capture.task.cancel()
+
+		try? await Task.sleep(nanoseconds: 700_000_000)
+
+		let session = URLSession(configuration: .ephemeral)
+		let (_, response) = try await session.data(for: generalSSERequest(url: url, sessionID: sessionID, lastEventID: lastEventID))
+		#expect((response as! HTTPURLResponse).statusCode == 404)
+		#endif
 	}
 
 	// MARK: - Uploads
@@ -610,7 +608,7 @@ struct HTTPTransportTests {
 		#expect((response as! HTTPURLResponse).statusCode == 404)
 	}
 
-	// MARK: - CORS
+	// MARK: - CORS / OpenAPI / Error cases
 
 	@Test("OPTIONS returns CORS headers")
 	func corsHeaders() async throws {
@@ -628,8 +626,6 @@ struct HTTPTransportTests {
 		#expect(http.value(forHTTPHeaderField: "Access-Control-Allow-Headers")?.contains("Content-Type") == true)
 		#expect(http.value(forHTTPHeaderField: "Access-Control-Allow-Headers")?.contains("Mcp-Session-Id") == true)
 	}
-
-	// MARK: - OpenAPI
 
 	@Test("GET /.well-known/ai-plugin.json returns manifest when serveOpenAPI is true")
 	func aiPluginManifest() async throws {
@@ -681,13 +677,10 @@ struct HTTPTransportTests {
 
 		let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
 		#expect(json["openapi"] as? String == "3.1.0")
-
 		let info = json["info"] as? [String: Any]
 		#expect(info?["title"] as? String == "Calculator")
-
-		// Should have paths for Calculator tools
 		let paths = json["paths"] as? [String: Any]
-		#expect(paths?["/calculator/add"] != nil, "Expected /calculator/add path")
+		#expect(paths?["/calculator/add"] != nil)
 	}
 
 	@Test("POST /{serverName}/{toolName} calls tool and returns result")
@@ -709,13 +702,9 @@ struct HTTPTransportTests {
 		let (data, response) = try await session.data(for: request)
 		let http = response as! HTTPURLResponse
 		#expect(http.statusCode == 200)
-
-		// The result should contain 10 (3 + 7)
 		let body = String(data: data, encoding: .utf8) ?? ""
-		#expect(body.contains("10"), "Expected result to contain 10, got: \(body)")
+		#expect(body.contains("10"))
 	}
-
-	// MARK: - Error cases
 
 	@Test("POST /mcp: missing body returns 400")
 	func missingBody() async throws {
@@ -726,8 +715,7 @@ struct HTTPTransportTests {
 		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
 		request.httpMethod = "POST"
 		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		request.setValue("application/json", forHTTPHeaderField: "Accept")
-		// No body
+		request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
 
 		let (_, response) = try await session.data(for: request)
 		#expect((response as! HTTPURLResponse).statusCode == 400)
@@ -746,18 +734,19 @@ struct HTTPTransportTests {
 		#expect((response as! HTTPURLResponse).statusCode == 400)
 	}
 
-	@Test("GET /mcp: unknown session returns 404")
-	func unknownModernSSESession() async throws {
+	@Test("POST /mcp: invalid protocol header returns 400")
+	func invalidProtocolVersionHeader() async throws {
 		let (transport, baseURL) = try await startTransport()
 		defer { Task { try? await transport.stop() } }
 
 		let session = URLSession(configuration: .ephemeral)
-		var request = URLRequest(url: baseURL.appendingPathComponent("mcp"))
-		request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
-		request.setValue(UUID().uuidString, forHTTPHeaderField: "Mcp-Session-Id")
-
+		let request = try streamablePOSTRequest(
+			url: baseURL.appendingPathComponent("mcp"),
+			message: initializeRequest(),
+			protocolVersion: "bogus"
+		)
 		let (_, response) = try await session.data(for: request)
-		#expect((response as! HTTPURLResponse).statusCode == 404)
+		#expect((response as! HTTPURLResponse).statusCode == 400)
 	}
 
 	@Test("unknown path returns 404")
@@ -771,6 +760,11 @@ struct HTTPTransportTests {
 	}
 }
 
+private struct StreamCapture {
+	let response: Box<HTTPURLResponse?>
+	let events: Box<[SSEClientMessage]>
+	let task: Task<Void, Error>
+}
 
 /// Thread-safe box for capturing values from @Sendable closures.
 private final class Box<T: Sendable>: @unchecked Sendable {

--- a/Tests/SwiftMCPTests/HTTPTransportTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTests.swift
@@ -106,6 +106,23 @@ struct HTTPTransportTests {
 	}
 
 	private func readFiniteSSEResponse(_ request: URLRequest) async throws -> (HTTPURLResponse, [SSEClientMessage]) {
+		#if canImport(FoundationNetworking)
+		let delegate = SSEStreamingDelegate { _ in }
+		let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+		let task = session.dataTask(with: request)
+		task.resume()
+
+		var events: [SSEClientMessage] = []
+		for try await message in delegate.lines.sseMessages() {
+			events.append(message)
+		}
+
+		guard let httpResponse = delegate.response as? HTTPURLResponse else {
+			throw TestError("Expected HTTPURLResponse")
+		}
+
+		return (httpResponse, events)
+		#else
 		let session = URLSession(configuration: .ephemeral)
 		let (bytes, response) = try await session.bytes(for: request)
 		guard let httpResponse = response as? HTTPURLResponse else {
@@ -118,6 +135,7 @@ struct HTTPTransportTests {
 		}
 
 		return (httpResponse, events)
+		#endif
 	}
 
 	private func openStreamingRequest(_ request: URLRequest) -> StreamCapture {
@@ -125,12 +143,24 @@ struct HTTPTransportTests {
 		let eventsBox = Box<[SSEClientMessage]>([])
 
 		let task = Task {
+			#if canImport(FoundationNetworking)
+			let delegate = SSEStreamingDelegate { response in
+				responseBox.value = response as? HTTPURLResponse
+			}
+			let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+			let dataTask = session.dataTask(with: request)
+			dataTask.resume()
+			for try await message in delegate.lines.sseMessages() {
+				eventsBox.value.append(message)
+			}
+			#else
 			let session = URLSession(configuration: .ephemeral)
 			let (bytes, response) = try await session.bytes(for: request)
 			responseBox.value = response as? HTTPURLResponse
 			for try await message in bytes.lines.sseMessages() {
 				eventsBox.value.append(message)
 			}
+			#endif
 		}
 
 		return StreamCapture(response: responseBox, events: eventsBox, task: task)

--- a/Tests/SwiftMCPTests/LineTransportInitializationTests.swift
+++ b/Tests/SwiftMCPTests/LineTransportInitializationTests.swift
@@ -9,7 +9,7 @@ struct LineTransportInitializationTests {
             id: id,
             method: "initialize",
             params: [
-                "protocolVersion": .string("2025-06-18"),
+                "protocolVersion": .string("2025-11-25"),
                 "capabilities": .object([:]),
                 "clientInfo": .object([
                     "name": .string("TestClient"),

--- a/Tests/SwiftMCPTests/MCPServerParametersTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerParametersTests.swift
@@ -29,7 +29,7 @@ struct MCPServerParametersTests {
             id: 1,
             method: "initialize",
             params: [
-                "protocolVersion": "2025-06-18",
+                "protocolVersion": "2025-11-25",
                 "capabilities": .object([
                     "experimental": .object([:]),
                     "resources": .object(["listChanged": false]),
@@ -65,7 +65,7 @@ struct MCPServerParametersTests {
             id: 1,
             method: "initialize",
             params: [
-                "protocolVersion": "2025-06-18",
+                "protocolVersion": "2025-11-25",
                 "capabilities": .object([
                     "experimental": .object([:]),
                     "resources": .object(["listChanged": false]),

--- a/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
@@ -1,0 +1,79 @@
+import Testing
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import SwiftMCP
+
+@Suite("MCPServerProxy Streamable HTTP")
+struct MCPServerProxyStreamableHTTPTests {
+    private func startTransport(server: some MCPServer = Calculator()) async throws -> (HTTPSSETransport, URL) {
+        let transport = HTTPSSETransport(server: server, host: "127.0.0.1", port: 0)
+        try await transport.start()
+        let baseURL = URL(string: "http://127.0.0.1:\(transport.port)/mcp")!
+        return (transport, baseURL)
+    }
+
+    @Test("Proxy connects to streamable HTTP and can ping/list tools")
+    func connectAndPing() async throws {
+        let (transport, url) = try await startTransport()
+        defer { Task { try? await transport.stop() } }
+
+        let proxy = MCPServerProxy(config: .sse(config: MCPServerSseConfig(url: url)))
+        defer { Task { await proxy.disconnect() } }
+
+        try await proxy.connect()
+        let serverName = await proxy.serverName
+        #expect(serverName == "Calculator")
+
+        try await proxy.ping()
+        let tools = try await proxy.listTools()
+        #expect(!tools.isEmpty)
+    }
+
+    @Test("Proxy receives list-changed notifications over the general GET stream")
+    func receivesToolsListChanged() async throws {
+        let (transport, url) = try await startTransport()
+        defer { Task { try? await transport.stop() } }
+
+        let handler = ToolsListChangedCapture()
+        let proxy = MCPServerProxy(config: .sse(config: MCPServerSseConfig(url: url)))
+        await proxy.setToolsListChangedHandler(handler)
+        defer { Task { await proxy.disconnect() } }
+
+        try await proxy.connect()
+        let generalStreamReady = await waitForCondition {
+            await transport.sseChannelCount > 0
+        }
+        #expect(generalStreamReady)
+        await transport.broadcastToolsListChanged()
+
+        let delivered = await waitForCondition {
+            await handler.count > 0
+        }
+        #expect(delivered)
+    }
+
+    private func waitForCondition(
+        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        pollNanoseconds: UInt64 = 50_000_000,
+        _ condition: @escaping @Sendable () async -> Bool
+    ) async -> Bool {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if await condition() {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: pollNanoseconds)
+        }
+        return await condition()
+    }
+}
+
+private actor ToolsListChangedCapture: MCPServerProxyToolsListChangedHandling {
+    private(set) var count = 0
+
+    func mcpServerProxyToolsListDidChange(_ proxy: MCPServerProxy) async {
+        count += 1
+    }
+}

--- a/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
@@ -42,8 +42,10 @@ struct MCPServerProxyStreamableHTTPTests {
         defer { Task { await proxy.disconnect() } }
 
         try await proxy.connect()
+        let sessionID = try #require(await proxy.sessionID)
+        let sessionUUID = try #require(UUID(uuidString: sessionID))
         let generalStreamReady = await waitForCondition {
-            await transport.sseChannelCount > 0
+            await transport.sessionManager.hasActivePrimaryGeneralConnection(for: sessionUUID)
         }
         #expect(generalStreamReady)
         await transport.broadcastToolsListChanged()

--- a/Tests/SwiftMCPTests/MCPServerTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerTests.swift
@@ -11,7 +11,7 @@ func testInitializeRequest() async throws {
         id: 1,
         method: "initialize",
         params: [
-            "protocolVersion": "2025-06-18",
+            "protocolVersion": "2025-11-25",
             "capabilities": .object([
                 "experimental": .object([:]),
                 "resources": .object(["listChanged": false]),
@@ -48,7 +48,7 @@ func testInitializeRequest() async throws {
     guard let protocolVersion = result["protocolVersion"]?.value as? String else {
         throw TestError("protocolVersion not found")
     }
-    #expect(protocolVersion == "2025-06-18")
+    #expect(protocolVersion == "2025-11-25")
 
     // Extract the server capabilities
     guard let capabilitiesDict = result["capabilities"]?.value as? [String: Any] else {

--- a/Tests/SwiftMCPTests/MCPToolNamingTests.swift
+++ b/Tests/SwiftMCPTests/MCPToolNamingTests.swift
@@ -159,7 +159,7 @@ func testToolsListReturnsTransformedNames() async throws {
         id: 1,
         method: "initialize",
         params: [
-            "protocolVersion": "2025-06-18",
+            "protocolVersion": "2025-11-25",
             "capabilities": .object([:]),
             "clientInfo": .object(["name": "test", "version": "1.0"])
         ]

--- a/Tests/SwiftMCPTests/SSEParserTests.swift
+++ b/Tests/SwiftMCPTests/SSEParserTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import Foundation
+@testable import SwiftMCP
+
+@Suite("SSE Parser")
+struct SSEParserTests {
+    private func collectMessages(from lines: [String]) async throws -> [SSEClientMessage] {
+        let stream = AsyncStream<String> { continuation in
+            for line in lines {
+                continuation.yield(line)
+            }
+            continuation.finish()
+        }
+
+        var messages: [SSEClientMessage] = []
+        for try await message in stream.sseMessages() {
+            messages.append(message)
+        }
+        return messages
+    }
+
+    @Test("Parses priming events with id and empty data")
+    func parsesPrimingEvent() async throws {
+        let messages = try await collectMessages(from: [
+            "id: stream-1:1",
+            "data:",
+            ""
+        ])
+
+        let message = try #require(messages.first)
+        #expect(message.id == "stream-1:1")
+        #expect(message.data == "")
+        #expect(message.event == "")
+        #expect(message.retry == nil)
+    }
+
+    @Test("Parses multiline data and retry fields")
+    func parsesMultilineData() async throws {
+        let messages = try await collectMessages(from: [
+            "id: stream-1:2",
+            "event: update",
+            "retry: 2500",
+            "data: first",
+            "data: second",
+            ""
+        ])
+
+        let message = try #require(messages.first)
+        #expect(message.id == "stream-1:2")
+        #expect(message.event == "update")
+        #expect(message.retry == 2500)
+        #expect(message.data == "first\nsecond")
+    }
+
+    @Test("Parses JSON-RPC single-line payloads without waiting for EOF")
+    func parsesJSONRPCPayload() async throws {
+        let messages = try await collectMessages(from: [
+            "id: stream-1:3",
+            "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/tools/list_changed\"}"
+        ])
+
+        let message = try #require(messages.first)
+        #expect(message.id == "stream-1:3")
+        #expect(message.data.contains("\"jsonrpc\":\"2.0\""))
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the HTTP transport around retained sessions plus per-stream SSE state
- implement MCP 2025-11-25 streamable HTTP semantics for POST-created response streams and GET-based resume
- update the client proxy, SSE parsing, docs, and tests for the new `/mcp` flow

## Testing
- swift test

Supersedes #109.