### PR TITLE
Add hints support to @MCPAppIntentTool

### DIFF
--- a/Demos/SwiftMCPIntentsDemo/Intents.swift
+++ b/Demos/SwiftMCPIntentsDemo/Intents.swift
@@ -51,7 +51,7 @@ struct SoupOrderQuery: EntityQuery {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-@MCPAppIntentTool(description: "Orders a soup for delivery.")
+@MCPAppIntentTool(description: "Orders a soup for delivery.", hints: [.openWorld])
 struct OrderSoupIntent: AppIntent {
     static let title: LocalizedStringResource = "Order Soup"
 
@@ -74,7 +74,7 @@ struct OrderSoupIntent: AppIntent {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-@MCPAppIntentTool(description: "Turns the kitchen light on or off.")
+@MCPAppIntentTool(description: "Turns the kitchen light on or off.", hints: [.idempotent, .openWorld])
 struct ToggleKitchenLightIntent: AppIntent {
     static let title: LocalizedStringResource = "Toggle Kitchen Light"
 
@@ -91,7 +91,7 @@ struct ToggleKitchenLightIntent: AppIntent {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-@MCPAppIntentTool(description: "Adds a delivery note for the order.")
+@MCPAppIntentTool(description: "Adds a delivery note for the order.", hints: [.idempotent])
 struct SetDeliveryNoteIntent: AppIntent {
     static let title: LocalizedStringResource = "Set Delivery Note"
 
@@ -110,7 +110,7 @@ struct SetDeliveryNoteIntent: AppIntent {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-@MCPAppIntentTool
+@MCPAppIntentTool(hints: [.readOnly, .idempotent])
 struct ListRecentSoupOrdersIntent: AppIntent {
     static let title: LocalizedStringResource = "List Recent Soup Orders"
     static let description: IntentDescription? = IntentDescription("Lists recent soup orders.")

--- a/Sources/SwiftMCP/MCPMacros.swift
+++ b/Sources/SwiftMCP/MCPMacros.swift
@@ -92,9 +92,24 @@ public macro MCPTool(
 ///
 /// Apply this macro to AppIntent types to generate tool metadata and a wrapper
 /// that maps MCP arguments to intent parameters.
+///
+/// Example:
+/// ```swift
+/// @MCPAppIntentTool(description: "Lists recent orders", hints: [.readOnly])
+/// struct ListRecentOrdersIntent: AppIntent { ... }
+/// ```
+///
+/// - Parameters:
+///   - description: Optional override for the intent's description
+///   - hints: OptionSet of tool behavior hints (preferred API)
+///   - isConsequential: Whether the function's actions are consequential (defaults to true, deprecated - use hints instead)
 @attached(member, names: named(mcpToolMetadata), named(mcpPerform))
 @attached(extension, conformances: MCPAppIntentTool)
-public macro MCPAppIntentTool(description: String? = nil, isConsequential: Bool = true) = #externalMacro(module: "SwiftMCPMacros", type: "MCPAppIntentToolMacro")
+public macro MCPAppIntentTool(
+    description: String? = nil,
+    hints: MCPToolHints = [],
+    isConsequential: Bool = true
+) = #externalMacro(module: "SwiftMCPMacros", type: "MCPAppIntentToolMacro")
 
 /// A macro that adds a `mcpTools` property to a class to aggregate function metadata.
 ///

--- a/Sources/SwiftMCPMacros/MCPAppIntentToolMacro.swift
+++ b/Sources/SwiftMCPMacros/MCPAppIntentToolMacro.swift
@@ -38,14 +38,8 @@ public struct MCPAppIntentToolMacro: MemberMacro, ExtensionMacro {
                    let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self) {
                     let stringValue = stringLiteral.segments.description
                     descriptionOverrideArg = "\"\(stringValue.escapedForSwiftString)\""
-                } else if argument.label?.text == "hints",
-                          let arrayExpr = argument.expression.as(ArrayExprSyntax.self) {
-                    for element in arrayExpr.elements {
-                        if let memberAccess = element.expression.as(MemberAccessExprSyntax.self) {
-                            let hintName = memberAccess.declName.baseName.text
-                            hintsFromOptionSet.append(".\(hintName)")
-                        }
-                    }
+                } else if argument.label?.text == "hints" {
+                    hintsFromOptionSet.append(contentsOf: parseHintsExpression(argument.expression))
                 } else if argument.label?.text == "isConsequential",
                           let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self) {
                     isConsequentialArg = boolLiteral.literal.text

--- a/Sources/SwiftMCPMacros/MCPAppIntentToolMacro.swift
+++ b/Sources/SwiftMCPMacros/MCPAppIntentToolMacro.swift
@@ -30,6 +30,7 @@ public struct MCPAppIntentToolMacro: MemberMacro, ExtensionMacro {
         var descriptionOverrideArg = "nil"
         var docDescriptionArg = "nil"
         var isConsequentialArg = "true"
+        var hintsFromOptionSet: [String] = []
 
         if let arguments = node.arguments?.as(LabeledExprListSyntax.self) {
             for argument in arguments {
@@ -37,11 +38,27 @@ public struct MCPAppIntentToolMacro: MemberMacro, ExtensionMacro {
                    let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self) {
                     let stringValue = stringLiteral.segments.description
                     descriptionOverrideArg = "\"\(stringValue.escapedForSwiftString)\""
+                } else if argument.label?.text == "hints",
+                          let arrayExpr = argument.expression.as(ArrayExprSyntax.self) {
+                    for element in arrayExpr.elements {
+                        if let memberAccess = element.expression.as(MemberAccessExprSyntax.self) {
+                            let hintName = memberAccess.declName.baseName.text
+                            hintsFromOptionSet.append(".\(hintName)")
+                        }
+                    }
                 } else if argument.label?.text == "isConsequential",
                           let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self) {
                     isConsequentialArg = boolLiteral.literal.text
                 }
             }
+        }
+
+        let annotationsArg: String
+        if hintsFromOptionSet.isEmpty {
+            annotationsArg = "nil"
+        } else {
+            let sortedHints = Set(hintsFromOptionSet).sorted()
+            annotationsArg = "MCPToolAnnotations(hints: [\(sortedHints.joined(separator: ", "))])"
         }
 
         if !documentation.description.isEmpty {
@@ -68,7 +85,8 @@ public static let mcpToolMetadata: MCPToolMetadata = {
       returnTypeDescription: nil,
       isAsync: true,
       isThrowing: true,
-      isConsequential: \(isConsequentialArg)
+      isConsequential: \(isConsequentialArg),
+      annotations: \(annotationsArg)
    )
 }()
 """

--- a/Sources/SwiftMCPMacros/MCPToolHintsParser.swift
+++ b/Sources/SwiftMCPMacros/MCPToolHintsParser.swift
@@ -1,0 +1,29 @@
+//
+//  MCPToolHintsParser.swift
+//  SwiftMCPMacros
+//
+//  Shared parsing helpers for the `hints:` argument used by both
+//  `@MCPTool` and `@MCPAppIntentTool`.
+//
+
+import SwiftSyntax
+
+/// Extracts hint member names (e.g. `.readOnly`) from a `hints:` argument expression.
+///
+/// Supports both array-literal form (`[.readOnly, .destructive]`) and a single
+/// OptionSet member access (`.readOnly`) — the latter is valid Swift for any
+/// `ExpressibleByArrayLiteral` / OptionSet but the array variant must still be
+/// accepted because that's how the API is documented.
+func parseHintsExpression(_ expression: ExprSyntax) -> [String] {
+    if let arrayExpr = expression.as(ArrayExprSyntax.self) {
+        return arrayExpr.elements.compactMap { element in
+            element.expression.as(MemberAccessExprSyntax.self).map {
+                ".\($0.declName.baseName.text)"
+            }
+        }
+    }
+    if let memberAccess = expression.as(MemberAccessExprSyntax.self) {
+        return [".\(memberAccess.declName.baseName.text)"]
+    }
+    return []
+}

--- a/Sources/SwiftMCPMacros/MCPToolMacro.swift
+++ b/Sources/SwiftMCPMacros/MCPToolMacro.swift
@@ -103,14 +103,10 @@ public struct MCPToolMacro: PeerMacro {
                 } else if argument.label?.text == "description", let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self) {
                     let stringValue = stringLiteral.segments.description
                     descriptionArg = "\"\(stringValue.escapedForSwiftString)\"" // Ensure proper escaping
-                } else if argument.label?.text == "hints", let arrayExpr = argument.expression.as(ArrayExprSyntax.self) {
-                    // Parse hints array: [.readOnly, .destructive]
-                    for element in arrayExpr.elements {
-                        if let memberAccess = element.expression.as(MemberAccessExprSyntax.self) {
-                            let hintName = memberAccess.declName.baseName.text
-                            hintsFromOptionSet.append(".\(hintName)")
-                        }
-                    }
+                } else if argument.label?.text == "hints" {
+                    // Parse hints: accept array literal ([.readOnly, .destructive])
+                    // or a single OptionSet member access (.readOnly).
+                    hintsFromOptionSet.append(contentsOf: parseHintsExpression(argument.expression))
                 } else if argument.label?.text == "isConsequential", let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self) {
                     isConsequentialArg = boolLiteral.literal.text
                 } else if argument.label?.text == "readOnlyHint", let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self) {


### PR DESCRIPTION
## Summary
- Extend `@MCPAppIntentTool` to accept `hints: MCPToolHints` (same OptionSet that `@MCPTool` supports), parse it in `MCPAppIntentToolMacro`, and emit `MCPToolAnnotations` into the generated `MCPToolMetadata`.
- `isConsequential` is derived from the hints via the existing `MCPToolMetadata.computedIsConsequential` path — no special handling in the macro itself.
- Annotate the IntentsDemo intents so they show correct hints in the MCP Inspector.

Closes #115.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — all 415 tests pass
- [ ] Verify in MCP Inspector that the IntentsDemo intents now show the expected hints (no longer flagged as destructive when not appropriate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)