### PR TITLE
Client: stop wiping streamable session ID on error responses (#125)

### DIFF
--- a/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
@@ -13,6 +13,19 @@ extension MCPServerProxy {
         streamFailure = nil
         endpointURL = nil
 
+        // Reset the session identity so a reconnect after `.sessionInvalidated`
+        // starts clean. The stdio/TCP cases immediately assign a fresh
+        // client-side UUID below; the SSE case must NOT send a stale
+        // `Mcp-Session-Id` on the initialize POST, because a server that has
+        // forgotten the session rejects it as "Unknown session" before it can
+        // create a new one. (#125)
+        sessionID = nil
+
+        // Cancel any stream left over from a previous connection so reconnecting
+        // on the same proxy doesn't leave a second general-SSE loop running.
+        streamTask?.cancel()
+        streamTask = nil
+
         switch config {
         case .stdio(let stdioConfig):
             sessionID = UUID().uuidString

--- a/Sources/SwiftMCP/Client/MCPServerProxy+SSE.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+SSE.swift
@@ -154,22 +154,39 @@ extension MCPServerProxy {
                     )
 
                     let (asyncBytes, response) = try await session.bytes(for: request)
-                    self.handleSSEResponse(
+                    let serverReturned404 = self.handleSSEResponse(
                         response,
                         sseConfig: sseConfig,
                         isStreamableMCP: true
                     )
 
-                    for try await message in asyncBytes.lines.sseMessages() {
-                        if let id = message.id {
-                            lastEventID = id
+                    if serverReturned404 {
+                        if lastEventID != nil {
+                            // A 404 while resuming may only mean our
+                            // `Last-Event-ID` resume point expired, not that the
+                            // session died. Drop it and reconnect from a fresh
+                            // general stream before concluding the session is
+                            // gone.
+                            self.logger.error(
+                                "[MCP DEBUG] Streamable general SSE resume rejected (HTTP 404); reconnecting fresh"
+                            )
+                            lastEventID = nil
+                        } else {
+                            // A fresh general GET still 404s — the server has
+                            // forgotten our session (e.g. it restarted). Stop
+                            // reconnecting with the dead ID and surface a typed
+                            // error so the application can reconnect. (#125)
+                            self.logger.error(
+                                "[MCP DEBUG] Streamable general SSE session invalidated by server (HTTP 404)"
+                            )
+                            self.handleStreamTermination(MCPServerProxyError.sessionInvalidated)
+                            return
                         }
-                        if let retry = message.retry {
-                            retryMilliseconds = retry
-                        }
-                        await self.processIncomingMessage(
-                            event: message.event,
-                            data: message.data
+                    } else {
+                        (lastEventID, retryMilliseconds) = try await self.consumeGeneralSSEStream(
+                            asyncBytes,
+                            lastEventID: lastEventID,
+                            retryMilliseconds: retryMilliseconds
                         )
                     }
                 } catch is CancellationError {
@@ -194,25 +211,75 @@ extension MCPServerProxy {
         }
     }
 
+    /// Reads a general SSE stream to completion, dispatching each message and
+    /// tracking the resume cursor. Returns the updated `Last-Event-ID` and retry
+    /// interval so the next reconnect can resume from where this stream ended.
+    private func consumeGeneralSSEStream(
+        _ asyncBytes: URLSession.AsyncBytes,
+        lastEventID: String?,
+        retryMilliseconds: Int
+    ) async throws -> (lastEventID: String?, retryMilliseconds: Int) {
+        var lastEventID = lastEventID
+        var retryMilliseconds = retryMilliseconds
+
+        for try await message in asyncBytes.lines.sseMessages() {
+            if let id = message.id {
+                lastEventID = id
+            }
+            if let retry = message.retry {
+                retryMilliseconds = retry
+            }
+            await processIncomingMessage(event: message.event, data: message.data)
+        }
+
+        return (lastEventID, retryMilliseconds)
+    }
+
     // MARK: - Shared SSE Helpers
 
+    /// Processes the HTTP response that opened an SSE stream, adopting any
+    /// server-issued session ID and resolving the endpoint URL.
+    ///
+    /// - Returns: `true` if the server returned HTTP 404 to our streamable
+    ///   request while a session ID was in effect. The caller decides how to
+    ///   react: a fresh reconnect that still 404s means the session is gone,
+    ///   whereas a 404 only while resuming (with a `Last-Event-ID`) may just be
+    ///   an expired resume point.
+    @discardableResult
     internal func handleSSEResponse(
         _ response: URLResponse,
         sseConfig: MCPServerSseConfig,
         isStreamableMCP: Bool
-    ) {
-        if let httpResponse = response as? HTTPURLResponse {
-            sessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id")
-            if isStreamableMCP {
-                endpointURL = sseConfig.url
-            } else if let sessionID,
-                      let endpoint = messageEndpointURL(
-                        baseURL: sseConfig.url,
-                        sessionId: sessionID
-                      ) {
-                endpointURL = endpoint
-            }
+    ) -> Bool {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return false
         }
+
+        // Only adopt a session ID from a successful response that actually
+        // carries the header. Error responses (e.g. 404 "Unknown session"
+        // after a server restart) do not include `Mcp-Session-Id`; assigning
+        // the absent header here would wipe the existing ID and strip it from
+        // every subsequent request, trapping the retry loop forever. (#125)
+        if (200...299).contains(httpResponse.statusCode),
+           let newSessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id") {
+            sessionID = newSessionID
+        }
+
+        if isStreamableMCP {
+            endpointURL = sseConfig.url
+        } else if let sessionID,
+                  let endpoint = messageEndpointURL(
+                    baseURL: sseConfig.url,
+                    sessionId: sessionID
+                  ) {
+            endpointURL = endpoint
+        }
+
+        // A 404 to a request that carried an `Mcp-Session-Id` signals the server
+        // rejected our session ID. Per the MCP streamable-HTTP spec this usually
+        // means the session was terminated, but it can also be a merely expired
+        // resume point — the caller disambiguates (see the doc comment).
+        return isStreamableMCP && sessionID != nil && httpResponse.statusCode == 404
     }
 
     internal func waitForEndpointIfNeeded(isStreamableMCP: Bool) async throws {

--- a/Sources/SwiftMCP/Client/MCPServerProxy+StreamableHTTP.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+StreamableHTTP.swift
@@ -13,6 +13,11 @@ extension MCPServerProxy {
         guard let requestID = message.id else {
             throw MCPServerProxyError.communicationError("Message must have an ID")
         }
+        // Fail fast if the stream has already terminated (e.g. the session was
+        // invalidated by the server), mirroring the line-based send path. (#125)
+        if let streamFailure {
+            throw streamFailure
+        }
         guard let endpointURL = endpointURL
             ?? (isStreamableMCPURL(sseConfig.url) ? sseConfig.url : nil) else {
             throw MCPServerProxyError.communicationError("Not connected to server")
@@ -108,6 +113,21 @@ extension MCPServerProxy {
             }
             let responseBody = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            // A 404 to a POST carrying an `Mcp-Session-Id` means the server has
+            // terminated the session (e.g. after a restart) — POSTs have no
+            // resumable-stream path, so the session is unambiguously gone.
+            // Surface a typed error so callers reconnect instead of retrying
+            // with the dead session ID. (#125) GET retries (`requestBody == nil`)
+            // are excluded: their 404 can also mean an expired resume point on a
+            // still-live session.
+            if httpResponse.statusCode == 404, sessionID != nil, requestBody != nil {
+                logger.error(
+                    "[MCP DEBUG] Streamable request rejected — session invalidated by server: \(responseBody)"
+                )
+                throw MCPServerProxyError.sessionInvalidated
+            }
+
             let details = responseBody.isEmpty ? "" : ": \(responseBody)"
             throw MCPServerProxyError.communicationError(
                 "HTTP error \(httpResponse.statusCode)\(details)"

--- a/Sources/SwiftMCP/Errors/MCPServerProxyError.swift
+++ b/Sources/SwiftMCP/Errors/MCPServerProxyError.swift
@@ -6,6 +6,12 @@ public enum MCPServerProxyError: Error, LocalizedError {
     case communicationError(String)
     case toolError(String)
     case unsupportedPlatform(String)
+    /// The server no longer recognizes this session (it returned HTTP 404 to a
+    /// request that carried an `Mcp-Session-Id`), typically because the server
+    /// was restarted and lost its in-memory session table. The existing session
+    /// is dead and cannot be revived by retrying; the proxy must reconnect (call
+    /// `connect()` again, or create a fresh proxy) to obtain a new session.
+    case sessionInvalidated
 
     public var errorDescription: String? {
         switch self {
@@ -17,6 +23,8 @@ public enum MCPServerProxyError: Error, LocalizedError {
             return "Tool call failed: \(message)"
         case .unsupportedPlatform(let message):
             return "Unsupported platform: \(message)"
+        case .sessionInvalidated:
+            return "MCP session is no longer valid; reconnect to start a new session."
         }
     }
 }

--- a/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
@@ -53,6 +53,41 @@ struct MCPServerProxyStreamableHTTPTests {
         #expect(delivered)
     }
 
+    @Test("Tool call after the server forgets the session throws sessionInvalidated and keeps the session ID")
+    func sessionInvalidationSurfacesTypedError() async throws {
+        let (transport, url) = try await startTransport()
+        defer { Task { try? await transport.stop() } }
+
+        let proxy = MCPServerProxy(config: .sse(config: MCPServerSseConfig(url: url)))
+        defer { Task { await proxy.disconnect() } }
+
+        try await proxy.connect()
+        let sessionID = try #require(await proxy.sessionID)
+        let sessionUUID = try #require(UUID(uuidString: sessionID))
+
+        // Simulate a server restart wiping its in-memory session table: the
+        // session UUID the client still holds is no longer known to the server.
+        await transport.sessionManager.removeSession(id: sessionUUID)
+
+        // A subsequent request must surface a typed `.sessionInvalidated` error
+        // rather than spinning or returning a generic communication error. (#125)
+        do {
+            try await proxy.ping()
+            Issue.record("Expected ping to throw after the session was invalidated")
+        } catch let error as MCPServerProxyError {
+            guard case .sessionInvalidated = error else {
+                Issue.record("Expected .sessionInvalidated, got \(error)")
+                return
+            }
+        }
+
+        // The 404 must NOT have wiped the stale-but-present session ID, so the
+        // header keeps being attached and the application retains the context it
+        // needs to decide how to reconnect.
+        let retainedSessionID = await proxy.sessionID
+        #expect(retainedSessionID == sessionID)
+    }
+
     private func waitForCondition(
         timeoutNanoseconds: UInt64 = 2_000_000_000,
         pollNanoseconds: UInt64 = 50_000_000,

--- a/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
@@ -88,6 +88,34 @@ struct MCPServerProxyStreamableHTTPTests {
         #expect(retainedSessionID == sessionID)
     }
 
+    @Test("Reconnecting the same proxy after invalidation establishes a fresh session")
+    func reconnectAfterInvalidationEstablishesFreshSession() async throws {
+        let (transport, url) = try await startTransport()
+        defer { Task { try? await transport.stop() } }
+
+        let proxy = MCPServerProxy(config: .sse(config: MCPServerSseConfig(url: url)))
+        defer { Task { await proxy.disconnect() } }
+
+        try await proxy.connect()
+        let firstSession = try #require(await proxy.sessionID)
+        let firstUUID = try #require(UUID(uuidString: firstSession))
+
+        // Simulate a server restart wiping its in-memory session table.
+        await transport.sessionManager.removeSession(id: firstUUID)
+
+        // Following the `.sessionInvalidated` guidance, reconnect the SAME proxy.
+        // The stale session ID must not leak onto the initialize POST (the server
+        // would reject it as unknown); the server must issue a fresh session. (#125)
+        try await proxy.connect()
+        let secondSession = try #require(await proxy.sessionID)
+        #expect(secondSession != firstSession)
+
+        // The reconnected proxy is fully functional against the new session.
+        try await proxy.ping()
+        let tools = try await proxy.listTools()
+        #expect(!tools.isEmpty)
+    }
+
     private func waitForCondition(
         timeoutNanoseconds: UInt64 = 2_000_000_000,
         pollNanoseconds: UInt64 = 50_000_000,


### PR DESCRIPTION
Fixes #125.

## Problem

`MCPServerProxy`'s streamable HTTP path lost its `sessionID` whenever the general-SSE stream received an error response. `handleSSEResponse` assigned `sessionID` unconditionally from the response's `Mcp-Session-Id` header:

```swift
sessionID = httpResponse.value(forHTTPHeaderField: "Mcp-Session-Id")  // ⚠️ unconditional
```

After a server restart wipes the in-memory session table, the server returns `404 "Unknown session. Send initialize first."` **with no** `Mcp-Session-Id` header. The client therefore cleared its own session ID, after which every POST / notification / SSE GET went out with no header, the server rejected each one, and the general-SSE retry loop spun forever against the dead session — never recovering. From the app layer, every tool call failed with `HTTP error 404: Unknown session.` and the proxy never re-initialized on its own.

This was traced downstream in Aigent, where Mac apps lost the ability to log in after `aigentd` restarts.

## Changes

1. **Stop wiping the session ID.** `handleSSEResponse` now only adopts a session ID from a **2xx** response that actually carries the header, and never clears it on error responses.

2. **Typed `MCPServerProxyError.sessionInvalidated`.** Surfaced when the server returns 404 to a session-bearing request, so the application can react (call `connect()` again, or recreate the proxy) instead of spinning.
   - The general-SSE loop now **stops** on session death and signals via `handleStreamTermination`, instead of retrying the dead UUID forever.
   - The POST request path throws `.sessionInvalidated` on a 404.
   - `sendStreamableRequest` now fails fast on `streamFailure`, mirroring the line-based transports.

3. **Avoided a false positive found while tracing this.** The `/mcp` GET also returns 404 for an *expired resume point* on a still-live session (general-stream messages carry resumable event IDs that the client echoes as `Last-Event-ID`). Rather than brittle body-string matching, the loop retries once from a **fresh** stream (dropping `Last-Event-ID`) and only concludes the session is dead if a fresh GET *also* 404s. The POST path is scoped to `requestBody != nil`, where a 404 is unambiguous.

## Testing

- Adds a regression test (`MCPServerProxyStreamableHTTPTests`) that simulates the server forgetting the session (`removeSession`) and asserts the tool call throws `.sessionInvalidated` **and** that the session ID is retained (not wiped). The test logs confirm both new paths fire — the background loop logs session invalidation and stops, and the request path throws the typed error.
- Full suite green: 420 tests pass; `swift build` and `swiftlint` clean.

## Notes for reviewers

- The issue mentioned separate `…Apple` / `…Linux` general-SSE variants; those have since been unified into a single `URLSession.bytes(for:)` path (via SwiftCross), so this one fix covers all platforms.
- `MCPServerProxyError.sessionInvalidated` is a public API addition (a new enum case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)