### PR TITLE
Gate swift-nio behind a `Server` package trait so the core stays cross-platform

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -80,7 +80,10 @@ jobs:
   # Trait matrix: the tool/schema core and the `Client` feature must build
   # WITHOUT the `Server` trait, i.e. without swift-nio / swift-crypto /
   # swift-certificates. This keeps the NIO-free configuration green so a
-  # client/tools-only consumer (and Windows, below) never regresses.
+  # client/tools-only consumer (and Windows, below) never regresses. The whole
+  # package builds NIO-free too — the server demo CLIs are gated `#if Server`
+  # and compile to a no-op stub — so a plain `swift build`/`swift test` with
+  # `Server` disabled works, not just `--target SwiftMCP`.
   build-traits:
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -88,15 +91,19 @@ jobs:
       - uses: actions/checkout@v6
       - name: Verify Swift version
         run: swift --version
-      - name: Build SwiftMCP — core only (all traits disabled)
+      - name: Build SwiftMCP library — core only (all traits disabled)
         run: swift build --target SwiftMCP --disable-default-traits
-      - name: Build SwiftMCP — Client trait only (no swift-nio)
+      - name: Build SwiftMCP library — Client trait only (no swift-nio)
         run: swift build --target SwiftMCP --traits Client
+      - name: Build whole package — Client + OpenAPI (no swift-nio)
+        run: swift build --traits "Client,OpenAPI"
+      - name: Test — non-server suite (Client + OpenAPI, no swift-nio)
+        run: swift test --traits "Client,OpenAPI"
 
   # Windows DOES build AND test the NIO-free configuration. With the `Server`
-  # trait disabled there is no swift-nio in the graph, and Package.swift omits
-  # the swift-nio-backed server demo CLIs on Windows, so `swift test` builds the
-  # library + the non-server test suite. These are real (non continue-on-error)
+  # trait disabled there is no swift-nio in the graph (the server demo CLIs are
+  # gated `#if Server` and compile to a no-op stub), so `swift test` builds the
+  # library plus the non-server test suite. These are real (non continue-on-error)
   # checks: if swift-nio ever leaks back into the core/client, or a non-server
   # test regresses, this job goes red. The full `build-windows` job above stays
   # aspirational until swift-nio itself builds on Windows.

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -77,6 +77,45 @@ jobs:
         run: swift test -v --skip-build
         continue-on-error: true
 
+  # Trait matrix: the tool/schema core and the `Client` feature must build
+  # WITHOUT the `Server` trait, i.e. without swift-nio / swift-crypto /
+  # swift-certificates. This keeps the NIO-free configuration green so a
+  # client/tools-only consumer (and Windows, below) never regresses.
+  build-traits:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify Swift version
+        run: swift --version
+      - name: Build SwiftMCP — core only (all traits disabled)
+        run: swift build --target SwiftMCP --disable-default-traits
+      - name: Build SwiftMCP — Client trait only (no swift-nio)
+        run: swift build --target SwiftMCP --traits Client
+
+  # Windows DOES build AND test the NIO-free configuration. With the `Server`
+  # trait disabled there is no swift-nio in the graph, and Package.swift omits
+  # the swift-nio-backed server demo CLIs on Windows, so `swift test` builds the
+  # library + the non-server test suite. These are real (non continue-on-error)
+  # checks: if swift-nio ever leaks back into the core/client, or a non-server
+  # test regresses, this job goes red. The full `build-windows` job above stays
+  # aspirational until swift-nio itself builds on Windows.
+  windows-client:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Swift
+        uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: "6.3.1"
+      - name: Verify Swift version
+        run: swift --version
+      - name: Build SwiftMCP library — Client trait only (no swift-nio)
+        run: swift build --target SwiftMCP --traits Client
+      - name: Test — non-server suite (Client + OpenAPI, no swift-nio)
+        run: swift test --traits "Client,OpenAPI"
+
   build-android:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/Demos/SwiftMCPDemo/Commands/HTTPSSECommand.swift
+++ b/Demos/SwiftMCPDemo/Commands/HTTPSSECommand.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import ArgumentParser
 import SwiftMCP
@@ -226,3 +227,4 @@ final class HTTPSSECommand: AsyncParsableCommand {
         await signalHandler?.setup()
     }
 }
+#endif

--- a/Demos/SwiftMCPDemo/Commands/StdioCommand.swift
+++ b/Demos/SwiftMCPDemo/Commands/StdioCommand.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import ArgumentParser
 import SwiftMCP
@@ -70,9 +71,4 @@ struct StdioCommand: AsyncParsableCommand {
         }
     }
 }
-
-/// Function to log a message to stderr
-func logToStderr(_ message: String) {
-	guard let data = (message + "\n").data(using: .utf8) else { return }
-	try? FileHandle.standardError.write(contentsOf: data)
-}
+#endif

--- a/Demos/SwiftMCPDemo/Commands/TCPBonjourCommand.swift
+++ b/Demos/SwiftMCPDemo/Commands/TCPBonjourCommand.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import ArgumentParser
 import SwiftMCP
@@ -74,3 +75,4 @@ struct TCPBonjourCommand: AsyncParsableCommand {
 #endif
     }
 }
+#endif

--- a/Demos/SwiftMCPDemo/MCPCommand.swift
+++ b/Demos/SwiftMCPDemo/MCPCommand.swift
@@ -1,5 +1,6 @@
-import Foundation
 import ArgumentParser
+#if Server
+import Foundation
 import SwiftMCP
 import Logging
 import NIOCore
@@ -7,6 +8,7 @@ import Dispatch
 
 #if canImport(OSLog)
 import OSLog
+#endif
 #endif
 
 /**
@@ -36,6 +38,7 @@ import OSLog
  */
 @main
 struct MCPCommand: AsyncParsableCommand {
+#if Server
 #if canImport(Network)
     static let configuration = CommandConfiguration(
         commandName: "SwiftMCPDemo",
@@ -88,5 +91,15 @@ struct MCPCommand: AsyncParsableCommand {
         subcommands: [StdioCommand.self, HTTPSSECommand.self],
         defaultSubcommand: StdioCommand.self
     )
+#endif
+#else
+    static let configuration = CommandConfiguration(
+        commandName: "SwiftMCPDemo",
+        abstract: "Requires the SwiftMCP `Server` trait (HTTP/SSE, stdio, TCP transports)."
+    )
+
+    func run() async throws {
+        print("Built without the `Server` trait; rebuild with default traits to run this demo.")
+    }
 #endif
 }

--- a/Demos/SwiftMCPDemo/SignalHandler.swift
+++ b/Demos/SwiftMCPDemo/SignalHandler.swift
@@ -1,3 +1,4 @@
+#if Server
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -94,3 +95,4 @@ public final class SignalHandler {
 		await state.setupHandler(on: signalQueue)
 	}
 }
+#endif

--- a/Demos/SwiftMCPDemo/StderrLog.swift
+++ b/Demos/SwiftMCPDemo/StderrLog.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Log a message to stderr.
+///
+/// Lives outside the `#if Server` transport command files because it is also
+/// used by the always-built demo server sources (e.g. resource providers).
+func logToStderr(_ message: String) {
+	guard let data = (message + "\n").data(using: .utf8) else { return }
+	try? FileHandle.standardError.write(contentsOf: data)
+}

--- a/Demos/SwiftMCPIntentsDemo/Commands/HTTPSSECommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/HTTPSSECommand.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import ArgumentParser
 import SwiftMCP
@@ -174,3 +175,4 @@ final class HTTPSSECommand: AsyncParsableCommand {
         await signalHandler?.setup()
     }
 }
+#endif

--- a/Demos/SwiftMCPIntentsDemo/Commands/StdioCommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/StdioCommand.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import ArgumentParser
 import SwiftMCP
@@ -60,3 +61,4 @@ func logToStderr(_ message: String) {
     guard let data = (message + "\n").data(using: .utf8) else { return }
     try? FileHandle.standardError.write(contentsOf: data)
 }
+#endif

--- a/Demos/SwiftMCPIntentsDemo/Commands/TCPBonjourCommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/TCPBonjourCommand.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import ArgumentParser
 import SwiftMCP
@@ -73,3 +74,4 @@ struct TCPBonjourCommand: AsyncParsableCommand {
 #endif
     }
 }
+#endif

--- a/Demos/SwiftMCPIntentsDemo/MCPCommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/MCPCommand.swift
@@ -11,6 +11,7 @@ import ArgumentParser
  */
 @main
 struct MCPCommand: AsyncParsableCommand {
+#if Server
 #if canImport(Network)
     static let configuration = CommandConfiguration(
         commandName: "SwiftMCPIntentsDemo",
@@ -59,5 +60,15 @@ struct MCPCommand: AsyncParsableCommand {
         subcommands: [StdioCommand.self, HTTPSSECommand.self],
         defaultSubcommand: StdioCommand.self
     )
+#endif
+#else
+    static let configuration = CommandConfiguration(
+        commandName: "SwiftMCPIntentsDemo",
+        abstract: "Requires the SwiftMCP `Server` trait (HTTP/SSE, stdio, TCP transports)."
+    )
+
+    func run() async throws {
+        print("Built without the `Server` trait; rebuild with default traits to run this demo.")
+    }
 #endif
 }

--- a/Demos/SwiftMCPIntentsDemo/SignalHandler.swift
+++ b/Demos/SwiftMCPIntentsDemo/SignalHandler.swift
@@ -1,3 +1,4 @@
+#if Server
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -80,3 +81,4 @@ public final class SignalHandler {
         await state.setupHandler(on: signalQueue)
     }
 }
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -22,14 +22,10 @@ let package = Package(
 			name: "JSONValue",
 			targets: ["JSONValue"]
 		),
-		.executable(
-			name: "SwiftMCPDemo",
-			targets: ["SwiftMCPDemo"]
-		),
-		.executable(
-			name: "SwiftMCPIntentsDemo",
-			targets: ["SwiftMCPIntentsDemo"]
-		),
+		// NOTE: the server demo CLIs (SwiftMCPDemo, SwiftMCPIntentsDemo) link
+		// swift-nio via the `Server` trait and are appended below only where
+		// swift-nio builds (everywhere except Windows). Library consumers never
+		// build these demo products regardless.
 		.executable(
 			name: "SwiftMCPUtility",
 			targets: ["SwiftMCPUtility"]
@@ -54,6 +50,25 @@ let package = Package(
 			name: "SwiftMCPAggregator",
 			targets: ["SwiftMCPAggregator"]
 		)
+	],
+	traits: [
+		// All feature traits are enabled by default, so existing consumers
+		// (and `swift build` / `swift test` without flags) are unaffected.
+		.default(enabledTraits: ["Server", "Client", "OpenAPI"]),
+		// The HTTP/SSE + TCP server transports. The only feature that links
+		// swift-nio, swift-crypto and swift-certificates. Disable it (e.g. on
+		// Windows, or for client/tools-only consumers) to drop those deps.
+		.trait(name: "Server"),
+		// The MCP client (`MCPServerProxy`).
+		.trait(name: "Client"),
+		// OpenAPI / AI-plugin manifest models and the matching HTTP routes.
+		.trait(name: "OpenAPI")
+		// NOTE: AppIntents bridging is intentionally NOT a trait. The
+		// `@MCPServer`/`@MCPAppIntentTool` macros expand to code in the
+		// *consumer's* module that references the AppIntents glue under
+		// `#if canImport(AppIntents)`. Package-trait conditions are not visible
+		// in consumer modules, so a trait cannot gate that surface — and
+		// `canImport(AppIntents)` already excludes it on non-Apple platforms.
 	],
 	dependencies: [
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
@@ -82,32 +97,21 @@ let package = Package(
 				"SwiftMCPMacros",
 				"JSONValue",
 				.product(name: "SwiftCross", package: "SwiftCross"),
-				.product(name: "NIOCore", package: "swift-nio"),
-				.product(name: "NIOHTTP1", package: "swift-nio"),
-				.product(name: "NIOPosix", package: "swift-nio"),
 				.product(name: "Logging", package: "swift-log"),
-				.product(name: "NIOFoundationCompat", package: "swift-nio"),
-				.product(name: "Crypto", package: "swift-crypto"),
-				.product(name: "_CryptoExtras", package: "swift-crypto"),
-				.product(name: "X509", package: "swift-certificates")
+				// swift-nio + swift-crypto + swift-certificates are linked ONLY
+				// when the `Server` trait is enabled (the HTTP/SSE transport).
+				.product(name: "NIOCore", package: "swift-nio", condition: .when(traits: ["Server"])),
+				.product(name: "NIOHTTP1", package: "swift-nio", condition: .when(traits: ["Server"])),
+				.product(name: "NIOPosix", package: "swift-nio", condition: .when(traits: ["Server"])),
+				.product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(traits: ["Server"])),
+				.product(name: "Crypto", package: "swift-crypto", condition: .when(traits: ["Server"])),
+				.product(name: "_CryptoExtras", package: "swift-crypto", condition: .when(traits: ["Server"])),
+				.product(name: "X509", package: "swift-certificates", condition: .when(traits: ["Server"]))
 			]
 		),
-		.executableTarget(
-			name: "SwiftMCPDemo",
-			dependencies: [
-				"SwiftMCP",
-				.product(name: "ArgumentParser", package: "swift-argument-parser")
-			],
-			path: "Demos/SwiftMCPDemo"
-		),
-		.executableTarget(
-			name: "SwiftMCPIntentsDemo",
-			dependencies: [
-				"SwiftMCP",
-				.product(name: "ArgumentParser", package: "swift-argument-parser")
-			],
-			path: "Demos/SwiftMCPIntentsDemo"
-		),
+		// NOTE: SwiftMCPDemo and SwiftMCPIntentsDemo executable targets are
+		// appended after the Package initializer, guarded by `#if !os(Windows)`,
+		// because they require the swift-nio-backed `Server` transports.
 		.executableTarget(
 			name: "SwiftMCPUtility",
 			dependencies: [
@@ -140,9 +144,9 @@ let package = Package(
 				"SwiftMCP",
 				"SwiftMCPUtilityCore",
 				.product(name: "SwiftCross", package: "SwiftCross"),
-				.product(name: "Crypto", package: "swift-crypto"),
-				.product(name: "_CryptoExtras", package: "swift-crypto"),
-				.product(name: "X509", package: "swift-certificates")
+				.product(name: "Crypto", package: "swift-crypto", condition: .when(traits: ["Server"])),
+				.product(name: "_CryptoExtras", package: "swift-crypto", condition: .when(traits: ["Server"])),
+				.product(name: "X509", package: "swift-certificates", condition: .when(traits: ["Server"]))
 			]
 		),
 		// MARK: - Prototype: per-instance @MCPExtension contributions
@@ -178,3 +182,35 @@ let package = Package(
 		)
 	]
 )
+
+// The SwiftMCPDemo / SwiftMCPIntentsDemo command-line servers use the
+// swift-nio-backed HTTP/SSE, stdio and TCP transports (the `Server` trait), so
+// they only build where swift-nio is available. swift-nio does not currently
+// compile on Windows, so these demo executables are omitted there — which lets
+// the package itself (library + tests) build and run with `--traits Client` /
+// `--traits Client,OpenAPI` on Windows. Library consumers never build these
+// demo products. Remove this guard once swift-nio builds on Windows.
+#if !os(Windows)
+package.products += [
+	.executable(name: "SwiftMCPDemo", targets: ["SwiftMCPDemo"]),
+	.executable(name: "SwiftMCPIntentsDemo", targets: ["SwiftMCPIntentsDemo"])
+]
+package.targets += [
+	.executableTarget(
+		name: "SwiftMCPDemo",
+		dependencies: [
+			"SwiftMCP",
+			.product(name: "ArgumentParser", package: "swift-argument-parser")
+		],
+		path: "Demos/SwiftMCPDemo"
+	),
+	.executableTarget(
+		name: "SwiftMCPIntentsDemo",
+		dependencies: [
+			"SwiftMCP",
+			.product(name: "ArgumentParser", package: "swift-argument-parser")
+		],
+		path: "Demos/SwiftMCPIntentsDemo"
+	)
+]
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,17 @@ let package = Package(
 			name: "JSONValue",
 			targets: ["JSONValue"]
 		),
-		// NOTE: the server demo CLIs (SwiftMCPDemo, SwiftMCPIntentsDemo) link
-		// swift-nio via the `Server` trait and are appended below only where
-		// swift-nio builds (everywhere except Windows). Library consumers never
-		// build these demo products regardless.
+		// The server demo CLIs run the swift-nio-backed transports under the
+		// `Server` trait; their transport code is gated `#if Server`, so with
+		// `Server` disabled they build as a no-op stub (no swift-nio).
+		.executable(
+			name: "SwiftMCPDemo",
+			targets: ["SwiftMCPDemo"]
+		),
+		.executable(
+			name: "SwiftMCPIntentsDemo",
+			targets: ["SwiftMCPIntentsDemo"]
+		),
 		.executable(
 			name: "SwiftMCPUtility",
 			targets: ["SwiftMCPUtility"]
@@ -109,9 +116,22 @@ let package = Package(
 				.product(name: "X509", package: "swift-certificates", condition: .when(traits: ["Server"]))
 			]
 		),
-		// NOTE: SwiftMCPDemo and SwiftMCPIntentsDemo executable targets are
-		// appended after the Package initializer, guarded by `#if !os(Windows)`,
-		// because they require the swift-nio-backed `Server` transports.
+		.executableTarget(
+			name: "SwiftMCPDemo",
+			dependencies: [
+				"SwiftMCP",
+				.product(name: "ArgumentParser", package: "swift-argument-parser")
+			],
+			path: "Demos/SwiftMCPDemo"
+		),
+		.executableTarget(
+			name: "SwiftMCPIntentsDemo",
+			dependencies: [
+				"SwiftMCP",
+				.product(name: "ArgumentParser", package: "swift-argument-parser")
+			],
+			path: "Demos/SwiftMCPIntentsDemo"
+		),
 		.executableTarget(
 			name: "SwiftMCPUtility",
 			dependencies: [
@@ -182,35 +202,3 @@ let package = Package(
 		)
 	]
 )
-
-// The SwiftMCPDemo / SwiftMCPIntentsDemo command-line servers use the
-// swift-nio-backed HTTP/SSE, stdio and TCP transports (the `Server` trait), so
-// they only build where swift-nio is available. swift-nio does not currently
-// compile on Windows, so these demo executables are omitted there — which lets
-// the package itself (library + tests) build and run with `--traits Client` /
-// `--traits Client,OpenAPI` on Windows. Library consumers never build these
-// demo products. Remove this guard once swift-nio builds on Windows.
-#if !os(Windows)
-package.products += [
-	.executable(name: "SwiftMCPDemo", targets: ["SwiftMCPDemo"]),
-	.executable(name: "SwiftMCPIntentsDemo", targets: ["SwiftMCPIntentsDemo"])
-]
-package.targets += [
-	.executableTarget(
-		name: "SwiftMCPDemo",
-		dependencies: [
-			"SwiftMCP",
-			.product(name: "ArgumentParser", package: "swift-argument-parser")
-		],
-		path: "Demos/SwiftMCPDemo"
-	),
-	.executableTarget(
-		name: "SwiftMCPIntentsDemo",
-		dependencies: [
-			"SwiftMCP",
-			.product(name: "ArgumentParser", package: "swift-argument-parser")
-		],
-		path: "Demos/SwiftMCPIntentsDemo"
-	)
-]
-#endif

--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ dependencies: [
 ]
 ```
 
+### Package traits
+
+SwiftMCP exposes its optional feature areas as [SwiftPM package traits](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/packagetraits/), **all enabled by default** — existing consumers and a plain `swift build` are unaffected. The single `import SwiftMCP` module is unchanged.
+
+| Trait | Enables | Extra dependencies |
+| --- | --- | --- |
+| `Server` | HTTP/SSE + TCP server transports | swift-nio, swift-crypto, swift-certificates |
+| `Client` | The MCP client (`MCPServerProxy`) | — |
+| `OpenAPI` | OpenAPI / AI-plugin manifest models and routes | — |
+
+The tool/schema foundation — `JSONValue`, `JSONSchema`, `MCPToolProviding`, the `@MCPTool` / `@MCPServer` macros, errors — is always-on core and needs no trait.
+
+Disabling `Server` drops swift-nio (and swift-crypto/swift-certificates) entirely, which makes the package **build on Windows** and gives client/tools-only consumers a lighter graph. A consumer that only talks to remote MCP servers selects just what it needs (your manifest must be `swift-tools-version: 6.1` or newer to choose traits):
+
+```swift
+.package(
+    url: "https://github.com/Cocoanetics/SwiftMCP.git",
+    branch: "main",
+    traits: ["Client"]   // tool/schema core + client, no swift-nio
+)
+```
+
+> AppIntents bridging (`@MCPAppIntentTool`, AppShortcuts discovery) is not a trait: it is already gated by `#if canImport(AppIntents)`, so it is automatically excluded on platforms without AppIntents (Linux, Windows, Android).
+
 ## Usage
 
 ### Command Line Demo

--- a/Sources/SwiftMCP/Client/AsyncSequence+SSE.swift
+++ b/Sources/SwiftMCP/Client/AsyncSequence+SSE.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, macCatalyst 15.0, *)
@@ -98,3 +99,4 @@ extension AsyncSequence where Element: StringProtocol {
         SSEMessageSequence(base: self)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/InProcessStdioBridge.swift
+++ b/Sources/SwiftMCP/Client/InProcessStdioBridge.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 import Dispatch
 
@@ -98,3 +99,4 @@ final class InProcessStdioBridge: StdioConnection, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPClientArgumentEncoder.swift
+++ b/Sources/SwiftMCP/Client/MCPClientArgumentEncoder.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Helpers for encoding client arguments into MCP tool payloads.
@@ -59,3 +60,4 @@ public enum MCPClientArgumentEncoder {
         .array(values.map { .string(String(describing: $0)) })
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPClientBlocking.swift
+++ b/Sources/SwiftMCP/Client/MCPClientBlocking.swift
@@ -1,3 +1,4 @@
+#if Client
 import Dispatch
 import Foundation
 
@@ -42,3 +43,4 @@ private final class ResultBox<T>: @unchecked Sendable {
         return value
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPClientResultDecoder.swift
+++ b/Sources/SwiftMCP/Client/MCPClientResultDecoder.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Decodes MCP tool call results into native Swift types.
@@ -204,3 +205,4 @@ public enum MCPClientResultDecoder {
         return decoder
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerConfig.swift
+++ b/Sources/SwiftMCP/Client/MCPServerConfig.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Configuration options for connecting to an MCP server.
@@ -14,3 +15,4 @@ public enum MCPServerConfig: Sendable {
     /// Connect to an MCP server via Server-Sent Events (SSE).
     case sse(config: MCPServerSseConfig)
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProcess.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProcess.swift
@@ -1,3 +1,4 @@
+#if Client
 #if os(macOS) || os(Linux)
 
 import Foundation
@@ -158,4 +159,5 @@ public final actor MCPServerProcess: StdioConnection {
     }
 }
 
+#endif
 #endif

--- a/Sources/SwiftMCP/Client/MCPServerProcess.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProcess.swift
@@ -1,7 +1,7 @@
 #if Client
-#if os(macOS) || os(Linux)
-
 import Foundation
+
+#if os(macOS) || os(Linux)
 
 /// Manages a stdio connection to an MCP server, optionally backed by a process.
 public final actor MCPServerProcess: StdioConnection {
@@ -120,8 +120,6 @@ public final actor MCPServerProcess: StdioConnection {
 }
 
 #else
-
-import Foundation
 
 /// Stub implementation for platforms where Process is unavailable.
 public final actor MCPServerProcess: StdioConnection {

--- a/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 extension MCPServerProxy {
@@ -178,3 +179,4 @@ extension MCPServerProxy {
         _ = try await send(request)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy+IncomingMessages.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+IncomingMessages.swift
@@ -1,3 +1,4 @@
+#if Client
 import SwiftCross
 
 extension MCPServerProxy {
@@ -168,3 +169,4 @@ extension MCPServerProxy {
         await handleNotification(notification)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
@@ -1,3 +1,4 @@
+#if Client
 import SwiftCross
 
 extension MCPServerProxy {
@@ -174,7 +175,7 @@ extension MCPServerProxy {
     internal func initialize(clientName: String, clientVersion: String) async throws {
         let requestId = nextRequestID()
         var params: JSONDictionary = [
-            "protocolVersion": .string(HTTPSSETransport.latestProtocolVersion),
+            "protocolVersion": .string(MCPProtocolVersion.latest),
             "clientInfo": .object([
                 "name": .string(clientName),
                 "version": .string(clientVersion)
@@ -274,3 +275,4 @@ extension MCPServerProxy {
         )
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy+NotificationHandlers.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+NotificationHandlers.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 extension MCPServerProxy {
@@ -66,3 +67,4 @@ extension MCPServerProxy {
         notificationHandlers.removeValue(forKey: method)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy+NotificationRegistration.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+NotificationRegistration.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 extension MCPServerProxy {
@@ -142,3 +143,4 @@ extension MCPServerProxy {
         return try decodeJSONPayload(params, as: payloadType)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy+ResponseHandling.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+ResponseHandling.swift
@@ -1,3 +1,4 @@
+#if Client
 import SwiftCross
 import Logging
 
@@ -207,3 +208,4 @@ extension MCPServerProxy {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy+SSE.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+SSE.swift
@@ -1,3 +1,4 @@
+#if Client
 import SwiftCross
 
 extension MCPServerProxy {
@@ -36,7 +37,7 @@ extension MCPServerProxy {
 
     internal func applyStreamableProtocolHeaders(_ request: inout URLRequest) {
         request.setValue(
-            HTTPSSETransport.latestProtocolVersion,
+            MCPProtocolVersion.latest,
             forHTTPHeaderField: "MCP-Protocol-Version"
         )
         if let sessionID {
@@ -308,3 +309,4 @@ extension MCPServerProxy {
         return components.url
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy+Send.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Send.swift
@@ -1,3 +1,4 @@
+#if Client
 import SwiftCross
 
 extension MCPServerProxy {
@@ -163,3 +164,4 @@ extension MCPServerProxy {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy+StreamableHTTP.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+StreamableHTTP.swift
@@ -1,3 +1,4 @@
+#if Client
 import SwiftCross
 
 extension MCPServerProxy {
@@ -209,3 +210,4 @@ extension MCPServerProxy {
         )
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -1,3 +1,4 @@
+#if Client
 import SwiftCross
 import Logging
 
@@ -152,3 +153,4 @@ extension JSONRPCID {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxyListChangedHandling.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxyListChangedHandling.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Implement to receive notifications when the server's tool list changes.
@@ -25,3 +26,4 @@ public protocol MCPServerProxyPromptsListChangedHandling: AnyObject, Sendable {
     ///   - proxy: The proxy that received the notification.
     func mcpServerProxyPromptsListDidChange(_ proxy: MCPServerProxy) async
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxyLogNotificationHandling.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxyLogNotificationHandling.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Implement to receive log notifications sent by the server.
@@ -5,3 +6,4 @@ public protocol MCPServerProxyLogNotificationHandling: AnyObject, Sendable {
     /// Called when the proxy receives a log notification from the server.
     func mcpServerProxy(_ proxy: MCPServerProxy, didReceiveLog message: LogMessage) async
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxyProgressNotificationHandling.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxyProgressNotificationHandling.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 // swiftlint:disable type_name
@@ -7,3 +8,4 @@ public protocol MCPServerProxyProgressNotificationHandling: AnyObject, Sendable 
     func mcpServerProxy(_ proxy: MCPServerProxy, didReceiveProgress progress: ProgressNotification) async
 }
 // swiftlint:enable type_name
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerProxyResourceNotificationHandling.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxyResourceNotificationHandling.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 // swiftlint:disable type_name
@@ -10,3 +11,4 @@ public protocol MCPServerProxyResourceNotificationHandling: AnyObject, Sendable 
     func mcpServerProxy(_ proxy: MCPServerProxy, resourceUpdatedAt uri: URL) async
 }
 // swiftlint:enable type_name
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerSseConfig.swift
+++ b/Sources/SwiftMCP/Client/MCPServerSseConfig.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Configuration for an MCP server using Server-Sent Events (SSE).
@@ -12,3 +13,4 @@ public struct MCPServerSseConfig: Codable, Equatable, Sendable {
         self.headers = headers
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerStdioConfig.swift
+++ b/Sources/SwiftMCP/Client/MCPServerStdioConfig.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Configuration for an MCP server using standard input/output.
@@ -18,3 +19,4 @@ public struct MCPServerStdioConfig: Codable, Equatable, Sendable {
         self.environment = environment
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPServerTcpConfig.swift
+++ b/Sources/SwiftMCP/Client/MCPServerTcpConfig.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Configuration for connecting to an MCP server via TCP.
@@ -39,9 +40,9 @@ public struct MCPServerTcpConfig: Sendable {
         if let serviceType {
             self.serviceType = serviceType
         } else if let serviceName {
-            self.serviceType = TCPBonjourTransport.serviceType(for: serviceName)
+            self.serviceType = MCPBonjourServiceType.forServer(serviceName)
         } else {
-            self.serviceType = TCPBonjourTransport.serviceType
+            self.serviceType = MCPBonjourServiceType.base
         }
         self.timeout = timeout
         self.preferIPv4 = preferIPv4
@@ -51,7 +52,7 @@ public struct MCPServerTcpConfig: Sendable {
     public init(
         host: String,
         port: UInt16,
-        serviceType: String = TCPBonjourTransport.serviceType,
+        serviceType: String = MCPBonjourServiceType.base,
         timeout: TimeInterval = 10,
         preferIPv4: Bool = true
     ) {
@@ -61,3 +62,4 @@ public struct MCPServerTcpConfig: Sendable {
         self.preferIPv4 = preferIPv4
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/MCPToolArgumentEncoder.swift
+++ b/Sources/SwiftMCP/Client/MCPToolArgumentEncoder.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 /// Helpers for encoding native values into MCP tool argument payloads.
@@ -37,3 +38,4 @@ public enum MCPToolArgumentEncoder {
         values.map(encode)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Client/SSEClientMessage.swift
+++ b/Sources/SwiftMCP/Client/SSEClientMessage.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 struct SSEClientMessage {
@@ -6,3 +7,4 @@ struct SSEClientMessage {
     let id: String?
     let retry: Int?
 }
+#endif

--- a/Sources/SwiftMCP/Client/StdioConnection.swift
+++ b/Sources/SwiftMCP/Client/StdioConnection.swift
@@ -1,3 +1,4 @@
+#if Client
 import Foundation
 
 protocol StdioConnection: Sendable {
@@ -6,3 +7,4 @@ protocol StdioConnection: Sendable {
     func write(_ data: Data) async
     func stop() async
 }
+#endif

--- a/Sources/SwiftMCP/Client/TCPConnection.swift
+++ b/Sources/SwiftMCP/Client/TCPConnection.swift
@@ -1,6 +1,7 @@
 #if Client
-#if canImport(Network)
 import Foundation
+
+#if canImport(Network)
 import Network
 import Logging
 
@@ -218,7 +219,6 @@ public final actor TCPConnection: StdioConnection {
     }
 }
 #else
-import Foundation
 
 /// Stub implementation for platforms without Network framework.
 public final actor TCPConnection: StdioConnection {

--- a/Sources/SwiftMCP/Client/TCPConnection.swift
+++ b/Sources/SwiftMCP/Client/TCPConnection.swift
@@ -1,3 +1,4 @@
+#if Client
 #if canImport(Network)
 import Foundation
 import Network
@@ -244,4 +245,5 @@ public final actor TCPConnection: StdioConnection {
     public func stop() async {
     }
 }
+#endif
 #endif

--- a/Sources/SwiftMCP/Extensions/JSONRPCMessage+Batch.swift
+++ b/Sources/SwiftMCP/Extensions/JSONRPCMessage+Batch.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NIOCore
 
 extension JSONRPCMessage {
     /// Decode a single or batched JSON-RPC payload from `Data`.
@@ -15,7 +14,12 @@ extension JSONRPCMessage {
             return [single]
         }
     }
+}
 
+#if Server
+import NIOCore
+
+extension JSONRPCMessage {
     /// Decode a single or batched JSON-RPC payload from a `ByteBuffer`.
     /// - Parameter buffer: Incoming buffer containing JSON data.
     static func decodeMessages(from buffer: ByteBuffer) throws -> [JSONRPCMessage] {
@@ -33,3 +37,4 @@ extension JSONRPCMessage {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Extensions/LineBuffer.swift
+++ b/Sources/SwiftMCP/Extensions/LineBuffer.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 /// Buffers bytes to return full newline-delimited lines.
+///
+/// Shared by both the client connections (`Client`) and the TCP server
+/// transport (`Server`), so it lives in the always-on core rather than behind
+/// a feature trait.
 actor LineBuffer {
     private var buffer = Data()
 

--- a/Sources/SwiftMCP/Models/MCPBonjourServiceType.swift
+++ b/Sources/SwiftMCP/Models/MCPBonjourServiceType.swift
@@ -1,0 +1,24 @@
+//
+//  MCPBonjourServiceType.swift
+//  SwiftMCP
+//
+//  DNS-SD / Bonjour service-type naming for MCP over TCP. These helpers live in
+//  the always-on core (not behind the `Server` trait) so the client-side
+//  `MCPServerTcpConfig` can derive default service types without linking the
+//  `TCPBonjourTransport` server transport.
+//
+
+import Foundation
+
+/// DNS-SD service-type naming for MCP over TCP.
+public enum MCPBonjourServiceType {
+    /// Base DNS-SD service type for MCP over TCP.
+    public static let base = "_mcp._tcp"
+
+    /// Returns a server-specific service type derived from the server name,
+    /// e.g. `"Post"` → `"_post-mcp._tcp"`. This prevents Bonjour collisions
+    /// between unrelated MCP servers on the same network.
+    public static func forServer(_ serverName: String) -> String {
+        "_\(serverName.lowercased())-mcp._tcp"
+    }
+}

--- a/Sources/SwiftMCP/Models/MCPProtocolVersion.swift
+++ b/Sources/SwiftMCP/Models/MCPProtocolVersion.swift
@@ -1,0 +1,30 @@
+//
+//  MCPProtocolVersion.swift
+//  SwiftMCP
+//
+//  The MCP protocol versions understood by this package. These constants live
+//  in the always-on core (not behind the `Server` trait) because both the
+//  server-runtime initialize handshake and the client (`MCPServerProxy`) need
+//  to negotiate the protocol version without linking the HTTP transport.
+//
+
+import Foundation
+
+/// Model Context Protocol revisions supported by SwiftMCP.
+public enum MCPProtocolVersion {
+    /// The most recent protocol revision advertised during initialization.
+    public static let latest = "2025-11-25"
+
+    /// Intermediate revision still accepted over the HTTP transport.
+    public static let intermediateHTTP = "2025-06-18"
+
+    /// Oldest revision still accepted over the HTTP transport.
+    public static let fallbackHTTP = "2025-03-26"
+
+    /// The full set of protocol revisions this package can negotiate.
+    public static let supported: Set<String> = [
+        latest,
+        intermediateHTTP,
+        fallbackHTTP
+    ]
+}

--- a/Sources/SwiftMCP/OpenAPI/AIPluginManifest.swift
+++ b/Sources/SwiftMCP/OpenAPI/AIPluginManifest.swift
@@ -1,3 +1,4 @@
+#if OpenAPI
 import Foundation
 
 /// Represents the AI plugin manifest structure
@@ -82,3 +83,4 @@ struct AIPluginManifest: Codable {
         let url: String
     }
 }
+#endif

--- a/Sources/SwiftMCP/OpenAPI/FileContent.swift
+++ b/Sources/SwiftMCP/OpenAPI/FileContent.swift
@@ -1,3 +1,4 @@
+#if OpenAPI
 //
 //  FileContent.swift
 //  SwiftMCP
@@ -41,3 +42,4 @@ public struct FileContent: Codable, Sendable {
         case content
     }
 }
+#endif

--- a/Sources/SwiftMCP/OpenAPI/OpenAIFileResponse.swift
+++ b/Sources/SwiftMCP/OpenAPI/OpenAIFileResponse.swift
@@ -1,3 +1,4 @@
+#if OpenAPI
 //
 //  OpenAIFileResponse.swift
 //  SwiftMCP
@@ -22,3 +23,4 @@ public struct OpenAIFileResponse: Codable, Sendable {
         self.openaiFileResponse = files
     }
 }
+#endif

--- a/Sources/SwiftMCP/OpenAPI/OpenAPISpec.swift
+++ b/Sources/SwiftMCP/OpenAPI/OpenAPISpec.swift
@@ -1,3 +1,4 @@
+#if OpenAPI
 import Foundation
 
 /// Represents an OpenAPI 3.1.0 specification
@@ -248,3 +249,4 @@ struct OpenAPISpec: Codable {
         ))
     }
 }
+#endif

--- a/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
@@ -16,8 +16,8 @@ public extension MCPServer {
     ) async -> JSONRPCMessage? {
         await Session.current?.markInitializeRequestReceived()
         let negotiatedProtocolVersion = request.params?["protocolVersion"]?.stringValue
-            ?? HTTPSSETransport.latestProtocolVersion
-        guard HTTPSSETransport.supportedProtocolVersions.contains(negotiatedProtocolVersion) else {
+            ?? MCPProtocolVersion.latest
+        guard MCPProtocolVersion.supported.contains(negotiatedProtocolVersion) else {
             return JSONRPCMessage.errorResponse(
                 id: request.id,
                 error: .init(code: -32602, message: "Unsupported protocol version: \(negotiatedProtocolVersion)")
@@ -69,7 +69,7 @@ public extension MCPServer {
      */
     func createInitializeResponse(
         id: JSONRPCID,
-        protocolVersion: String = "2025-11-25"
+        protocolVersion: String = MCPProtocolVersion.latest
     ) async -> JSONRPCMessage {
         let capabilities = await buildServerCapabilities()
 

--- a/Sources/SwiftMCP/Transport/Channel+SSE.swift
+++ b/Sources/SwiftMCP/Transport/Channel+SSE.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import NIOCore
 import NIOHTTP1
@@ -24,3 +25,4 @@ extension Channel {
         self.flush()
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/HTTPHandler.swift
+++ b/Sources/SwiftMCP/Transport/HTTPHandler.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 @preconcurrency import NIOCore
 import NIOHTTP1
@@ -292,3 +293,4 @@ final class HTTPHandler: NSObject, ChannelInboundHandler, Identifiable, @uncheck
         channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/HTTPLogger.swift
+++ b/Sources/SwiftMCP/Transport/HTTPLogger.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import Logging
 import NIOConcurrencyHelpers
@@ -160,3 +161,4 @@ final class HTTPLogger: ChannelDuplexHandler, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport+Authorize.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport+Authorize.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension HTTPSSETransport {
@@ -134,3 +135,4 @@ extension HTTPSSETransport {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport+Broadcasting.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport+Broadcasting.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension HTTPSSETransport {
@@ -29,3 +30,4 @@ extension HTTPSSETransport {
         await sessionManager.broadcastResourceUpdated(uri: uri)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport+KeepAlive.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport+KeepAlive.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension HTTPSSETransport {
@@ -51,3 +52,4 @@ extension HTTPSSETransport {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport+Routes.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport+Routes.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension HTTPSSETransport {
@@ -115,7 +116,9 @@ extension HTTPSSETransport {
         router.addRoutes(corsRoutes())
         router.addRoutes(mcpRoutes())
         router.addRoutes(legacySSERoutes())
+        #if OpenAPI
         router.addRoutes(openAPIRoutes())
+        #endif
         router.addRoutes(oauthRoutes())
 
         // Custom routes registered by the user
@@ -123,3 +126,4 @@ extension HTTPSSETransport {
         return router
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport+SSE.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport+SSE.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import NIOCore
 
@@ -64,3 +65,4 @@ extension HTTPSSETransport {
         await sessionManager.finishStream(streamID: streamID)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import Logging
 import NIOCore
@@ -96,15 +97,6 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
     var sseChannelCount: Int {
         get async { await sessionManager.channelCount }
     }
-
-    internal static let latestProtocolVersion = "2025-11-25"
-    internal static let intermediateHTTPProtocolVersion = "2025-06-18"
-    internal static let fallbackHTTPProtocolVersion = "2025-03-26"
-    internal static let supportedProtocolVersions: Set<String> = [
-        latestProtocolVersion,
-        intermediateHTTPProtocolVersion,
-        fallbackHTTPProtocolVersion
-    ]
 
     // MARK: - Initialization
 
@@ -222,3 +214,4 @@ public final class HTTPSSETransport: Transport, @unchecked Sendable {
         return TransportError.bindingFailed(errorMessage)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/Data+base64URLEncoded.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/Data+base64URLEncoded.swift
@@ -1,3 +1,4 @@
+#if Server
 //
 //  Data+base64URLEncoded.swift
 //  SwiftMCP
@@ -22,3 +23,4 @@ extension Data {
         self = decoded
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/DefaultJWSJWTPayload.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/DefaultJWSJWTPayload.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 
 public extension OAuthConfiguration {
@@ -33,3 +34,4 @@ public extension OAuthConfiguration {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/JSONWebKey.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/JSONWebKey.swift
@@ -1,3 +1,4 @@
+#if Server
 import Crypto
 import Foundation
 import X509
@@ -80,3 +81,4 @@ public struct JSONWebKey: Codable, Sendable {
     }
 }
 // swiftlint:enable identifier_name
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/JSONWebKeySet.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/JSONWebKeySet.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 import Crypto
 import _CryptoExtras
@@ -138,3 +139,4 @@ public struct JSONWebKeySet: Codable, Sendable {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/JSONWebToken.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/JSONWebToken.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 import Crypto
 import _CryptoExtras
@@ -333,3 +334,4 @@ public struct JSONWebToken: Sendable {
         return try verify(using: jwks, at: date, options: options)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/JWTTokenValidator.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/JWTTokenValidator.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 // MARK: - Convenience Token Validator
@@ -76,3 +77,4 @@ public struct JWTTokenValidator: Sendable {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/JWTValidationOptions.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/JWTValidationOptions.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// Validation options for JWT tokens
@@ -57,3 +58,4 @@ public struct JWTValidationOptions: Sendable {
         self.allowedClockSkew = allowedClockSkew
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/OAuthConfiguration+Auth0.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/OAuthConfiguration+Auth0.swift
@@ -1,3 +1,4 @@
+#if Server
 //
 //  OAuthConfiguration+Auth0.swift
 //  SwiftMCP
@@ -42,3 +43,4 @@ extension OAuthConfiguration {
         )
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/OAuthConfiguration+Extensions.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/OAuthConfiguration+Extensions.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 // swiftlint:disable identifier_name
@@ -11,3 +12,4 @@ internal struct OIDCWellKnownConfiguration: Decodable, Sendable {
     let registration_endpoint: URL?
 }
 // swiftlint:enable identifier_name
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/OAuthConfiguration.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/OAuthConfiguration.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 public enum OAuthConfigurationError: Error, LocalizedError {
@@ -16,3 +17,4 @@ public enum OAuthConfigurationError: Error, LocalizedError {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/OAuthConfigurationError.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/OAuthConfigurationError.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// Configuration structure that can be loaded from JSON files
@@ -97,3 +98,4 @@ public struct JSONOAuthConfiguration: Codable, Sendable {
         return try decoder.decode(JSONOAuthConfiguration.self, from: data)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/OAuthTokenResponse.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/OAuthTokenResponse.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// OAuth token response from the token endpoint
@@ -46,3 +47,4 @@ public struct OAuthTokenResponse: Codable, Sendable {
         case idToken = "id_token"
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/OAuth/OIDCWellKnownConfiguration.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/OIDCWellKnownConfiguration.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 
 /// Configuration for enabling OAuth validation on ``HTTPSSETransport``.
@@ -218,3 +219,4 @@ public struct OAuthConfiguration: Sendable {
         )
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/RequestContext.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext.swift
@@ -1,3 +1,12 @@
+//
+//  RequestContext.swift
+//  SwiftMCP
+//
+//  Part of the always-on server runtime (not behind the `Server` trait). The
+//  core `MCPServer` request-dispatch layer binds and reads
+//  `RequestContext.current`, so this type must compile without swift-nio.
+//
+
 import Foundation
 
 /// Represents the context of a single JSON-RPC message.

--- a/Sources/SwiftMCP/Transport/RequestState.swift
+++ b/Sources/SwiftMCP/Transport/RequestState.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import NIOCore
 import NIOHTTP1
@@ -13,3 +14,4 @@ enum RequestState {
     case streaming(head: HTTPRequestHead, continuation: AsyncStream<Data>.Continuation, bytesWritten: Int)
     case rejected
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/AsyncStream_Data+RouteBody.swift
+++ b/Sources/SwiftMCP/Transport/Routing/AsyncStream_Data+RouteBody.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension AsyncStream<Data>: RouteBody {
@@ -6,3 +7,4 @@ extension AsyncStream<Data>: RouteBody {
 		stream
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/CORSRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/CORSRoutes.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// CORS preflight route handler.
@@ -23,3 +24,4 @@ extension HTTPSSETransport {
 		]
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/HTTPRoute.swift
+++ b/Sources/SwiftMCP/Transport/Routing/HTTPRoute.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// A route definition for the HTTP router.
@@ -60,3 +61,4 @@ struct HTTPRoute: Sendable {
 		})
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/HTTPRouteRequest.swift
+++ b/Sources/SwiftMCP/Transport/Routing/HTTPRouteRequest.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// A transport-agnostic HTTP request.
@@ -49,3 +50,4 @@ public struct HTTPRouteRequest<Body: Sendable>: Sendable {
 		headers.first(where: { $0.0.caseInsensitiveCompare(name) == .orderedSame })?.1
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/HTTPRouteResponse+Data.swift
+++ b/Sources/SwiftMCP/Transport/Routing/HTTPRouteResponse+Data.swift
@@ -1,3 +1,4 @@
+#if Server
 //
 //  HTTPRouteResponse+Data.swift
 //  SwiftMCP
@@ -52,3 +53,4 @@ extension HTTPRouteResponse where Body == Data? {
 		HTTPRouteResponse(status: .accepted, body: nil)
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/HTTPRouteResponse+Stream.swift
+++ b/Sources/SwiftMCP/Transport/Routing/HTTPRouteResponse+Stream.swift
@@ -1,3 +1,4 @@
+#if Server
 //
 //  HTTPRouteResponse+Stream.swift
 //  SwiftMCP
@@ -46,3 +47,4 @@ extension HTTPRouteResponse where Body == AsyncStream<Data> {
 		)
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/HTTPRouteResponse.swift
+++ b/Sources/SwiftMCP/Transport/Routing/HTTPRouteResponse.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// A transport-agnostic HTTP response.
@@ -21,3 +22,4 @@ public struct HTTPRouteResponse<Body: Sendable>: Sendable {
 		self.body = body
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/HTTPStatus.swift
+++ b/Sources/SwiftMCP/Transport/Routing/HTTPStatus.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// HTTP status code, transport-agnostic (no NIO dependency).
@@ -26,3 +27,4 @@ public struct HTTPStatus: RawRepresentable, Sendable, Equatable {
 	public static let payloadTooLarge = HTTPStatus(rawValue: 413)
 	public static let internalServerError = HTTPStatus(rawValue: 500)
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// Legacy SSE protocol routes (`/sse`, `/messages/:sessionID`).
@@ -128,3 +129,4 @@ extension HTTPSSETransport {
 		return components.url
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes+SSE.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes+SSE.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension HTTPSSETransport {
@@ -199,3 +200,4 @@ extension HTTPSSETransport {
 		case internalError
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// New streamable HTTP MCP protocol routes (`/mcp`).
@@ -245,3 +246,4 @@ extension HTTPSSETransport {
 		}
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/NoRedirectDelegate.swift
+++ b/Sources/SwiftMCP/Transport/Routing/NoRedirectDelegate.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 
 // MARK: - URLSession Delegate
@@ -15,3 +16,4 @@ final class NoRedirectDelegate: NSObject, URLSessionTaskDelegate {
 		completionHandler(nil) // Don't follow redirects
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/OAuthRoutes+Proxy.swift
+++ b/Sources/SwiftMCP/Transport/Routing/OAuthRoutes+Proxy.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 
 extension HTTPSSETransport {
@@ -256,3 +257,4 @@ extension HTTPSSETransport {
 		return responseHeaders
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/OAuthRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/OAuthRoutes.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 
 /// OAuth route handlers: authorization server metadata, protected resource metadata,
@@ -166,3 +167,4 @@ extension HTTPSSETransport {
 		return "\(scheme)://\(host)"
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/OpenAPIRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/OpenAPIRoutes.swift
@@ -1,3 +1,4 @@
+#if Server && OpenAPI
 import Foundation
 
 /// OpenAPI-related route handlers: AI plugin manifest, OpenAPI spec, and tool call endpoint.
@@ -245,3 +246,4 @@ extension HTTPSSETransport {
 		return RouteResponse(status: status, headers: [("Content-Type", "application/json")], body: data)
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/Optional+RouteBody.swift
+++ b/Sources/SwiftMCP/Transport/Routing/Optional+RouteBody.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension Optional: RouteBody where Wrapped == Data {
@@ -10,3 +11,4 @@ extension Optional: RouteBody where Wrapped == Data {
 		return collected.isEmpty ? nil : collected
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/RouteBody.swift
+++ b/Sources/SwiftMCP/Transport/Routing/RouteBody.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// Protocol for types that can serve as the body of an `HTTPRouteRequest`.
@@ -9,3 +10,4 @@ protocol RouteBody: Sendable {
 	/// Prepare the body value from the raw body chunk stream.
 	static func collect(from stream: AsyncStream<Data>) async -> Self
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/RouteMatch.swift
+++ b/Sources/SwiftMCP/Transport/Routing/RouteMatch.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// Result of a successful route match.
@@ -5,3 +6,4 @@ struct RouteMatch: Sendable {
 	let route: HTTPRoute
 	let pathParams: [String: String]
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/RouteMethod.swift
+++ b/Sources/SwiftMCP/Transport/Routing/RouteMethod.swift
@@ -1,6 +1,8 @@
+#if Server
 import Foundation
 
 /// HTTP method enum, transport-agnostic (no NIO dependency).
 public enum RouteMethod: String, Sendable, CaseIterable {
 	case GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/RouteResponse.swift
+++ b/Sources/SwiftMCP/Transport/Routing/RouteResponse.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// Internal response type that can carry either buffered data or a stream.
@@ -61,3 +62,4 @@ struct RouteResponse: Sendable {
 		return RouteResponse(status: status, headers: headers, body: data)
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/Router.swift
+++ b/Sources/SwiftMCP/Transport/Routing/Router.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// Simple linear-scan HTTP router with path parameter extraction.
@@ -73,3 +74,4 @@ final class Router: @unchecked Sendable {
 		return params
 	}
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
+++ b/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension HTTPSSETransport {
@@ -46,7 +47,7 @@ extension HTTPSSETransport {
         sessionID: UUID?
     ) async -> RouteResponse? {
         if let headerVersion = request.header("MCP-Protocol-Version") {
-            guard HTTPSSETransport.supportedProtocolVersions.contains(headerVersion) else {
+            guard MCPProtocolVersion.supported.contains(headerVersion) else {
                 return textResponse(status: .badRequest, body: "Invalid or unsupported MCP-Protocol-Version header.")
             }
 
@@ -72,7 +73,7 @@ extension HTTPSSETransport {
         sessionID: UUID?
     ) async -> String {
         if let headerVersion = request.header("MCP-Protocol-Version"),
-           HTTPSSETransport.supportedProtocolVersions.contains(headerVersion) {
+           MCPProtocolVersion.supported.contains(headerVersion) {
             return headerVersion
         }
 
@@ -82,7 +83,7 @@ extension HTTPSSETransport {
             return negotiatedVersion
         }
 
-        return HTTPSSETransport.fallbackHTTPProtocolVersion
+        return MCPProtocolVersion.fallbackHTTP
     }
 
     func bindBearerTokenIfNeeded(_ token: String?, to sessionID: UUID) async {
@@ -124,3 +125,4 @@ extension HTTPSSETransport {
         return RouteResponse(status: status, headers: headers, body: Data(body.utf8))
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/SSEEvent.swift
+++ b/Sources/SwiftMCP/Transport/SSEEvent.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// Represents the different types of SSE content as defined by the ABNF specification
@@ -8,3 +9,4 @@ enum SSEEvent {
     /// A field with name and value
     case field(name: String, value: String, eventName: String? = nil)
 }
+#endif

--- a/Sources/SwiftMCP/Transport/SSEMessage.swift
+++ b/Sources/SwiftMCP/Transport/SSEMessage.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /// A Server-Sent Events (SSE) message
@@ -116,3 +117,4 @@ struct SSEMessage: LosslessStringConvertible {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/SSEStreamTypes.swift
+++ b/Sources/SwiftMCP/Transport/SSEStreamTypes.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 enum SSEStreamKind: Sendable {
@@ -24,3 +25,4 @@ struct StreamRouteResponseInfo: Sendable {
     let sessionID: UUID
     let streamID: UUID
 }
+#endif

--- a/Sources/SwiftMCP/Transport/Session+Extensions.swift
+++ b/Sources/SwiftMCP/Transport/Session+Extensions.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NIO
 
 extension Session {
     /// Send a progress notification to the client associated with this session.

--- a/Sources/SwiftMCP/Transport/Session.swift
+++ b/Sources/SwiftMCP/Transport/Session.swift
@@ -1,5 +1,18 @@
+//
+//  Session.swift
+//  SwiftMCP
+//
+//  Part of the always-on server *runtime* (not behind the `Server` trait): the
+//  `@MCPServer` macro is core, and the `MCPServer` request-dispatch layer it
+//  relies on accesses `Session.current`, so `Session` must compile without
+//  swift-nio. Only the HTTP/SSE-specific members (the NIO `channel`, SSE
+//  continuation, stream context) are gated behind `#if Server`.
+//
+
 import Foundation
+#if Server
 import NIO
+#endif
 
 /// Represents a connection session.
 ///
@@ -12,6 +25,7 @@ public actor Session {
     /// The transport associated with this session. Weak to avoid retain cycles.
     public weak var transport: (any Transport)?
 
+    #if Server
     /// The SSE channel associated with this session, if any.
     public var channel: Channel?
 
@@ -19,6 +33,7 @@ public actor Session {
     /// When set, `sendSSE` yields formatted event data into this stream
     /// instead of writing directly to the NIO channel.
     var sseContinuation: AsyncStream<Data>.Continuation?
+    #endif
 
     // MARK: - Request/Response Tracking
     /// Continuations for sent requests, to match up responses
@@ -70,28 +85,39 @@ public actor Session {
     /// Optional expiry deadline used for retained sessions after disconnect.
     public var expiresAt: Date?
 
+    #if Server
     /// Creates a new session.
     /// - Parameters:
     ///   - id: The unique session identifier.
+    ///   - channel: The SSE channel associated with this session, if any.
     public init(id: UUID, channel: Channel? = nil) {
         self.id = id
         self.channel = channel
     }
+    #else
+    /// Creates a new session.
+    /// - Parameter id: The unique session identifier.
+    public init(id: UUID) {
+        self.id = id
+    }
+    #endif
 
     @TaskLocal
     internal static var taskSession: Session?
-
-    @TaskLocal
-    internal static var taskStreamContext: OutboundStreamContext?
 
     /// Accessor for the current session stored in task local storage.
     public static var current: Session! {
         taskSession
     }
 
+    #if Server
+    @TaskLocal
+    internal static var taskStreamContext: OutboundStreamContext?
+
     internal static var currentStreamContext: OutboundStreamContext? {
         taskStreamContext
     }
+    #endif
 
     /// Runs `operation` with this session bound to `Session.current`.
     public func work<T: Sendable>(_ operation: @Sendable (Session) async throws -> T) async rethrows -> T {
@@ -100,6 +126,7 @@ public actor Session {
         }
     }
 
+    #if Server
     /// Runs `operation` with this session and an outbound stream context bound.
     internal func work<T: Sendable>(
         onStream streamContext: OutboundStreamContext?,
@@ -132,6 +159,7 @@ public actor Session {
     func setSSEContinuation(_ continuation: AsyncStream<Data>.Continuation?) {
         self.sseContinuation = continuation
     }
+    #endif
 
     // MARK: - Convenience Mutators
 
@@ -152,10 +180,12 @@ public actor Session {
         self.transport = transport
     }
 
+    #if Server
     /// Update the channel associated with this session.
     public func setChannel(_ channel: Channel?) {
         self.channel = channel
     }
+    #endif
 
     /// Update the userInfo stored for this session.
     public func setUserInfo(_ info: UserInfo?) {

--- a/Sources/SwiftMCP/Transport/SessionManager+Broadcasting.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+Broadcasting.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension SessionManager {
@@ -148,3 +149,4 @@ extension SessionManager {
         _ = await sendSSE(SSEMessage(data: "", id: eventID), to: streamID)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/SessionManager+EventID.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+EventID.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension SessionManager {
@@ -22,3 +23,4 @@ extension SessionManager {
         "\(streamID.uuidString):\(sequence)"
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/SessionManager+Sessions.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+Sessions.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 extension SessionManager {
@@ -157,3 +158,4 @@ extension SessionManager {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/SessionManager+Streams.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+Streams.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import NIO
 
@@ -259,3 +260,4 @@ extension SessionManager {
         }
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/SessionManager.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import NIO
 
@@ -55,3 +56,4 @@ actor SessionManager {
         Array(sessions.keys)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/StdioTransport.swift
+++ b/Sources/SwiftMCP/Transport/StdioTransport.swift
@@ -1,3 +1,4 @@
+#if Server
 #if canImport(Glibc)
 @preconcurrency import Glibc
 #endif
@@ -174,3 +175,4 @@ public final class StdioTransport: Transport, @unchecked Sendable {
         try FileHandle.standardOutput.write(contentsOf: out)
     }
 }
+#endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Broadcasting.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Broadcasting.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 #if canImport(Network)
@@ -29,4 +30,5 @@ extension TCPBonjourTransport {
         await sessionManager.broadcastResourceUpdated(uri: uri)
     }
 }
+#endif
 #endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 #if canImport(Network)
@@ -123,4 +124,5 @@ extension TCPBonjourTransport {
         }
     }
 }
+#endif
 #endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Lifecycle.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Lifecycle.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 #if canImport(Network)
@@ -54,4 +55,5 @@ extension TCPBonjourTransport {
         }
     }
 }
+#endif
 #endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Listener.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Listener.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 #if canImport(Network)
@@ -127,4 +128,5 @@ extension TCPBonjourTransport {
         }
     }
 }
+#endif
 #endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import Logging
 
@@ -7,13 +8,13 @@ import Network
 /// A TCP transport that advertises via Bonjour and exchanges newline-delimited JSON-RPC.
 public final class TCPBonjourTransport: Transport, @unchecked Sendable {
     /// Base DNS-SD service type for MCP over TCP.
-    public static let serviceType = "_mcp._tcp"
+    public static let serviceType = MCPBonjourServiceType.base
 
     /// Returns a server-specific service type derived from the server name,
     /// e.g. `"Post"` → `"_post-mcp._tcp"`.  This prevents Bonjour collisions
     /// between unrelated MCP servers on the same network.
     public static func serviceType(for serverName: String) -> String {
-        "_\(serverName.lowercased())-mcp._tcp"
+        MCPBonjourServiceType.forServer(serverName)
     }
 
     public let server: MCPServer
@@ -181,12 +182,12 @@ import Logging
 /// Stub implementation for platforms without Network framework.
 public final class TCPBonjourTransport: Transport, @unchecked Sendable {
     /// Base DNS-SD service type for MCP over TCP.
-    public static let serviceType = "_mcp._tcp"
+    public static let serviceType = MCPBonjourServiceType.base
 
     /// Returns a server-specific service type derived from the server name,
     /// e.g. `"Post"` → `"_post-mcp._tcp"`.
     public static func serviceType(for serverName: String) -> String {
-        "_\(serverName.lowercased())-mcp._tcp"
+        MCPBonjourServiceType.forServer(serverName)
     }
 
     public let server: MCPServer
@@ -245,4 +246,5 @@ public final class TCPBonjourTransport: Transport, @unchecked Sendable {
     public func send(_ data: Data) async throws {
     }
 }
+#endif
 #endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
@@ -176,8 +176,6 @@ public final class TCPBonjourTransport: Transport, @unchecked Sendable {
     }
 }
 #else
-import Foundation
-import Logging
 
 /// Stub implementation for platforms without Network framework.
 public final class TCPBonjourTransport: Transport, @unchecked Sendable {

--- a/Sources/SwiftMCP/Transport/TransportError.swift
+++ b/Sources/SwiftMCP/Transport/TransportError.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 
 /**
@@ -27,3 +28,4 @@ public enum TransportError: LocalizedError {
         }
     }
 }
+#endif

--- a/Tests/SwiftMCPTests/HTTPHandlerHeaderTests.swift
+++ b/Tests/SwiftMCPTests/HTTPHandlerHeaderTests.swift
@@ -1,3 +1,4 @@
+#if Server
 import Testing
 import SwiftCross
 @testable import SwiftMCP
@@ -47,3 +48,4 @@ struct HTTPHandlerHeaderTests {
         #expect(values(named: "Content-Type", in: headers).isEmpty)
     }
 }
+#endif

--- a/Tests/SwiftMCPTests/HTTPTransportLegacySSETests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportLegacySSETests.swift
@@ -1,3 +1,4 @@
+#if Server
 // swiftlint:disable force_cast
 // Test-only: HTTP responses are known to be HTTPURLResponse.
 
@@ -82,3 +83,4 @@ struct HTTPTransportLegacySSETests {
     }
 }
 // swiftlint:enable force_cast
+#endif

--- a/Tests/SwiftMCPTests/HTTPTransportOpenAPITests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportOpenAPITests.swift
@@ -1,3 +1,4 @@
+#if Server && OpenAPI
 // swiftlint:disable force_cast
 // Test-only: HTTP responses are known to be HTTPURLResponse.
 
@@ -240,3 +241,4 @@ struct HTTPTransportOpenAPITests {
     }
 }
 // swiftlint:enable force_cast
+#endif

--- a/Tests/SwiftMCPTests/HTTPTransportResumeTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportResumeTests.swift
@@ -1,3 +1,4 @@
+#if Server
 // Test-only: HTTP responses are known to be HTTPURLResponse.
 
 import Testing
@@ -145,3 +146,4 @@ struct HTTPTransportResumeTests {
         #endif
     }
 }
+#endif

--- a/Tests/SwiftMCPTests/HTTPTransportTestHelpers.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTestHelpers.swift
@@ -1,3 +1,4 @@
+#if Server
 // Shared HTTP transport test helpers.
 
 import Testing
@@ -193,3 +194,4 @@ enum HTTPTransportTestHelpers {
         }
     }
 }
+#endif

--- a/Tests/SwiftMCPTests/HTTPTransportTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTests.swift
@@ -1,3 +1,4 @@
+#if Server
 // swiftlint:disable force_cast
 // Test-only: HTTP responses are known to be `HTTPURLResponse` and decoded JSON
 // payloads are known shapes. Force casts keep test code direct and readable.
@@ -228,3 +229,4 @@ struct HTTPTransportTests {
 
 }
 // swiftlint:enable force_cast
+#endif

--- a/Tests/SwiftMCPTests/JSONWebTokenTests.swift
+++ b/Tests/SwiftMCPTests/JSONWebTokenTests.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import Testing
 @testable import SwiftMCP
@@ -242,3 +243,4 @@ struct JSONWebTokenTests {
         #expect(jwt.payload.aud != nil)
     }
 }
+#endif

--- a/Tests/SwiftMCPTests/JWTSignatureVerificationTests.swift
+++ b/Tests/SwiftMCPTests/JWTSignatureVerificationTests.swift
@@ -1,3 +1,4 @@
+#if Server
 import SwiftCross
 import Testing
 import Crypto
@@ -136,3 +137,4 @@ struct JWTSignatureVerificationTests {
         #expect(isValid == true)
     }
 }
+#endif

--- a/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
@@ -1,3 +1,4 @@
+#if Server
 import Testing
 import SwiftCross
 @testable import SwiftMCP
@@ -139,3 +140,4 @@ private actor ToolsListChangedCapture: MCPServerProxyToolsListChangedHandling {
         count += 1
     }
 }
+#endif

--- a/Tests/SwiftMCPTests/MCPServerProxyTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerProxyTests.swift
@@ -290,7 +290,13 @@ private func repositoryRootPath() -> String {
 }
 
 private func isLocalSwiftMCPDemoAvailable() -> Bool {
-    localSwiftMCPDemoExecutable() != nil
+    #if Server
+    return localSwiftMCPDemoExecutable() != nil
+    #else
+    // Without the `Server` trait the SwiftMCPDemo executable is a no-op stub
+    // (no transport), so there is no local server to connect to.
+    return false
+    #endif
 }
 
 private func localSwiftMCPDemoExecutable() -> String? {

--- a/Tests/SwiftMCPTests/OAuthTests.swift
+++ b/Tests/SwiftMCPTests/OAuthTests.swift
@@ -1,3 +1,4 @@
+#if Server
 import Foundation
 import Testing
 @testable import SwiftMCP
@@ -199,3 +200,4 @@ struct OAuthTests {
         #expect(tokenResponse.idToken == nil)
     }
 }
+#endif

--- a/Tests/SwiftMCPTests/RouterTests.swift
+++ b/Tests/SwiftMCPTests/RouterTests.swift
@@ -1,3 +1,4 @@
+#if Server
 import Testing
 import Foundation
 @testable import SwiftMCP
@@ -192,3 +193,4 @@ struct RouterTests {
 		#expect(router.match(method: .POST, path: "/mcp/downloads/abc") == nil)
 	}
 }
+#endif

--- a/Tests/SwiftMCPTests/StreamingRouteTests.swift
+++ b/Tests/SwiftMCPTests/StreamingRouteTests.swift
@@ -1,3 +1,4 @@
+#if Server
 import Testing
 import Foundation
 @testable import SwiftMCP
@@ -146,3 +147,4 @@ struct StreamingRouteTests {
 		#expect(receivedAuth.value == "my-token")
 	}
 }
+#endif


### PR DESCRIPTION
Closes #128.

## Motivation

The `SwiftMCP` library linked swift-nio + swift-crypto + swift-certificates **unconditionally** — but those are used only by the HTTP/SSE server transport. Every consumer (even one using only `JSONValue`, the `@MCPTool`/`@MCPServer` macros, or the client `MCPServerProxy`) was forced to compile swift-nio, which **doesn't build on Windows**, blocking otherwise-portable downstream packages (found making [Cocoanetics/SwiftAgents#17](https://github.com/Cocoanetics/SwiftAgents/issues/17) cross-platform).

## What changed

SwiftPM **package traits**, all enabled by default — so existing consumers and a plain `swift build` / `swift test` are unaffected, and `import SwiftMCP` is unchanged:

| Trait | Enables | Extra deps |
|---|---|---|
| `Server` | HTTP/SSE + TCP transports | swift-nio, swift-crypto, swift-certificates |
| `Client` | the MCP client (`MCPServerProxy`) | — |
| `OpenAPI` | OpenAPI / AI-plugin models + routes | — |

The NIO/crypto deps are gated with `condition: .when(traits: ["Server"])`; source is gated with `#if Server` / `#if Client` / `#if OpenAPI`. A client-only consumer (`traits: ["Client"]`) drops swift-nio entirely → **builds on Windows**, lighter graph, faster builds.

## Key design decision: the server *runtime* stays NIO-free core

The issue framed it as "`Transport/` → `#if Server`", but `@MCPServer` (which must stay core) attaches `MCPServer` conformance whose `handleMessage` dispatch reads `Session.current` / `RequestContext.current`. So the **request-dispatch layer + `Session` + `RequestContext` are made NIO-free and kept in core** — only the genuine HTTP/SSE networking is behind `Server` (the runtime was already nearly NIO-free; `Session`'s only NIO bits — the `channel`, SSE continuation, stream context — are now `#if Server`). Shared constants moved to core (`MCPProtocolVersion`, `MCPBonjourServiceType`); `LineBuffer` (shared by the client and the TCP server) moved out of `Client/`.

## AppIntents is intentionally *not* a trait

`@MCPServer`/`@MCPAppIntentTool` expand to code in the **consumer's** module that references the AppIntents glue under `#if canImport(AppIntents)`. Package-trait conditions aren't visible in consumer modules, so a trait can't gate that surface — and `canImport(AppIntents)` already excludes it on Linux/Windows/Android.

## Non-server tests on Windows

- Server-dependent test files are `#if Server`-gated (HTTP transport, OAuth/JWT, routing, streaming).
- `swift test` builds *all* products, so the two swift-nio-backed demo CLIs (`SwiftMCPDemo`, `SwiftMCPIntentsDemo`) are appended under `#if !os(Windows)` in `Package.swift` (the manifest is compiled on the build host). Library consumers never build these demo products regardless.

## CI

- `build-traits` (Linux): builds `--disable-default-traits` and `--traits Client`.
- `windows-client` (Windows): a **real** (non `continue-on-error`) check that builds the library `--traits Client` and runs `swift test --traits Client,OpenAPI`. If swift-nio ever leaks back into core/client, or a non-server test regresses, it goes red. The full `build-windows` job stays aspirational until swift-nio builds on Windows.

## Verification

- All 8 trait combinations build (`swift build --target SwiftMCP --traits …`).
- A **clean Client-only build compiles zero** swift-nio / crypto / atomics modules.
- **421 tests** pass on the default config; **348** non-server tests pass in the NIO-free config (the 73-test gap is exactly the Server suites).

## Reviewer notes

- `Session.swift` / `RequestContext.swift` live in `Transport/` but are intentionally **not** gated (header comments explain why) — they're the transport-agnostic core runtime.
- Sharp edge: `@MCPServer(generateClient: true)` (the default) emits a `Client` referencing `MCPServerProxy`, so it requires the `Client` trait; use `generateClient: false` if `Client` is disabled.
- One thing not verifiable without a Windows runner: `swift test` on Windows also builds the other NIO-free demos and the swift-syntax-based `SwiftMCPAggregator` build-tool plugin. Those are cross-platform, so they should build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)