### PR TITLE
Remove dead `import OSLog` from demo command files

### DIFF
--- a/Demos/SwiftMCPDemo/Commands/HTTPSSECommand.swift
+++ b/Demos/SwiftMCPDemo/Commands/HTTPSSECommand.swift
@@ -4,9 +4,6 @@ import ArgumentParser
 import SwiftMCP
 import Logging
 import ServiceLifecycle
-#if canImport(OSLog)
-import OSLog
-#endif
 
 /**
  A command that starts an HTTP server with Server-Sent Events (SSE) support for SwiftMCP.

--- a/Demos/SwiftMCPDemo/Commands/StdioCommand.swift
+++ b/Demos/SwiftMCPDemo/Commands/StdioCommand.swift
@@ -5,9 +5,6 @@ import SwiftMCP
 import Logging
 import NIOCore
 import ServiceLifecycle
-#if canImport(OSLog)
-import OSLog
-#endif
 
 /**
  A command that processes JSON-RPC requests from standard input and writes responses to standard output.

--- a/Demos/SwiftMCPDemo/Commands/TCPBonjourCommand.swift
+++ b/Demos/SwiftMCPDemo/Commands/TCPBonjourCommand.swift
@@ -4,9 +4,6 @@ import ArgumentParser
 import SwiftMCP
 import Logging
 import ServiceLifecycle
-#if canImport(OSLog)
-import OSLog
-#endif
 
 /**
  A command that exposes the demo server over TCP with Bonjour discovery.

--- a/Demos/SwiftMCPDemo/MCPCommand.swift
+++ b/Demos/SwiftMCPDemo/MCPCommand.swift
@@ -5,10 +5,6 @@ import SwiftMCP
 import Logging
 import NIOCore
 import Dispatch
-
-#if canImport(OSLog)
-import OSLog
-#endif
 #endif
 
 /**

--- a/Demos/SwiftMCPIntentsDemo/Commands/HTTPSSECommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/HTTPSSECommand.swift
@@ -4,9 +4,6 @@ import ArgumentParser
 import SwiftMCP
 import Logging
 import ServiceLifecycle
-#if canImport(OSLog)
-import OSLog
-#endif
 
 /**
  A command that starts an HTTP server with Server-Sent Events (SSE) support for SwiftMCP.

--- a/Demos/SwiftMCPIntentsDemo/Commands/StdioCommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/StdioCommand.swift
@@ -5,9 +5,6 @@ import SwiftMCP
 import Logging
 import NIOCore
 import ServiceLifecycle
-#if canImport(OSLog)
-import OSLog
-#endif
 
 /**
  A command that processes JSON-RPC requests from standard input and writes responses to standard output.

--- a/Demos/SwiftMCPIntentsDemo/Commands/TCPBonjourCommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/TCPBonjourCommand.swift
@@ -4,9 +4,6 @@ import ArgumentParser
 import SwiftMCP
 import Logging
 import ServiceLifecycle
-#if canImport(OSLog)
-import OSLog
-#endif
 
 /**
  A command that exposes the AppIntents demo server over TCP with Bonjour discovery.


### PR DESCRIPTION
## Summary

`import OSLog` should appear only where Swift Logging is bridged to OSLog — the `OSLogHandler` and `LoggingSystem.bootstrapWithOSLog()` helpers. The six demo subcommands and `MCPCommand` only *call* `bootstrapWithOSLog()`, which needs no OSLog import. The stray `import OSLog` in those files was dead — and it shadowed `Logging.Logger` with `os.Logger` (the reason the lifecycle-logger lines needed `Logging.Logger` qualification in #133).

## What changed

Removed the `#if canImport(OSLog) import OSLog #endif` blocks from:

- **SwiftMCPDemo**: `MCPCommand`, `HTTPSSECommand`, `StdioCommand`, `TCPBonjourCommand`
- **SwiftMCPIntentsDemo**: `HTTPSSECommand`, `StdioCommand`, `TCPBonjourCommand`

Kept the `#if canImport(OSLog)` guard around the Apple-only `bootstrapWithOSLog()` calls. `import OSLog` now lives only in the bridge files (`OSLogHandler.swift` / `LoggingSystem.swift`).

7 files, −22 lines, no functional change.

## Verification

- [x] `swift build` (default traits) — green; the call sites compile without the import, proving it was dead
- [x] `grep "import OSLog"` → only the 4 bridge files remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
