### PR TITLE
String+Hostname: import the right libc shim on each platform

### DIFF
--- a/Sources/SwiftMCP/Extensions/String+Hostname.swift
+++ b/Sources/SwiftMCP/Extensions/String+Hostname.swift
@@ -3,8 +3,14 @@
 
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#elseif canImport(WinSDK)
+import WinSDK
 #endif
 
 import Foundation
@@ -20,9 +26,25 @@ extension String {
         if let hostname = Host.current().name {
             return hostname
         }
+        #elseif os(Windows)
+        // `gethostname()` on Windows is a Winsock function and requires
+        // `WSAStartup()` to have been called first; without that it
+        // returns `WSANOTINITIALISED` and we'd silently fall back to
+        // `"localhost"`. `GetComputerNameExW(_:_:_:)` reads the
+        // configured DNS hostname directly from the local registry
+        // without touching Winsock — the right tool for EHLO/HELO.
+        var size: DWORD = 256
+        var buffer = [WCHAR](repeating: 0, count: Int(size))
+        if GetComputerNameExW(ComputerNameDnsFullyQualified, &buffer, &size) {
+            let name = String(decodingCString: buffer, as: UTF16.self)
+            if !name.isEmpty {
+                return name
+            }
+        }
         #else
-        // Use system call on Linux and other platforms
-        var hostname = [CChar](repeating: 0, count: 256) // Linux typically uses 256 as max hostname length.
+        // POSIX: Linux / Android / musl all expose `gethostname(_:_:)`
+        // through their respective libc shim imported above.
+        var hostname = [CChar](repeating: 0, count: 256) // POSIX HOST_NAME_MAX is 64; 256 is generous.
         if gethostname(&hostname, hostname.count) == 0 {
             // Create a string from the C string
             if let name = String(cString: hostname, encoding: .utf8), !name.isEmpty {


### PR DESCRIPTION
## Summary

`Sources/SwiftMCP/Extensions/String+Hostname.swift` currently does:

```swift
#if canImport(Darwin)
import Darwin
#else
import Glibc
#endif
```

The `#else` falls through to `import Glibc` unconditionally on every non-Apple platform, which breaks compilation on Android, musl-Linux (Alpine), and Windows — none of those ship a `Glibc` module.

The SwiftAgents Android CI job (which runs the swift.org Android SDK) currently hits this at:

```
.build/checkouts/SwiftMCP/Sources/SwiftMCP/Extensions/String+Hostname.swift:7:8:
error: no such module 'Glibc'
```

This PR reaches the same `gethostname(_:_:)` symbol via whichever libc shim each platform actually ships:

| Platform              | Module    |
|-----------------------|-----------|
| Apple                 | Darwin    |
| glibc-Linux           | Glibc     |
| musl-Linux (Alpine)   | Musl      |
| Android               | Android (the swift.org Android SDK module that wraps Bionic) |
| Windows               | WinSDK    |

## Notes

Other modules transitively pulled by SwiftMCP (Swift NIO, etc.) may still gate Android / Windows out at later compile stages. This PR makes `String+Hostname.swift` itself portable; further downstream port work is a separate effort.

## Test plan

- [x] `swift build` clean on macOS
- [ ] (CI) Android job in downstream SwiftAgents progresses past this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)