### PR TITLE
Allow swift-crypto 4.x (widen range to 3.0.0..<5.0.0)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -83,7 +83,13 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
 		.package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.0.0"),
 		.package(url: "https://github.com/swiftlang/swift-syntax.git", "602.0.0-latest"..<"604.0.0"),
-		.package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+		// Allow both the crypto 3.x and 4.x major series. swift-certificates
+		// >= 1.19 moves to crypto 4.x, so capping at < 4.0 here would make a
+		// blanket `swift package update` unresolvable. crypto 4.0's only
+		// breaking change is additive `CryptoError` cases, and `_RSA.Signing`
+		// (the only API we use) still supports macOS 10.15 / iOS 13, so the
+		// bump is safe for our macOS 12 / iOS 15 floor.
+		.package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
 		.package(url: "https://github.com/apple/swift-certificates.git", from: "1.1.0"),
 		.package(url: "https://github.com/Cocoanetics/SwiftCross.git", from: "1.2.0")
     ],


### PR DESCRIPTION
## Problem

`swift-crypto` was pinned `from: "3.0.0"` — i.e. `[3.0.0, 4.0.0)`, a hard cap below 4.0. A blanket `swift package update` fails to resolve once the dependency graph wants crypto 4.x:

```
error: Dependencies could not be resolved … exhausted attempts to resolve
```

## Fix

Widen the range to allow both major series:

```diff
-.package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+.package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
```

This mirrors swift-certificates' own constraint (`"3.12.3"..<"5.0.0"`) and keeps downstream consumers free to stay on crypto 3.x rather than forcing a hard floor at 4.0.

## Why it's safe

- crypto 4.0's **only** breaking change is additive `CryptoError` enum cases.
- `_RSA.Signing` (the only crypto API the OAuth/JWT code uses) still supports **macOS 10.15 / iOS 13** — under SwiftMCP's macOS 12 / iOS 15 floor — so **no platform-floor change** is needed.
- `_CryptoExtras` was renamed to `CryptoExtras` in 4.0 but the old product/import is retained, so **no source changes** are needed.
- crypto/certificates are linked only under the `Server` trait, so the NIO-free path is unaffected.

## Validation

- `swift package update` resolves cleanly → **swift-crypto 4.5.0** / **swift-certificates 1.19.1**.
- `SwiftMCP` and all test targets compile against crypto 4.5.0.
- All **5 JWT signature-verification tests pass**, including the two that fetch live JWKS and run real RSA verification (`_RSA.Signing` + `.insecurePKCS1v1_5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)