### PR TITLE
Bump SwiftCross dependency floor to 1.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -85,7 +85,7 @@ let package = Package(
 		.package(url: "https://github.com/swiftlang/swift-syntax.git", "602.0.0-latest"..<"604.0.0"),
 		.package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
 		.package(url: "https://github.com/apple/swift-certificates.git", from: "1.1.0"),
-		.package(url: "https://github.com/Cocoanetics/SwiftCross.git", from: "1.0.0")
+		.package(url: "https://github.com/Cocoanetics/SwiftCross.git", from: "1.2.0")
     ],
 	targets: [
 		.macro(


### PR DESCRIPTION
Raises the SwiftCross dependency floor from `1.0.0` to `1.2.0`.

1.1.0 (`WallClock`) and 1.2.0 (`Environment.set`) are purely **additive** over 1.0.0, and all three are `swift-tools-version:6.1`, so:
- the unpinned Swift 6.1 `build-macos` job is unaffected,
- no SwiftMCP source changes are needed.

Raising the floor just guarantees consumers resolve a SwiftCross with the new portable helpers. (`Package.resolved` is gitignored, so only the manifest floor changes.)

## Verification (local, macOS, against SwiftCross 1.2.0)
- `swift build --target SwiftMCP --disable-default-traits` — ✅
- `swift build --build-tests` + `swift test` — ✅ 421 tests
- `swift test --traits "Client,OpenAPI"` — ✅ 348 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
