### PR TITLE
Remove leftover DEBUG print statements from elicit(_:)

### DIFF
--- a/Sources/SwiftMCP/Transport/RequestContext.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext.swift
@@ -186,17 +186,12 @@ public final class RequestContext: Sendable {
 
         // Check if client supports elicitation
         let capabilities = await session.clientCapabilities
-        print("DEBUG: Client capabilities: \(String(describing: capabilities))")
-        print("DEBUG: Elicitation support: \(String(describing: capabilities?.elicitation))")
         guard capabilities?.elicitation != nil else {
             throw MCPServerError.clientHasNoElicitationSupport
         }
 
         // Encode the request parameters
         let params = try JSONDictionary(encoding: request)
-
-        // Debug: Print the encoded parameters
-        print("DEBUG: Encoded elicitation params: \(params)")
 
         // Send the elicitation request to the client
         let response = try await session.request(method: "elicitation/create", params: params)


### PR DESCRIPTION
## What

Removes three leftover `print("DEBUG: ...")` statements (and an orphaned debug comment) from the `elicit(_:)` method in `Sources/SwiftMCP/Transport/RequestContext.swift`:

- `print("DEBUG: Client capabilities: ...")`
- `print("DEBUG: Elicitation support: ...")`
- `print("DEBUG: Encoded elicitation params: ...")`

## Why

These wrote to **stdout** in production. On the STDIO transport, stdout *is* the JSON-RPC message channel, so stray `print` output can corrupt the protocol stream for any client connected over stdio.

## Notes for reviewers

- **No `logger.debug(...)` replacement was added**, by design. The sibling `sample(_:)` method (just above `elicit(_:)`) performs the identical client-capability guard with no logging at all, and the unsupported-elicitation case is already surfaced through the typed `MCPServerError.clientHasNoElicitationSupport` error. Adding a logger only to `elicit(_:)` would diverge from its sibling.
- The encoded params are **deliberately not logged** — they carry elicitation request content that should not leak by default.
- swift-log *is* available NIO-free to the core target (`Logging` is a dependency of `SwiftMCP` without a trait condition), so a logger was an option; it just wasn't the consistent choice here.

## Verification

- `swift build` — **Build complete!** (default traits `Server`/`Client`/`OpenAPI` all enabled, so the full NIO-transport path is exercised).
- `grep -rn 'print("DEBUG' Sources/SwiftMCP` — no matches remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)