### PR TITLE
Version-conditional behavior: gate structured output, batching & resource_link by negotiated version

### DIFF
--- a/Sources/SwiftMCP/Client/InProcessStdioBridge.swift
+++ b/Sources/SwiftMCP/Client/InProcessStdioBridge.swift
@@ -79,6 +79,9 @@ final class InProcessStdioBridge: StdioConnection, @unchecked Sendable {
                     return SessionInitializationGate.rejectionResponses(for: messages)
                 }
 
+                // The in-process bridge is internal SwiftMCP infrastructure, not an
+                // external wire transport, so it is intentionally not version-gated
+                // for batching (see LineTransportInitializationTests).
                 return await server.processBatch(messages)
             }
             guard !responses.isEmpty else { return }

--- a/Sources/SwiftMCP/Extensions/Array+MCPTool.swift
+++ b/Sources/SwiftMCP/Extensions/Array+MCPTool.swift
@@ -8,7 +8,12 @@
 import Foundation
 
 extension Array where Element == MCPToolMetadata {
-    public func convertedToTools() -> [MCPTool] {
+    /// Converts tool metadata into wire `MCPTool`s.
+    ///
+    /// - Parameter includeOutputSchema: When `false`, the `outputSchema` field
+    ///   is omitted — structured tool output was introduced in `2025-06-18`, so
+    ///   it must not be advertised to clients negotiating an earlier revision.
+    public func convertedToTools(includeOutputSchema: Bool = true) -> [MCPTool] {
         return self.map { meta in
             // Create properties for the JSON schema
             let properties = Dictionary(uniqueKeysWithValues: meta.parameters.map { param in
@@ -26,7 +31,7 @@ extension Array where Element == MCPToolMetadata {
                 description: hasParameters ? meta.description : nil,
                 additionalProperties: hasParameters ? nil : false
             ))
-            let outputSchema = meta.outputSchema
+            let outputSchema = includeOutputSchema ? meta.outputSchema : nil
 
             // Create and return the tool
             return MCPTool(

--- a/Sources/SwiftMCP/Extensions/JSONRPCMessage+Batch.swift
+++ b/Sources/SwiftMCP/Extensions/JSONRPCMessage+Batch.swift
@@ -47,6 +47,27 @@ extension JSONRPCMessage {
         }
         return !profile.has(.jsonRPCBatching)
     }
+
+    /// The protocol version that governs batching on a session-bound transport
+    /// (stdio, TCP, in-process): the session's negotiated version, else a
+    /// leading `initialize`'s declared version, else `latest` — mirroring the
+    /// HTTP resolution order.
+    static func batchingVersion(for messages: [JSONRPCMessage], session: Session) async -> String {
+        await session.negotiatedProtocolVersion
+            ?? SessionInitializationGate.initializeProtocolVersion(messages)
+            ?? MCPProtocolVersion.latest
+    }
+
+    /// The JSON-RPC error response for a batch rejected under `version`.
+    static func batchingRejectionResponse(version: String) -> JSONRPCMessage {
+        .errorResponse(
+            id: nil,
+            error: .init(
+                code: -32600,
+                message: "JSON-RPC batching is not supported in protocol version \(version)."
+            )
+        )
+    }
 }
 
 #if Server

--- a/Sources/SwiftMCP/Protocols/MCPServer+Tools.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Tools.swift
@@ -18,9 +18,12 @@ public extension MCPServer {
             ])
         }
 
+        // `outputSchema` is a 2025-06-18 feature; omit it for older clients.
+        let includeOutputSchema = await RequestContext.current?.supports(.structuredToolOutput) ?? true
         let toolMetadata = await toolProvider.mcpToolMetadata
-        if let tools = try? JSONValue(encoding: toolMetadata.convertedToTools()) {
-            return JSONRPCMessage.response(id: id, result: ["tools": tools])
+        let tools = toolMetadata.convertedToTools(includeOutputSchema: includeOutputSchema)
+        if let encoded = try? JSONValue(encoding: tools) {
+            return JSONRPCMessage.response(id: id, result: ["tools": encoded])
         }
         return JSONRPCMessage.errorResponse(
             id: id,
@@ -50,6 +53,9 @@ public extension MCPServer {
 
         let metadata = mcpToolMetadata(for: toolName)
 
+        // `structuredContent` is a 2025-06-18 feature; omit it for older clients.
+        let includeStructuredContent = await RequestContext.current?.supports(.structuredToolOutput) ?? true
+
         do {
             let result = try await toolProvider.callTool(toolName, arguments: arguments)
             let wrappedResult = try metadata?.wrapOutputIfNeeded(result) ?? result
@@ -58,7 +64,8 @@ public extension MCPServer {
             return try buildToolCallResponse(
                 requestID: request.id,
                 wrappedResult: wrappedResult,
-                expectsToolResult: expectsToolResult
+                expectsToolResult: expectsToolResult,
+                includeStructuredContent: includeStructuredContent
             )
         } catch {
             return JSONRPCMessage.response(
@@ -79,7 +86,8 @@ public extension MCPServer {
     private func buildToolCallResponse(
         requestID: JSONRPCID,
         wrappedResult: Encodable & Sendable,
-        expectsToolResult: Bool
+        expectsToolResult: Bool,
+        includeStructuredContent: Bool
     ) throws -> JSONRPCMessage {
         var resultPayload: JSONDictionary = [
             "isError": false
@@ -103,7 +111,7 @@ public extension MCPServer {
         // Fallback: encode as JSON and wrap in a text content block.
         let (content, structured) = try encodeFallbackTextContent(wrappedResult)
         resultPayload["content"] = .array([.object(content)])
-        if let structured {
+        if let structured, includeStructuredContent {
             resultPayload["structuredContent"] = structured
         }
         return JSONRPCMessage.response(id: requestID, result: resultPayload)

--- a/Sources/SwiftMCP/Protocols/MCPServer+Tools.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Tools.swift
@@ -53,8 +53,11 @@ public extension MCPServer {
 
         let metadata = mcpToolMetadata(for: toolName)
 
-        // `structuredContent` is a 2025-06-18 feature; omit it for older clients.
-        let includeStructuredContent = await RequestContext.current?.supports(.structuredToolOutput) ?? true
+        // structuredContent and resource_link are 2025-06-18 features; degrade
+        // both for clients that negotiated an earlier revision.
+        let profile = await RequestContext.current?.protocolProfile
+        let includeStructuredContent = profile?.has(.structuredToolOutput) ?? true
+        let includeResourceLinks = profile?.has(.resourceLinks) ?? true
 
         do {
             let result = try await toolProvider.callTool(toolName, arguments: arguments)
@@ -65,7 +68,8 @@ public extension MCPServer {
                 requestID: request.id,
                 wrappedResult: wrappedResult,
                 expectsToolResult: expectsToolResult,
-                includeStructuredContent: includeStructuredContent
+                includeStructuredContent: includeStructuredContent,
+                includeResourceLinks: includeResourceLinks
             )
         } catch {
             return JSONRPCMessage.response(
@@ -87,34 +91,62 @@ public extension MCPServer {
         requestID: JSONRPCID,
         wrappedResult: Encodable & Sendable,
         expectsToolResult: Bool,
-        includeStructuredContent: Bool
+        includeStructuredContent: Bool,
+        includeResourceLinks: Bool
     ) throws -> JSONRPCMessage {
         var resultPayload: JSONDictionary = [
             "isError": false
         ]
 
+        var content: JSONValue
+        var structured: JSONValue?
+
         if let payload = try encodeSingleContent(wrappedResult) {
-            resultPayload["content"] = payload
-            return JSONRPCMessage.response(id: requestID, result: resultPayload)
+            content = payload
+        } else if let payload = try encodeContentArray(wrappedResult, expectsToolResult: expectsToolResult) {
+            content = payload
+        } else if let payload = try encodeResourceContent(wrappedResult, expectsToolResult: expectsToolResult) {
+            content = payload
+        } else {
+            // Fallback: encode as JSON and wrap in a text content block.
+            let (textContent, structuredContent) = try encodeFallbackTextContent(wrappedResult)
+            content = .array([.object(textContent)])
+            structured = structuredContent
         }
 
-        if let payload = try encodeContentArray(wrappedResult, expectsToolResult: expectsToolResult) {
-            resultPayload["content"] = payload
-            return JSONRPCMessage.response(id: requestID, result: resultPayload)
+        // resource_link is a 2025-06-18 content type; degrade to text for older clients.
+        if !includeResourceLinks {
+            content = degradingResourceLinks(in: content)
         }
+        resultPayload["content"] = content
 
-        if let payload = try encodeResourceContent(wrappedResult, expectsToolResult: expectsToolResult) {
-            resultPayload["content"] = payload
-            return JSONRPCMessage.response(id: requestID, result: resultPayload)
-        }
-
-        // Fallback: encode as JSON and wrap in a text content block.
-        let (content, structured) = try encodeFallbackTextContent(wrappedResult)
-        resultPayload["content"] = .array([.object(content)])
         if let structured, includeStructuredContent {
             resultPayload["structuredContent"] = structured
         }
         return JSONRPCMessage.response(id: requestID, result: resultPayload)
+    }
+
+    /// Rewrites any `resource_link` content blocks (a 2025-06-18 feature) into
+    /// plain `text` blocks carrying the link's name and URI, for clients that
+    /// negotiated an earlier revision. Non-array content is returned unchanged,
+    /// so single, array and mixed tool results are all handled uniformly.
+    private func degradingResourceLinks(in content: JSONValue) -> JSONValue {
+        guard case .array(let items) = content else { return content }
+        return .array(items.map(degradeResourceLink))
+    }
+
+    private func degradeResourceLink(_ item: JSONValue) -> JSONValue {
+        guard case .object(let object) = item,
+              object["type"]?.stringValue == "resource_link" else {
+            return item
+        }
+
+        let uri = object["uri"]?.stringValue ?? ""
+        var text = object["name"]?.stringValue.map { "\($0): \(uri)" } ?? uri
+        if let description = object["description"]?.stringValue, !description.isEmpty {
+            text += " — \(description)"
+        }
+        return .object(["type": .string("text"), "text": .string(text)])
     }
 
     /// Encodes a single MCP content value (text/image/audio/link/embedded) if applicable.

--- a/Sources/SwiftMCP/Transport/RequestContext+ProtocolVersion.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext+ProtocolVersion.swift
@@ -56,4 +56,12 @@ public extension RequestContext {
     /// logging via `_meta`). `nil` for legacy requests, which use the
     /// session-wide level set by `logging/setLevel`.
     var requestedLogLevel: LogLevel? { meta?.logLevel }
+
+    /// Whether the request's negotiated protocol version supports `feature`.
+    ///
+    /// Convenience over ``protocolProfile`` for the common version-gating case:
+    /// `if await RequestContext.current?.supports(.structuredToolOutput) ?? true`.
+    func supports(_ feature: MCPFeature) async -> Bool {
+        await protocolProfile.has(feature)
+    }
 }

--- a/Sources/SwiftMCP/Transport/RequestContext+ProtocolVersion.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext+ProtocolVersion.swift
@@ -16,14 +16,20 @@ public extension RequestContext {
 
     /// The protocol revision in effect for this request.
     ///
-    /// Resolution order: the modern `_meta` value, then the legacy
-    /// session-negotiated version, then the server's current ``MCPProtocolVersion/latest``.
+    /// Resolution order: the negotiated **legacy session** version, then the
+    /// modern `_meta` value, then the server's current ``MCPProtocolVersion/latest``.
+    ///
+    /// The session is checked first on purpose: on the legacy (stateful) path a
+    /// client commits to a version at `initialize`, and it must not be able to
+    /// opt back into a different version by adding a per-request
+    /// `_meta["io.modelcontextprotocol/protocolVersion"]`. The modern path is
+    /// sessionless, so there `_meta` is the only source.
     var effectiveProtocolVersion: String {
         get async {
-            if let version = meta?.protocolVersion {
+            if let version = await Session.current?.negotiatedProtocolVersion {
                 return version
             }
-            if let version = await Session.current?.negotiatedProtocolVersion {
+            if let version = meta?.protocolVersion {
                 return version
             }
             return MCPProtocolVersion.latest
@@ -41,14 +47,18 @@ public extension RequestContext {
         }
     }
 
-    /// The client's declared capabilities, from `_meta` (modern) or the session
-    /// (legacy).
+    /// The client's declared capabilities: from the negotiated **legacy
+    /// session** if present, otherwise the modern `_meta` value.
+    ///
+    /// Session-first for the same reason as ``effectiveProtocolVersion`` — a
+    /// legacy client's negotiated capabilities are authoritative and cannot be
+    /// overridden per-request via `_meta`.
     var effectiveClientCapabilities: ClientCapabilities? {
         get async {
-            if let capabilities = meta?.clientCapabilities {
+            if let capabilities = await Session.current?.clientCapabilities {
                 return capabilities
             }
-            return await Session.current?.clientCapabilities
+            return meta?.clientCapabilities
         }
     }
 

--- a/Sources/SwiftMCP/Transport/StdioTransport.swift
+++ b/Sources/SwiftMCP/Transport/StdioTransport.swift
@@ -146,6 +146,13 @@ public final class StdioTransport: Transport, Service, @unchecked Sendable {
                 return
             }
 
+            let batchVersion = await JSONRPCMessage.batchingVersion(for: messages, session: session)
+            if JSONRPCMessage.batchingRejected(body: data, version: batchVersion) {
+                logger.warning("Rejected stdio batch on protocol version \(batchVersion)")
+                try await send([JSONRPCMessage.batchingRejectionResponse(version: batchVersion)])
+                return
+            }
+
             let responses = await server.processBatch(messages)
 
             guard !responses.isEmpty else {

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
@@ -118,6 +118,13 @@ extension TCPBonjourTransport {
                     return
                 }
 
+                let batchVersion = await JSONRPCMessage.batchingVersion(for: messages, session: session)
+                if JSONRPCMessage.batchingRejected(body: data, version: batchVersion) {
+                    logger.warning("Rejected TCP batch on protocol version \(batchVersion) (\(session.id))")
+                    try await send([JSONRPCMessage.batchingRejectionResponse(version: batchVersion)])
+                    return
+                }
+
                 let responses = await server.processBatch(messages)
                 guard !responses.isEmpty else { return }
                 try await send(responses)

--- a/Tests/SwiftMCPTests/JSONRPCBatchingGateTests.swift
+++ b/Tests/SwiftMCPTests/JSONRPCBatchingGateTests.swift
@@ -59,4 +59,30 @@ struct JSONRPCBatchingGateTests {
         let bareInitialize = JSONRPCMessage.request(id: 1, method: "initialize", params: [:])
         #expect(SessionInitializationGate.initializeProtocolVersion([bareInitialize]) == nil)
     }
+
+    @Test("batchingVersion prefers the negotiated session, then a leading initialize, then latest")
+    func batchingVersionResolution() async {
+        let ping = JSONRPCMessage.request(id: 1, method: "ping")
+
+        let negotiated = Session(id: UUID())
+        await negotiated.setNegotiatedProtocolVersion("2025-06-18")
+        #expect(await JSONRPCMessage.batchingVersion(for: [ping], session: negotiated) == "2025-06-18")
+
+        let fresh = Session(id: UUID())
+        let initialize = JSONRPCMessage.request(
+            id: 1, method: "initialize", params: ["protocolVersion": .string("2025-03-26")]
+        )
+        #expect(await JSONRPCMessage.batchingVersion(for: [initialize, ping], session: fresh) == "2025-03-26")
+        #expect(await JSONRPCMessage.batchingVersion(for: [ping], session: fresh) == MCPProtocolVersion.latest)
+    }
+
+    @Test("batchingRejectionResponse is a JSON-RPC -32600 error with no id")
+    func rejectionResponseShape() {
+        guard case .errorResponse(let data) = JSONRPCMessage.batchingRejectionResponse(version: "2025-11-25") else {
+            Issue.record("Expected an error response")
+            return
+        }
+        #expect(data.id == nil)
+        #expect(data.error.code == -32600)
+    }
 }

--- a/Tests/SwiftMCPTests/ProtocolVersionProfileTests.swift
+++ b/Tests/SwiftMCPTests/ProtocolVersionProfileTests.swift
@@ -97,6 +97,22 @@ struct ProtocolVersionProfileTests {
         #expect(!MCPProtocolVersion.supported.contains(MCPProtocolVersion.modern))
     }
 
+    /// Guardrail: the server must only advertise the latest stable version it
+    /// more or less fully supports. Until the modern (`2026-07-28`) surface
+    /// (server/discover, MRTR, sessionless transport, …) is implemented, every
+    /// advertised version must be legacy-era, and `latest` must be advertised.
+    /// Adding a modern version here must be a deliberate change to this test.
+    @Test("Only fully-supported (legacy-era) versions are advertised")
+    func advertisesOnlyImplementedVersions() {
+        for version in MCPProtocolVersion.supported {
+            let profile = MCPProtocolVersion.profile(for: version)
+            #expect(profile != nil, "advertised version \(version) has no profile")
+            #expect(profile?.era == .legacy, "advertised version \(version) is not a fully-supported version")
+        }
+        #expect(MCPProtocolVersion.supported.contains(MCPProtocolVersion.latest))
+        #expect(!MCPProtocolVersion.supported.contains(MCPProtocolVersion.modern))
+    }
+
     // MARK: - The batching delta (the motivating case)
 
     @Test("JSON-RPC batching is only on for the revisions that defined it")

--- a/Tests/SwiftMCPTests/RequestContextProtocolVersionTests.swift
+++ b/Tests/SwiftMCPTests/RequestContextProtocolVersionTests.swift
@@ -76,15 +76,17 @@ struct RequestContextProtocolVersionTests {
         }
     }
 
-    @Test("_meta wins over the session when both are present")
-    func metaWinsOverSession() async {
+    @Test("A negotiated legacy session wins over a stray _meta version")
+    func sessionVersionWinsOverMeta() async {
         let session = Session(id: UUID())
         await session.setNegotiatedProtocolVersion("2025-06-18")
-        let context = makeContext(meta: [MCPMetaKey.protocolVersion: .string("2026-07-28")])
+        // A legacy client must not be able to opt into a different version by
+        // adding a per-request _meta protocolVersion.
+        let context = makeContext(meta: [MCPMetaKey.protocolVersion: .string("2025-11-25")])
 
         await session.work { _ in
-            #expect(await context.effectiveProtocolVersion == "2026-07-28")
-            #expect(await context.protocolProfile.isModern)
+            #expect(await context.effectiveProtocolVersion == "2025-06-18")
+            #expect(await context.protocolProfile.era == .legacy)
         }
     }
 }

--- a/Tests/SwiftMCPTests/ResourceLinkGatingTests.swift
+++ b/Tests/SwiftMCPTests/ResourceLinkGatingTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import SwiftMCP
+
+@MCPServer(name: "ResourceLinkServer")
+final class ResourceLinkServer {
+    @MCPTool(description: "Returns a resource link")
+    func getLink() -> MCPResourceLink {
+        MCPResourceLink(
+            uri: URL(string: "file:///docs/readme.md")!,
+            name: "README",
+            description: "Project readme"
+        )
+    }
+
+    @MCPTool(description: "Returns several resource links")
+    func getLinks() -> [MCPResourceLink] {
+        [
+            MCPResourceLink(uri: URL(string: "file:///a.md")!, name: "A"),
+            MCPResourceLink(uri: URL(string: "file:///b.md")!, name: "B")
+        ]
+    }
+}
+
+/// `resource_link` is a 2025-06-18 tool-result content type. For clients that
+/// negotiated an earlier revision it is degraded to a plain `text` block that
+/// still carries the link's name and URI.
+@Suite("resource_link version gating")
+struct ResourceLinkGatingTests {
+
+    private func callTool(_ name: String, negotiating version: String) async -> [[String: Any]]? {
+        let session = Session(id: UUID())
+        await session.setNegotiatedProtocolVersion(version)
+        let request = JSONRPCMessage.request(
+            id: 1,
+            method: "tools/call",
+            params: ["name": .string(name), "arguments": [:]]
+        )
+        let response = await session.work { _ in
+            await ResourceLinkServer().handleMessage(request)
+        }
+        guard case .response(let data)? = response,
+              let result = data.result,
+              let content = result["content"]?.value as? [[String: Any]] else {
+            return nil
+        }
+        return content
+    }
+
+    @Test("resource_link is preserved for 2025-06-18")
+    func preservedForModern() async throws {
+        let content = try #require(await callTool("getLink", negotiating: "2025-06-18"))
+        let first = try #require(content.first)
+        #expect(first["type"] as? String == "resource_link")
+        #expect(first["uri"] as? String == "file:///docs/readme.md")
+    }
+
+    @Test("resource_link degrades to a text block carrying name and URI for 2025-03-26")
+    func degradedForLegacy() async throws {
+        let content = try #require(await callTool("getLink", negotiating: "2025-03-26"))
+        let first = try #require(content.first)
+        #expect(first["type"] as? String == "text")
+        #expect(first["uri"] == nil)
+        let text = try #require(first["text"] as? String)
+        #expect(text.contains("README"))
+        #expect(text.contains("file:///docs/readme.md"))
+        #expect(text.contains("Project readme"))
+    }
+
+    @Test("each resource_link in an array degrades for 2025-03-26")
+    func arrayDegradedForLegacy() async throws {
+        let content = try #require(await callTool("getLinks", negotiating: "2025-03-26"))
+        #expect(content.count == 2)
+        #expect(content.allSatisfy { $0["type"] as? String == "text" })
+
+        let modern = try #require(await callTool("getLinks", negotiating: "2025-06-18"))
+        #expect(modern.allSatisfy { $0["type"] as? String == "resource_link" })
+    }
+}

--- a/Tests/SwiftMCPTests/StructuredToolOutputGatingTests.swift
+++ b/Tests/SwiftMCPTests/StructuredToolOutputGatingTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import SwiftMCP
+
+/// `outputSchema` (tools/list) and `structuredContent` (tools/call) are
+/// structured-tool-output features introduced in `2025-06-18`. They must be
+/// omitted for clients that negotiated an earlier revision.
+@Suite("Structured tool output version gating")
+struct StructuredToolOutputGatingTests {
+
+    /// Routes a request through the server with `version` bound as the
+    /// session-negotiated protocol version (the legacy resolution path).
+    private func result(
+        for request: JSONRPCMessage,
+        negotiating version: String
+    ) async -> JSONDictionary? {
+        let session = Session(id: UUID())
+        await session.setNegotiatedProtocolVersion(version)
+        let response = await session.work { _ in
+            await ComplexTypesServer().handleMessage(request)
+        }
+        guard case .response(let data)? = response else { return nil }
+        return data.result
+    }
+
+    private func createContactTool(in tools: [[String: Any]]) throws -> [String: Any] {
+        try #require(tools.first { $0["name"] as? String == "createContact" })
+    }
+
+    @Test("tools/list includes outputSchema for 2025-06-18 but omits it for 2025-03-26")
+    func outputSchemaGated() async throws {
+        let request = JSONRPCMessage.request(id: 1, method: "tools/list")
+
+        let modern = try #require(await result(for: request, negotiating: "2025-06-18"))
+        let modernTools = try #require(modern["tools"]?.value as? [[String: Any]])
+        #expect(try createContactTool(in: modernTools)["outputSchema"] != nil)
+
+        let legacy = try #require(await result(for: request, negotiating: "2025-03-26"))
+        let legacyTools = try #require(legacy["tools"]?.value as? [[String: Any]])
+        #expect(try createContactTool(in: legacyTools)["outputSchema"] == nil)
+    }
+
+    @Test("tools/call includes structuredContent for 2025-06-18 but omits it for 2025-03-26")
+    func structuredContentGated() async throws {
+        let request = JSONRPCMessage.request(
+            id: 1,
+            method: "tools/call",
+            params: [
+                "name": "createContact",
+                "arguments": [
+                    "name": "John Doe",
+                    "email": "john@example.com",
+                    "phone": "+1234567890",
+                    "age": 30,
+                    "isActive": true
+                ]
+            ]
+        )
+
+        let modern = try #require(await result(for: request, negotiating: "2025-06-18"))
+        #expect(modern["structuredContent"] != nil)
+
+        let legacy = try #require(await result(for: request, negotiating: "2025-03-26"))
+        #expect(legacy["structuredContent"] == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Puts the Phase 0 profile (merged in #139) to work: **toggle already-implemented behavior by the negotiated protocol version**, and keep what we advertise honest.

> Supersedes #140, which GitHub auto-closed when #139's branch was deleted on merge. Same commits, rebased onto `main`, plus the Codex review fix folded in.

The goal is conformance for the versions SwiftMCP *already* advertises (`2025-03-26` → `2025-11-25`), not new modern features.

## What's gated

| Behavior | Versions | Change |
|---|---|---|
| **Structured tool output** (`outputSchema`, `structuredContent`) | 2025-06-18+ | omitted for clients negotiating an earlier revision |
| **JSON-RPC batching** on **stdio + TCP** | removed 2025-06-18 | rejected (`-32600`); HTTP was done in #139 |
| **`resource_link`** in tool results | 2025-06-18+ | degraded to a `text` block carrying `<name>: <uri>` (+ description) |

Plus the `await ...supports(.feature)` seam every gate reads, and a **guardrail test** encoding "advertise only the latest stable we fully support" (`2026-07-28` stays out of `supported`).

## Design
- Gates resolve through the seam (`protocolProfile`), branching on capabilities, not version strings.
- **The negotiated session is authoritative** on the legacy path: a per-request `_meta` can't let a client override the version it negotiated at `initialize` (session-first resolution — addressed a Codex P2 on #140).
- **Default is permissive**: an unbound context resolves to `latest`, so current clients are unaffected; the stricter behavior only applies to clients that negotiated an older version.
- The **in-process bridge is intentionally ungated** — internal SwiftMCP infrastructure, not an external wire transport.

## Testing
- New gating tests: structured output (list + call), `resource_link` (single + array), batching resolver/rejection shape, and the advertising guardrail.
- Full suite **457 tests in 77 suites**, green; `swiftlint --strict` clean.

## Deferred (tracked)
- serverInfo `title` / `icons` / `websiteUrl` parity → #141 (additive feature).

Part of #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
