### PR TITLE
Fix @MCPServer Client doc comments breaking on `*/` in source docs

### DIFF
--- a/Sources/SwiftMCPMacros/MCPServerMacro+ClientGeneration.swift
+++ b/Sources/SwiftMCPMacros/MCPServerMacro+ClientGeneration.swift
@@ -210,19 +210,13 @@ extension MCPServerMacro {
 
         guard !bodyLines.isEmpty else { return [] }
 
-        var lines: [String] = []
-        lines.append("    /**")
-        for bodyLine in bodyLines {
-            lines.append("     \(bodyLine)")
-        }
-        lines.append("     */")
-        return lines
+        return lineDocCommentLines(bodyLines, indent: "    ")
     }
 
     static func clientTypeDocCommentLines(description: String?) -> [String] {
         guard let description, !description.isEmpty else { return [] }
         let bodyLines = description.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        return blockDocCommentLines(bodyLines, indent: "")
+        return lineDocCommentLines(bodyLines, indent: "")
     }
 
     static func initDocCommentLines() -> [String] {
@@ -230,7 +224,7 @@ extension MCPServerMacro {
             "Creates a client using the provided proxy.",
             "- Parameter proxy: The proxy used to call server tools, resources, and prompts."
         ]
-        return blockDocCommentLines(bodyLines, indent: "    ")
+        return lineDocCommentLines(bodyLines, indent: "    ")
     }
 
     static func encodedArgumentLines(
@@ -254,15 +248,18 @@ extension MCPServerMacro {
         return lines
     }
 
-    static func blockDocCommentLines(_ bodyLines: [String], indent: String) -> [String] {
+    /// Emits the given body lines as `///` line doc comments.
+    ///
+    /// We deliberately avoid the `/** … */` block form here: doc-comment text
+    /// for tools/resources/prompts is taken verbatim from user source, and a
+    /// `*/` substring inside that text (e.g. `"**/*"` in a glob example) would
+    /// close the block comment early and let the rest of the line spill into
+    /// the generated Swift source — see issue #121.
+    static func lineDocCommentLines(_ bodyLines: [String], indent: String) -> [String] {
         guard !bodyLines.isEmpty else { return [] }
-        var lines: [String] = []
-        lines.append("\(indent)/**")
-        for line in bodyLines {
-            lines.append("\(indent) \(line)")
+        return bodyLines.map { line in
+            line.isEmpty ? "\(indent)///" : "\(indent)/// \(line)"
         }
-        lines.append("\(indent) */")
-        return lines
     }
 
 }

--- a/Sources/SwiftMCPMacros/MCPServerMacro+ClientGeneration.swift
+++ b/Sources/SwiftMCPMacros/MCPServerMacro+ClientGeneration.swift
@@ -255,10 +255,21 @@ extension MCPServerMacro {
     /// `*/` substring inside that text (e.g. `"**/*"` in a glob example) would
     /// close the block comment early and let the rest of the line spill into
     /// the generated Swift source — see issue #121.
+    ///
+    /// Each body element is further split on any embedded `\n` so multi-line
+    /// content (e.g. a multi-paragraph `- Returns:` produced by
+    /// `Documentation.combineLines`) is emitted one `///` line per physical
+    /// line — `///` comments terminate at the newline, so an unsplit element
+    /// would leak its continuation into the generated source.
     static func lineDocCommentLines(_ bodyLines: [String], indent: String) -> [String] {
         guard !bodyLines.isEmpty else { return [] }
-        return bodyLines.map { line in
-            line.isEmpty ? "\(indent)///" : "\(indent)/// \(line)"
+        return bodyLines.flatMap { bodyLine -> [String] in
+            let physicalLines = bodyLine
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map(String.init)
+            return physicalLines.map { line in
+                line.isEmpty ? "\(indent)///" : "\(indent)/// \(line)"
+            }
         }
     }
 

--- a/Tests/SwiftMCPTests/Issue121ReproTests.swift
+++ b/Tests/SwiftMCPTests/Issue121ReproTests.swift
@@ -17,6 +17,18 @@ final class Issue121Server {
     func grep(pattern: String, outputMode: String, glob: String? = nil) -> String {
         ""
     }
+
+    /// Computes something interesting.
+    /// - Parameter input: The input value.
+    /// - Returns: The first paragraph of the return docs.
+    ///
+    ///   A second paragraph separated by a blank line. `Documentation.combineLines`
+    ///   collapses this into a single `Returns:` string with an embedded `\n\n`,
+    ///   which must not break the generated `///` doc comments.
+    @MCPTool
+    func compute(input: String) -> String {
+        input
+    }
 }
 
 @Suite("Issue 121 Reproducer", .tags(.client))
@@ -25,13 +37,23 @@ struct Issue121ReproTests {
     func macroExpandsWithQuotedAsteriskDocs() {
         let server = Issue121Server()
         let metadata = server.mcpToolMetadata
-        #expect(metadata.count == 1)
+        #expect(metadata.count == 2)
 
-        let tool = try? #require(metadata.first)
-        #expect(tool?.name == "grep")
+        let grep = metadata.first { $0.name == "grep" }
         // Parameter descriptions survive the round trip unchanged.
-        let parameters = Dictionary(uniqueKeysWithValues: (tool?.parameters ?? []).map { ($0.name, $0) })
+        let parameters = Dictionary(uniqueKeysWithValues: (grep?.parameters ?? []).map { ($0.name, $0) })
         #expect(parameters["outputMode"]?.description?.contains("\"content\"") == true)
         #expect(parameters["glob"]?.description?.contains("\"**/*\"") == true)
+    }
+
+    @Test("Macro handles multi-paragraph `- Returns:` docs without leaking into source")
+    func macroHandlesMultiParagraphReturns() {
+        let server = Issue121Server()
+        // The mere fact that this server compiles proves the regression is
+        // fixed — if `lineDocCommentLines` did not split embedded newlines,
+        // the second paragraph of `compute`'s `- Returns:` block would have
+        // been emitted as raw Swift between the `///` doc comment and the
+        // function signature, failing macro expansion.
+        #expect(server.mcpToolMetadata.contains { $0.name == "compute" })
     }
 }

--- a/Tests/SwiftMCPTests/Issue121ReproTests.swift
+++ b/Tests/SwiftMCPTests/Issue121ReproTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+import SwiftMCP
+
+/// A server whose tool doc comments contain content that previously broke
+/// macro expansion: embedded `"…"` strings and a `**/*` glob example (whose
+/// inner `*/` substring closed the generated `/** … */` block comment early).
+///
+/// Regression test for https://github.com/Cocoanetics/SwiftMCP/issues/121
+@MCPServer
+final class Issue121Server {
+    /// Search files.
+    /// - Parameter pattern: The regex pattern.
+    /// - Parameter outputMode: "content" shows matching lines, "files" shows only file paths.
+    /// - Parameter glob: e.g. "*.swift" or "*.ts". Do NOT use "**/*".
+    @MCPTool
+    func grep(pattern: String, outputMode: String, glob: String? = nil) -> String {
+        ""
+    }
+}
+
+@Suite("Issue 121 Reproducer", .tags(.client))
+struct Issue121ReproTests {
+    @Test("Macro expands cleanly with quoted/asterisk doc-comment content")
+    func macroExpandsWithQuotedAsteriskDocs() {
+        let server = Issue121Server()
+        let metadata = server.mcpToolMetadata
+        #expect(metadata.count == 1)
+
+        let tool = try? #require(metadata.first)
+        #expect(tool?.name == "grep")
+        // Parameter descriptions survive the round trip unchanged.
+        let parameters = Dictionary(uniqueKeysWithValues: (tool?.parameters ?? []).map { ($0.name, $0) })
+        #expect(parameters["outputMode"]?.description?.contains("\"content\"") == true)
+        #expect(parameters["glob"]?.description?.contains("\"**/*\"") == true)
+    }
+}


### PR DESCRIPTION
## Summary

`@MCPServer`'s generated `Client` type emitted tool/resource/prompt doc comments as `/** … */` blocks. Any `*/` substring in the user's source doc text — most commonly inside a glob example like `"**/*"` — closed the block comment early, spilling the rest of the line into the emitted Swift source and producing "unterminated string literal" / "operator must be static" cascades at macro-expansion time.

Switch all three doc-comment emitters (`docCommentLines(for:)`, `clientTypeDocCommentLines`, `initDocCommentLines`) to `///` line comments via a new `lineDocCommentLines` helper. Line comments end at the newline, so embedded `*/` (and embedded quotes) in user doc text are harmless.

Fixes #121.

## Test plan

- [x] Reproduced the issue with the exact `grep` example from #121 — confirmed the failure mode is `*/` inside `**/*`, not unescaped quotes as #121 hypothesized.
- [x] Added `Issue121ReproTests` regression test: macro expands cleanly and parameter descriptions (including `"content"` and `"**/*"`) survive round-trip.
- [x] Full test suite passes (417 tests, including all existing `MCPClientGenerationTests` / `ProxyGeneratorDocCommentTests` / `MacroDocumentationTests`).
- [x] SwiftLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)