### PR TITLE
Fix red main + harden CI: Sendable fixtures, async MCPLoggingProviding, Windows/Android CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -51,14 +51,21 @@ jobs:
       - name: Test (Linux)
         run: swift test -v --skip-build
 
-  # Aspirational platform: swift-nio (NIOPosix) does not currently compile on
-  # Windows (IPPROTO / Sendable errors in System.swift, Thread.swift,
-  # ThreadWindows.swift) — an upstream issue, not in SwiftMCP. The Build/Test
-  # steps use step-level `continue-on-error` so the job's *check* reports green
-  # and does not block merges (a job-level flag leaves the check red, which
-  # branch protection still blocks on). Unexpected failures in other steps
-  # (e.g. toolchain setup) still surface. Remove the per-step flags once
-  # swift-nio builds on Windows. See https://github.com/apple/swift-nio.
+  # Windows runs in two parts within a single job:
+  #
+  # 1. Real, enforced (no `continue-on-error`): the NIO-free configuration
+  #    (`Server` trait off, so no swift-nio in the graph — the server demo CLIs
+  #    are gated `#if Server` and compile to a no-op stub) builds AND tests on
+  #    Windows today. If swift-nio ever leaks back into the core/client, or a
+  #    non-server test regresses on Windows, these steps fail the job.
+  #
+  # 2. Aspirational (`continue-on-error`): the full, default-traits build pulls
+  #    swift-nio (NIOPosix), which does not currently compile on Windows
+  #    (IPPROTO / Sendable errors in System.swift, Thread.swift,
+  #    ThreadWindows.swift — an upstream issue, not in SwiftMCP). These steps
+  #    stay visible without failing the job; drop the two `continue-on-error`
+  #    flags once swift-nio builds on Windows. See
+  #    https://github.com/apple/swift-nio.
   build-windows:
     runs-on: windows-latest
     timeout-minutes: 45
@@ -70,10 +77,14 @@ jobs:
           swift-version: "6.3.1"
       - name: Verify Swift version
         run: swift --version
-      - name: Build (Windows)
+      - name: Build SwiftMCP library — Client trait only (no swift-nio)
+        run: swift build --target SwiftMCP --traits Client
+      - name: Test — non-server suite (Client + OpenAPI, no swift-nio)
+        run: swift test --traits "Client,OpenAPI"
+      - name: Build — full (default traits, with swift-nio)
         run: swift build --build-tests -v
         continue-on-error: true
-      - name: Test (Windows)
+      - name: Test — full (default traits)
         run: swift test -v --skip-build
         continue-on-error: true
 
@@ -97,29 +108,6 @@ jobs:
         run: swift build --target SwiftMCP --traits Client
       - name: Build whole package — Client + OpenAPI (no swift-nio)
         run: swift build --traits "Client,OpenAPI"
-      - name: Test — non-server suite (Client + OpenAPI, no swift-nio)
-        run: swift test --traits "Client,OpenAPI"
-
-  # Windows DOES build AND test the NIO-free configuration. With the `Server`
-  # trait disabled there is no swift-nio in the graph (the server demo CLIs are
-  # gated `#if Server` and compile to a no-op stub), so `swift test` builds the
-  # library plus the non-server test suite. These are real (non continue-on-error)
-  # checks: if swift-nio ever leaks back into the core/client, or a non-server
-  # test regresses, this job goes red. The full `build-windows` job above stays
-  # aspirational until swift-nio itself builds on Windows.
-  windows-client:
-    runs-on: windows-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v6
-      - name: Setup Swift
-        uses: SwiftyLab/setup-swift@latest
-        with:
-          swift-version: "6.3.1"
-      - name: Verify Swift version
-        run: swift --version
-      - name: Build SwiftMCP library — Client trait only (no swift-nio)
-        run: swift build --target SwiftMCP --traits Client
       - name: Test — non-server suite (Client + OpenAPI, no swift-nio)
         run: swift test --traits "Client,OpenAPI"
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -111,12 +111,20 @@ jobs:
       - name: Test — non-server suite (Client + OpenAPI, no swift-nio)
         run: swift test --traits "Client,OpenAPI"
 
+  # A normal Android run (build + emulator boot + test) finishes in ~8 min. But
+  # when a test FAILS, swift-android-action's emulator teardown can hang
+  # (`adb emu kill` → "stop: Not implemented"), so a fast test failure would
+  # otherwise run out the whole job timeout and report as a confusing
+  # "cancelled". Bound the action with a step-level timeout so a failure (or a
+  # hung teardown) surfaces as a red check in ~25 min, and keep the job timeout
+  # just above it.
   build-android:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Build & test (Android emulator)
+        timeout-minutes: 25
         uses: skiptools/swift-android-action@v2
         with:
           swift-version: "6.3.2"

--- a/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
@@ -22,10 +22,11 @@ extension MCPServerProxy {
         // create a new one. (#125)
         sessionID = nil
 
-        // Cancel any stream left over from a previous connection so reconnecting
-        // on the same proxy doesn't leave a second general-SSE loop running.
-        streamTask?.cancel()
-        streamTask = nil
+        // Retire any stream left over from a previous connection: cancel it and
+        // advance the generation so reconnecting on the same proxy neither leaves
+        // a second general-SSE loop running nor lets that stale loop's eventual
+        // `handleStreamTermination` fail this connection's requests. (#125)
+        retireStream()
 
         switch config {
         case .stdio(let stdioConfig):
@@ -97,8 +98,7 @@ extension MCPServerProxy {
             endpointContinuation.resume(throwing: disconnectError)
         }
 
-        streamTask?.cancel()
-        streamTask = nil
+        retireStream()
         endpointURL = nil
 
         switch config {
@@ -118,6 +118,7 @@ extension MCPServerProxy {
         }
         try await lineConnection.start()
 
+        let generation = streamGeneration
         streamTask = Task {
             do {
                 let lines = await lineConnection.lines()
@@ -127,13 +128,14 @@ extension MCPServerProxy {
                 self.handleStreamTermination(
                     MCPServerProxyError.communicationError(
                         "Connection closed by server before response was received"
-                    )
+                    ),
+                    generation: generation
                 )
             } catch is CancellationError {
                 // Pending requests are cancelled in disconnect().
             } catch {
                 logger.error("[MCP DEBUG] Stream error: \(error.localizedDescription)")
-                self.handleStreamTermination(error)
+                self.handleStreamTermination(error, generation: generation)
             }
         }
     }
@@ -147,7 +149,22 @@ extension MCPServerProxy {
         }
     }
 
-    internal func handleStreamTermination(_ error: Error) {
+    /// Retire the active stream task: cancel it and advance the generation so a
+    /// late `handleStreamTermination` from the now-stale task is ignored.
+    internal func retireStream() {
+        streamTask?.cancel()
+        streamTask = nil
+        streamGeneration += 1
+    }
+
+    internal func handleStreamTermination(_ error: Error, generation: Int) {
+        // Ignore terminations from a stream that has since been retired by a
+        // reconnect or disconnect. Without this, a leftover general-SSE loop that
+        // hits the server's "unknown session" 404 would fail the requests of the
+        // connection that replaced it (e.g. a reconnect's `initialize`). (#125)
+        guard generation == streamGeneration else {
+            return
+        }
         guard !isDisconnecting else {
             return
         }

--- a/Sources/SwiftMCP/Client/MCPServerProxy+SSE.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+SSE.swift
@@ -102,6 +102,7 @@ extension MCPServerProxy {
         request.httpMethod = "GET"
         configureSSEGETRequest(&request, sseConfig: sseConfig)
 
+        let generation = streamGeneration
         streamTask = Task {
             do {
                 let (asyncBytes, response) = try await session.bytes(for: request)
@@ -117,13 +118,14 @@ extension MCPServerProxy {
                 self.handleStreamTermination(
                     MCPServerProxyError.communicationError(
                         "SSE stream closed by server before response was received"
-                    )
+                    ),
+                    generation: generation
                 )
             } catch is CancellationError {
                 // Pending requests are cancelled in disconnect().
             } catch {
                 self.logger.error("[MCP DEBUG] SSE stream error: \(error)")
-                self.handleStreamTermination(error)
+                self.handleStreamTermination(error, generation: generation)
             }
         }
 
@@ -135,6 +137,7 @@ extension MCPServerProxy {
 
     // swiftlint:disable:next function_body_length
     internal func startStreamableGeneralSSE(sseConfig: MCPServerSseConfig) {
+        let generation = streamGeneration
         streamTask = Task {
             var lastEventID: String?
             var retryMilliseconds = 1000
@@ -180,7 +183,10 @@ extension MCPServerProxy {
                             self.logger.error(
                                 "[MCP DEBUG] Streamable general SSE session invalidated by server (HTTP 404)"
                             )
-                            self.handleStreamTermination(MCPServerProxyError.sessionInvalidated)
+                            self.handleStreamTermination(
+                                MCPServerProxyError.sessionInvalidated,
+                                generation: generation
+                            )
                             return
                         }
                     } else {

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -74,6 +74,11 @@ public final actor MCPServerProxy {
     public internal(set) var endpointURL: URL?
     public internal(set) var sessionID: String?
     internal var streamTask: Task<Void, Error>?
+    /// Identifies the currently-active stream. Bumped whenever a stream is
+    /// retired (reconnect / disconnect) so a late `handleStreamTermination`
+    /// from a now-stale stream task is ignored instead of failing the requests
+    /// of the connection that replaced it.
+    internal var streamGeneration: Int = 0
 
     public internal(set) var serverName: String?
     public internal(set) var serverVersion: String?

--- a/Sources/SwiftMCP/Protocols/MCPLoggingProviding.swift
+++ b/Sources/SwiftMCP/Protocols/MCPLoggingProviding.swift
@@ -13,11 +13,15 @@ import Foundation
 public protocol MCPLoggingProviding: MCPService {
     /// The current minimum log level for sending messages to clients.
     /// Only messages with this level or higher will be sent.
-    nonisolated var minimumLogLevel: LogLevel { get }
+    ///
+    /// Declared `async` so actor-based servers can store the level as
+    /// actor-isolated state; synchronous (e.g. class) conformers satisfy it
+    /// without `await`.
+    var minimumLogLevel: LogLevel { get async }
 
     /// Sets the minimum log level for sending messages to clients.
     /// - Parameter level: The new minimum log level
-    func setMinimumLogLevel(_ level: LogLevel)
+    func setMinimumLogLevel(_ level: LogLevel) async
 
     /// Sends a log message to all connected clients.
     /// - Parameter message: The log message to send

--- a/Tests/SwiftMCPTests/Calculator.swift
+++ b/Tests/SwiftMCPTests/Calculator.swift
@@ -8,7 +8,7 @@ import SwiftMCP
  A Calculator for simple math doing additionals, subtractions etc.
  */
 @MCPServer
-class Calculator {
+final class Calculator {
 	/// Adds two integers and returns their sum
 	/// - Parameter a: First number to add
 	/// - Parameter b: Second number to add

--- a/Tests/SwiftMCPTests/CompletionTests.swift
+++ b/Tests/SwiftMCPTests/CompletionTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import SwiftMCP
 
 @MCPServer
-class CompletionServer {
+final class CompletionServer {
     enum Color: CaseIterable {
         case red
         case green
@@ -21,7 +21,7 @@ class CompletionServer {
 }
 
 @MCPServer
-class CustomCompletionServer: MCPCompletionProviding {
+final class CustomCompletionServer: MCPCompletionProviding {
     enum Color: CaseIterable { case red, green, blue }
 
     @MCPResource("color://message?color={color}")

--- a/Tests/SwiftMCPTests/ComplexTypesTests.swift
+++ b/Tests/SwiftMCPTests/ComplexTypesTests.swift
@@ -68,7 +68,7 @@ struct ContactInfoArrayOutput: Sendable, Codable {
 
 /// A test server with various tools
 @MCPServer(name: "ComplexTypesServer", version: "1.0")
-class ComplexTypesServer {
+final class ComplexTypesServer {
     /// Processes an array of integers
     /// - Parameter numbers: Array of integers to process
     /// - Returns: Array of doubled integers

--- a/Tests/SwiftMCPTests/EnumTests.swift
+++ b/Tests/SwiftMCPTests/EnumTests.swift
@@ -33,7 +33,7 @@ enum SortOrder: String, CaseIterable, CustomStringConvertible {
 // MARK: - Test Server
 
 @MCPServer
-class EnumTestServer {
+final class EnumTestServer {
     /// Process a priority value
     /// - Parameter priority: The priority to process
     @MCPTool

--- a/Tests/SwiftMCPTests/LoggingTests.swift
+++ b/Tests/SwiftMCPTests/LoggingTests.swift
@@ -5,7 +5,7 @@ import Logging
 
 /// A simple test server that implements logging
 @MCPServer(name: "Test Logging Server")
-class TestLoggingServer: MCPLoggingProviding {
+actor TestLoggingServer: MCPLoggingProviding {
     var minimumLogLevel: LogLevel = .info
 
     func setMinimumLogLevel(_ level: LogLevel) {
@@ -100,10 +100,10 @@ func testLoggingServer() async throws {
     await server.testLogging()
 
     // Test with debug level
-    server.setMinimumLogLevel(.debug)
+    await server.setMinimumLogLevel(.debug)
     await server.testLogging()
 
     // Test with error level
-    server.setMinimumLogLevel(.error)
+    await server.setMinimumLogLevel(.error)
     await server.testLogging()
 }

--- a/Tests/SwiftMCPTests/MCPServerAutoConformanceTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerAutoConformanceTests.swift
@@ -3,7 +3,7 @@ import SwiftMCP
 
 // Test class that uses the MCPServer macro without explicitly conforming to MCPServer
 @MCPServer
-class AutoConformingCalculator {
+final class AutoConformingCalculator {
     /// Adds two integers and returns their sum
     /// - Parameter a: First number to add
     /// - Parameter b: Second number to add

--- a/Tests/SwiftMCPTests/MCPToolHintsTests.swift
+++ b/Tests/SwiftMCPTests/MCPToolHintsTests.swift
@@ -12,7 +12,7 @@ import Testing
 // MARK: - Test Server with Tool Hints
 
 @MCPServer(name: "HintsTestServer", version: "1.0.0")
-class HintsTestServer {
+final class HintsTestServer {
 
     /// A read-only search function that doesn't modify anything
     @MCPTool(hints: [.readOnly])

--- a/Tests/SwiftMCPTests/MCPToolNamingTests.swift
+++ b/Tests/SwiftMCPTests/MCPToolNamingTests.swift
@@ -11,7 +11,7 @@ import Testing
 
 /// Server with default naming (functionName)
 @MCPServer(name: "DefaultNamingServer")
-class DefaultNamingServer {
+final class DefaultNamingServer {
     /// Lists all windows
     @MCPTool
     func listWindows() -> [String] { [] }
@@ -23,7 +23,7 @@ class DefaultNamingServer {
 
 /// Server with snake_case naming
 @MCPServer(name: "SnakeCaseServer", toolNaming: .snakeCase)
-class SnakeCaseServer {
+final class SnakeCaseServer {
     /// Lists all windows
     @MCPTool
     func listWindows() -> [String] { [] }
@@ -43,7 +43,7 @@ class SnakeCaseServer {
 
 /// Server with PascalCase naming
 @MCPServer(name: "PascalCaseServer", toolNaming: .pascalCase)
-class PascalCaseServer {
+final class PascalCaseServer {
     /// Lists all windows
     @MCPTool
     func listWindows() -> [String] { [] }

--- a/Tests/SwiftMCPTests/MCPToolTestFixtures.swift
+++ b/Tests/SwiftMCPTests/MCPToolTestFixtures.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // Test class with SchemaRepresentable types
 @MCPServer
-class SchemaRepresentableTests {
+final class SchemaRepresentableTests {
     /// A person's contact information
     @Schema
     struct ContactInfo {
@@ -47,7 +47,7 @@ class SchemaRepresentableTests {
 
 // Test class with array of enums
 @MCPServer
-class EnumArrayTest {
+final class EnumArrayTest {
     /// Function that takes an array of weekdays
     /// - Parameter days: Array of weekdays
     @MCPTool
@@ -65,7 +65,7 @@ class EnumArrayTest {
 
 // Test class with array of SchemaRepresentable types
 @MCPServer
-class SchemaRepresentableArrayTest {
+final class SchemaRepresentableArrayTest {
     /// Function that takes an array of addresses
     /// - Parameter addresses: Array of addresses
     @MCPTool

--- a/Tests/SwiftMCPTests/MCPToolTests.swift
+++ b/Tests/SwiftMCPTests/MCPToolTests.swift
@@ -15,7 +15,7 @@ import Testing
 
 // Test class with triple-slash documentation
 @MCPServer
-class TripleSlashDocumentation {
+final class TripleSlashDocumentation {
     /// Simple function with no parameters
     /// - Returns: A string
     @MCPTool
@@ -52,7 +52,7 @@ class TripleSlashDocumentation {
 
 // Test class with multi-line documentation
 @MCPServer
-class MultiLineDocumentation {
+final class MultiLineDocumentation {
     /**
      Function with multi-line documentation
      - Parameter a: First parameter
@@ -80,7 +80,7 @@ class MultiLineDocumentation {
 
 // Test class with mixed documentation styles
 @MCPServer
-class MixedDocumentationStyles {
+final class MixedDocumentationStyles {
     /// Triple-slash documentation
     @MCPTool
     func tripleSlash() {}
@@ -96,7 +96,7 @@ class MixedDocumentationStyles {
 
 // Test class with URL parameters
 @MCPServer
-class URLParameterHandling {
+final class URLParameterHandling {
     /// Function that takes a URL parameter
     /// - Parameter url: The URL to process
     /// - Returns: The URL's host

--- a/Tests/SwiftMCPTests/OpenAPIResourceTests.swift
+++ b/Tests/SwiftMCPTests/OpenAPIResourceTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import SwiftMCP
 
 @MCPServer(name: "OpenAPITestServer", version: "1.0")
-class OpenAPITestServer {
+final class OpenAPITestServer {
 
     /// A test tool
     @MCPTool

--- a/Tests/SwiftMCPTests/OpenAPISpecTests.swift
+++ b/Tests/SwiftMCPTests/OpenAPISpecTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import SwiftMCP
 
 @MCPServer(name: "test_server")
-class TestAPIServer {
+final class TestAPIServer {
     /// A simple function that returns a string
     /// - Returns: A greeting message
     @MCPTool
@@ -268,7 +268,7 @@ enum TestWeatherCondition: String, CaseIterable, Codable {
 
 // Test server with various return types
 @MCPServer(name: "TestServer", version: "1.0")
-class TestServer {
+final class TestServer {
 
     /// Get a single weather forecast
     /// - Returns: A weather forecast with temperature, condition and timestamp

--- a/Tests/SwiftMCPTests/PromptTests.swift
+++ b/Tests/SwiftMCPTests/PromptTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import SwiftMCP
 
 @MCPServer
-class PromptTestServer {
+final class PromptTestServer {
     enum Mood: String, CaseIterable { case happy, sad, excited }
     enum Priority: Int, CaseIterable { case low = 1, medium = 2, high = 3 }
 


### PR DESCRIPTION
## Problem

`main` is red — [Swift run #26818822729](https://github.com/Cocoanetics/SwiftMCP/actions/runs/26818822729) fails `build-macos`, `build-linux`, `build-android`, `build-traits`, and `windows-client` (only `build-ios` and the forced-green `build-windows` pass).

Root cause: commit aed0ca5 (`MCPToolProviding: require Sendable`, pushed straight to `main`) added `Sendable` to `MCPToolProviding`. That's correct — tool providers are invoked concurrently — but the `@MCPServer` **test fixtures** are non-final classes, which cannot satisfy a `Sendable` requirement. The SwiftMCP library itself compiles; every error is under `Tests/SwiftMCPTests`.

## Fix

**1. `final` on the 22 `@MCPServer` test fixtures.** A `final` class with `Sendable` stored state satisfies the new requirement — the macro emits the `MCPToolProviding` conformance, the class just has to be `final`.

**2. `MCPLoggingProviding.minimumLogLevel` / `setMinimumLogLevel` are now `async`.** `TestLoggingServer` is the only fixture with mutable state and is best modeled as an `actor` — but the protocol's accessors were synchronous and `nonisolated`-by-default, so an actor's isolated members couldn't witness them (`#ConformanceIsolation`). Making them `async` lets actor-based servers hold the level as ordinary **actor-isolated state** — no `nonisolated(unsafe)`, no lock.

- **Backward-compatible for conformers:** a synchronous (class) implementation still satisfies an `async` requirement.
- **No internal callers to migrate:** the provider-level value is never read inside the library (log filtering is per-`Session` via `Session.minimumLogLevel`); the only caller was the test, now `await`-ed.
- `TestLoggingServer` is now a clean `actor`.

## Verification (local, macOS) — mirrors every CI job

| Config | Result |
|---|---|
| default traits — `build --build-tests` + `test` | ✅ 421 tests |
| core only — `build --target SwiftMCP --disable-default-traits` | ✅ |
| Client only — `build --target SwiftMCP --traits Client` | ✅ |
| NIO-free — `build`/`test --traits Client,OpenAPI` | ✅ 348 tests |
| `swiftlint lint --strict` | ✅ clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also: consolidate the two Windows CI jobs into one

`build-windows` (aspirational full build, forced green via `continue-on-error` because swift-nio doesn't compile on Windows yet) and `windows-client` (the real, enforced NIO-free build+test) were two `windows-latest` runners for the same platform. Merged into a single `build-windows` job: the **enforced** NIO-free steps run first (no `continue-on-error`, so a swift-nio leak or non-server regression still fails the job), followed by the **aspirational** full-traits steps with `continue-on-error`. One runner instead of two, same enforcement. (`main` has no required-check rules, so dropping the `windows-client` check name breaks nothing.)

---

## Also: fix the pre-existing Android CI flakiness

Re-running Android surfaced two pre-existing issues (from #125/#127 and the #126 Android CI), fixed here:

- **Flaky reconnect — a real client race.** `MCPServerProxy.connect()` cancelled the previous general-SSE loop *without awaiting it*, then reset `streamFailure` and started a fresh `initialize()`. The stale loop, still in flight, would hit the server's "unknown session" 404 and call `handleStreamTermination(.sessionInvalidated)`, failing the **new** connection's pending `initialize` — so reconnecting the same proxy after `.sessionInvalidated` could itself throw `.sessionInvalidated`. Tiny window on fast hosts; wide enough on the Android emulator to flake `reconnectAfterInvalidationEstablishesFreshSession`. Fixed with a **stream-generation guard**: `connect()`/`disconnect()` retire the active stream (cancel + bump generation), and `handleStreamTermination` ignores terminations from a superseded generation. The live stream still surfaces `.sessionInvalidated` as before; non-blocking (no awaiting a possibly-stuck task).
- **Emulator-teardown hang.** When an Android test fails, `swift-android-action`'s emulator kill hangs (`stop: Not implemented`), running out the 60-min job timeout and reporting a confusing `cancelled`. Added a step-level `timeout-minutes: 25` (job 60→30) so failures surface red in ~25 min.
