### PR TITLE
Align swift-argument-parser URL with .git suffix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-		.package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
+		.package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
 		.package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
 		.package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.0.0"),
 		.package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0-latest"),


### PR DESCRIPTION
## Summary

Resolves the SwiftPM info warning:

> 'swiftmcp': dependency on 'swift-argument-parser' is represented by similar locations (`https://github.com/apple/swift-argument-parser.git` and `https://github.com/apple/swift-argument-parser`) which are treated as the same canonical location `github.com/apple/swift-argument-parser`.

### Root cause

`Package.swift` declared `swift-argument-parser` without the `.git` suffix while a transitive dependency (e.g. via `swift-syntax`/`swift-certificates`) references it with `.git`. SwiftPM canonicalizes both to the same package but reports the URL-form mismatch.

### Fix

Add `.git` to the `swift-argument-parser` dependency URL so it matches the form used by every other Apple dependency in the file (`swift-log`, `swift-nio`, `swift-crypto`, `swift-certificates`).

## Test plan

- [ ] `swift package resolve` no longer emits the duplicate-location info message
- [ ] `swift build` succeeds
- [ ] CI passes

https://claude.ai/code/session_01Mb82oCJf7qDceHjiCAAPCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mb82oCJf7qDceHjiCAAPCZ)_