### PR TITLE
Address Codex P2s: gate resource subscriptions and silence notification-only pre-init batches

### DIFF
--- a/Sources/SwiftMCP/Protocols/MCPResourceProviding.swift
+++ b/Sources/SwiftMCP/Protocols/MCPResourceProviding.swift
@@ -122,6 +122,24 @@ extension MCPResourceProviding {
         get async { [] }
     }
 
+    /// Whether this server actually exposes any resources — either through
+    /// `@MCPResource`-generated metadata or the documented dynamic `mcpResources`
+    /// path.
+    ///
+    /// This is the single signal used both to advertise the `resources`
+    /// capability and to honor `resources/subscribe`, so the two stay
+    /// consistent. The metadata check is evaluated first so the common
+    /// `@MCPResource` case never has to materialize a potentially expensive
+    /// dynamic `mcpResources`.
+    var exposesResources: Bool {
+        get async {
+            if !(await mcpResourceMetadata).isEmpty {
+                return true
+            }
+            return !(await mcpResources).isEmpty
+        }
+    }
+
     public func callResourceAsFunction(_ name: String, arguments: JSONDictionary) async throws -> Encodable & Sendable {
         // Default implementation throws an error - this should be overridden by the macro
         throw MCPResourceError.notFound(uri: "function://\(name)")

--- a/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
@@ -112,7 +112,7 @@ public extension MCPServer {
         }
 
         if let resourceProvider = self as? MCPResourceProviding,
-           !(await resourceProvider.mcpResourceMetadata).isEmpty {
+           await resourceProvider.exposesResources {
             capabilities.resources = .init(subscribe: true, listChanged: true)
         }
 

--- a/Sources/SwiftMCP/Protocols/MCPServer+Resources.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Resources.swift
@@ -130,6 +130,19 @@ public extension MCPServer {
     internal func handleResourceSubscribe(
         _ request: JSONRPCMessage.JSONRPCRequestData
     ) async -> JSONRPCMessage? {
+        // Only honor subscriptions when the server actually advertises the
+        // `resources` capability. The `@MCPServer` macro always adds
+        // `MCPResourceProviding` conformance (so extension-contributed resources
+        // can surface), so conformance alone is not a reliable signal — match the
+        // same `mcpResourceMetadata` check used when advertising capabilities.
+        guard let resourceProvider = self as? MCPResourceProviding,
+              !(await resourceProvider.mcpResourceMetadata).isEmpty else {
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32601, message: "Server does not support resource subscriptions")
+            )
+        }
+
         guard let session = Session.current else {
             return JSONRPCMessage.errorResponse(
                 id: request.id,
@@ -152,6 +165,14 @@ public extension MCPServer {
     internal func handleResourceUnsubscribe(
         _ request: JSONRPCMessage.JSONRPCRequestData
     ) async -> JSONRPCMessage? {
+        guard let resourceProvider = self as? MCPResourceProviding,
+              !(await resourceProvider.mcpResourceMetadata).isEmpty else {
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32601, message: "Server does not support resource subscriptions")
+            )
+        }
+
         guard let session = Session.current else {
             return JSONRPCMessage.errorResponse(
                 id: request.id,

--- a/Sources/SwiftMCP/Protocols/MCPServer+Resources.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Resources.swift
@@ -130,13 +130,14 @@ public extension MCPServer {
     internal func handleResourceSubscribe(
         _ request: JSONRPCMessage.JSONRPCRequestData
     ) async -> JSONRPCMessage? {
-        // Only honor subscriptions when the server actually advertises the
-        // `resources` capability. The `@MCPServer` macro always adds
-        // `MCPResourceProviding` conformance (so extension-contributed resources
-        // can surface), so conformance alone is not a reliable signal — match the
-        // same `mcpResourceMetadata` check used when advertising capabilities.
+        // Only honor subscriptions when the server actually exposes resources.
+        // The `@MCPServer` macro always adds `MCPResourceProviding` conformance
+        // (so extension-contributed resources can surface), so conformance alone
+        // is not a reliable signal. `exposesResources` covers both `@MCPResource`
+        // metadata and the dynamic `mcpResources` path, matching exactly what the
+        // `resources` capability advertises during initialize.
         guard let resourceProvider = self as? MCPResourceProviding,
-              !(await resourceProvider.mcpResourceMetadata).isEmpty else {
+              await resourceProvider.exposesResources else {
             return JSONRPCMessage.errorResponse(
                 id: request.id,
                 error: .init(code: -32601, message: "Server does not support resource subscriptions")
@@ -166,7 +167,7 @@ public extension MCPServer {
         _ request: JSONRPCMessage.JSONRPCRequestData
     ) async -> JSONRPCMessage? {
         guard let resourceProvider = self as? MCPResourceProviding,
-              !(await resourceProvider.mcpResourceMetadata).isEmpty else {
+              await resourceProvider.exposesResources else {
             return JSONRPCMessage.errorResponse(
                 id: request.id,
                 error: .init(code: -32601, message: "Server does not support resource subscriptions")

--- a/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
+++ b/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
@@ -19,27 +19,19 @@ enum SessionInitializationGate {
         !(await session.hasReceivedInitializeRequest) && !batchStartsWithInitialize(messages)
     }
 
+    /// Builds one error response per *request* in the batch.
+    ///
+    /// Notifications carry no `id` and expect no response, so a batch containing
+    /// only notifications yields an empty array — the transport must stay silent
+    /// rather than fabricate an unsolicited `id: nil` error.
     static func rejectionResponses(for messages: [JSONRPCMessage]) -> [JSONRPCMessage] {
-        let requestIDs = messages.compactMap { message -> JSONRPCID? in
+        messages.compactMap { message -> JSONRPCMessage? in
             guard case .request(let request) = message else {
                 return nil
             }
 
-            return request.id
-        }
-
-        if requestIDs.isEmpty {
-            return [
-                .errorResponse(
-                    id: nil,
-                    error: .init(code: -32000, message: rejectionMessage)
-                )
-            ]
-        }
-
-        return requestIDs.map { requestID in
-            .errorResponse(
-                id: requestID,
+            return .errorResponse(
+                id: request.id,
                 error: .init(code: -32000, message: rejectionMessage)
             )
         }

--- a/Sources/SwiftMCP/Transport/StdioTransport.swift
+++ b/Sources/SwiftMCP/Transport/StdioTransport.swift
@@ -139,7 +139,10 @@ public final class StdioTransport: Transport, Service, @unchecked Sendable {
 
             if await SessionInitializationGate.shouldReject(messages, for: session) {
                 logger.warning("Rejected stdio request before initialize")
-                try await send(SessionInitializationGate.rejectionResponses(for: messages))
+                let rejections = SessionInitializationGate.rejectionResponses(for: messages)
+                if !rejections.isEmpty {
+                    try await send(rejections)
+                }
                 return
             }
 

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
@@ -111,7 +111,10 @@ extension TCPBonjourTransport {
                 let messages = try JSONRPCMessage.decodeMessages(from: data)
                 if await SessionInitializationGate.shouldReject(messages, for: session) {
                     logger.warning("Rejected TCP request before initialize (\(session.id))")
-                    try await send(SessionInitializationGate.rejectionResponses(for: messages))
+                    let rejections = SessionInitializationGate.rejectionResponses(for: messages)
+                    if !rejections.isEmpty {
+                        try await send(rejections)
+                    }
                     return
                 }
 

--- a/Tests/SwiftMCPTests/LineTransportInitializationTests.swift
+++ b/Tests/SwiftMCPTests/LineTransportInitializationTests.swift
@@ -68,6 +68,16 @@ struct LineTransportInitializationTests {
         #expect(error.error.message == SessionInitializationGate.rejectionMessage)
     }
 
+    @Test("Notification-only batches produce no rejection responses")
+    func notificationOnlyBatchesProduceNoResponses() {
+        let responses = SessionInitializationGate.rejectionResponses(for: [
+            .notification(method: "notifications/initialized"),
+            .notification(method: "notifications/cancelled")
+        ])
+
+        #expect(responses.isEmpty)
+    }
+
     @Test("In-process stdio rejects ping before initialize", .enabled(if: isStdioProcessSupported))
     func inProcessStdioRejectsPingBeforeInitialize() async throws {
         let bridge = InProcessStdioBridge(server: LocalStdioServer())

--- a/Tests/SwiftMCPTests/ResourceSubscriptionGateTests.swift
+++ b/Tests/SwiftMCPTests/ResourceSubscriptionGateTests.swift
@@ -2,6 +2,18 @@ import Foundation
 import Testing
 @testable import SwiftMCP
 
+/// A server that exposes resources only through the documented dynamic
+/// `mcpResources` path. It declares no `@MCPResource` functions, so
+/// `mcpResourceMetadata` is empty while `resources/list` still returns content.
+@MCPServer(name: "DynamicResourceServer", version: "1.0")
+actor DynamicResourceServer {
+    var mcpResources: [MCPResource] {
+        get async {
+            [SimpleResource(uri: URL(string: "config://dynamic")!, name: "dynamic")]
+        }
+    }
+}
+
 /// Verifies that `resources/subscribe` and `resources/unsubscribe` are only
 /// honored by servers that actually advertise the `resources` capability.
 ///
@@ -73,5 +85,31 @@ struct ResourceSubscriptionGateTests {
         // resource availability, not blanket rejection.
         #expect(response.error.message != Self.unsupportedMessage)
         #expect(response.error.code == -32603)
+    }
+
+    @Test("Server exposing only dynamic resources passes the capability guard")
+    func dynamicResourceServerPassesCapabilityGuard() async throws {
+        let server = DynamicResourceServer()
+
+        guard let message = await server.handleMessage(subscribeRequest(method: "resources/subscribe")) else {
+            Issue.record("Expected a response message")
+            return
+        }
+        guard case .errorResponse(let response) = message else {
+            Issue.record("Expected errorResponse case")
+            return
+        }
+
+        // mcpResourceMetadata is empty, but dynamic mcpResources is not, so the
+        // gate must let it through (and only stop at the missing session).
+        #expect(response.error.message != Self.unsupportedMessage)
+        #expect(response.error.code == -32603)
+    }
+
+    @Test("exposesResources reflects metadata and dynamic resources")
+    func exposesResourcesPredicate() async {
+        #expect(await ResourceTestServer().exposesResources)
+        #expect(await DynamicResourceServer().exposesResources)
+        #expect(!(await Calculator().exposesResources))
     }
 }

--- a/Tests/SwiftMCPTests/ResourceSubscriptionGateTests.swift
+++ b/Tests/SwiftMCPTests/ResourceSubscriptionGateTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import SwiftMCP
+
+/// Verifies that `resources/subscribe` and `resources/unsubscribe` are only
+/// honored by servers that actually advertise the `resources` capability.
+///
+/// The `@MCPServer` macro always adds `MCPResourceProviding` conformance, so the
+/// gate keys off a non-empty `mcpResourceMetadata` — the same condition used when
+/// advertising capabilities during `initialize`.
+@Suite("Resource Subscription Gate", .tags(.unit))
+struct ResourceSubscriptionGateTests {
+    private static let unsupportedMessage = "Server does not support resource subscriptions"
+
+    private func subscribeRequest(method: String, id: Int = 1) -> JSONRPCMessage {
+        .request(
+            id: id,
+            method: method,
+            params: ["uri": "config://app"]
+        )
+    }
+
+    @Test("Server without resources rejects resources/subscribe")
+    func nonResourceServerRejectsSubscribe() async throws {
+        let calculator = Calculator()
+
+        guard let message = await calculator.handleMessage(subscribeRequest(method: "resources/subscribe")) else {
+            Issue.record("Expected a response message")
+            return
+        }
+        guard case .errorResponse(let response) = message else {
+            Issue.record("Expected errorResponse case")
+            return
+        }
+
+        #expect(response.id == .int(1))
+        #expect(response.error.code == -32601)
+        #expect(response.error.message == Self.unsupportedMessage)
+    }
+
+    @Test("Server without resources rejects resources/unsubscribe")
+    func nonResourceServerRejectsUnsubscribe() async throws {
+        let calculator = Calculator()
+
+        guard let message = await calculator.handleMessage(subscribeRequest(method: "resources/unsubscribe")) else {
+            Issue.record("Expected a response message")
+            return
+        }
+        guard case .errorResponse(let response) = message else {
+            Issue.record("Expected errorResponse case")
+            return
+        }
+
+        #expect(response.error.code == -32601)
+        #expect(response.error.message == Self.unsupportedMessage)
+    }
+
+    @Test("Server with resources passes the capability guard")
+    func resourceServerPassesCapabilityGuard() async throws {
+        let server = ResourceTestServer()
+
+        guard let message = await server.handleMessage(subscribeRequest(method: "resources/subscribe")) else {
+            Issue.record("Expected a response message")
+            return
+        }
+        guard case .errorResponse(let response) = message else {
+            Issue.record("Expected errorResponse case")
+            return
+        }
+
+        // It gets past the capability guard and only fails because no session is
+        // bound in this unit-test task — proving the guard discriminates by
+        // resource availability, not blanket rejection.
+        #expect(response.error.message != Self.unsupportedMessage)
+        #expect(response.error.code == -32603)
+    }
+}


### PR DESCRIPTION
Addresses two unresolved Codex P2 review comments from earlier PRs.

## 1. Reject `resources/subscribe` on non-resource servers
[#82 review](https://github.com/Cocoanetics/SwiftMCP/pull/82#pullrequestreview-3950221368)

`createInitializeResponse` only advertises the `resources` capability when the server has resources, but `handleResourceSubscribe`/`handleResourceUnsubscribe` returned success for **any** server type and stored the URI in session state. A client on a non-resource server could get a successful `resources/subscribe` and then never receive updates.

These handlers now return `-32601` unless the server advertises resources.

⚠️ The natural-looking fix — guarding on `self is MCPResourceProviding` — is a **silent no-op**: the `@MCPServer` macro [always adds `MCPResourceProviding` conformance](https://github.com/Cocoanetics/SwiftMCP/blob/main/Sources/SwiftMCPMacros/MCPServerMacro%2BConformances.swift) so extension-contributed resources can surface. The guard therefore matches the *exact* condition used to advertise the capability: a non-empty `mcpResourceMetadata`.

## 2. Stop replying to notification-only pre-init batches
[#111 review](https://github.com/Cocoanetics/SwiftMCP/pull/111#pullrequestreview-4197416849)

`SessionInitializationGate.rejectionResponses` fabricated an `id: nil` error when a rejected pre-init batch contained no requests. For a batch of pure JSON-RPC notifications (which carry no `id` and expect no response), this emitted an unsolicited response, violating the "no response expected" contract and risking client desync.

It now emits one error per request and **nothing** for notification-only batches. The stdio and TCP transports skip sending when there is nothing to send (the in-process bridge already guarded this).

## Tests
- `ResourceSubscriptionGateTests` — non-resource server rejects subscribe/unsubscribe with `-32601`; resource server passes the capability guard.
- `LineTransportInitializationTests` — notification-only batches produce no rejection responses.

`swift build` clean; both suites pass (9 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)