### PR TITLE
serverInfo identity round-trip: title / icons / websiteUrl (#141)

### DIFF
--- a/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
@@ -222,6 +222,9 @@ extension MCPServerProxy {
         serverName = initResult.serverInfo.name
         serverVersion = initResult.serverInfo.version
         serverDescription = initResult.serverInfo.description ?? rawServerDescription
+        serverTitle = initResult.serverInfo.title
+        serverWebsiteUrl = initResult.serverInfo.websiteUrl
+        serverIcons = initResult.serverInfo.icons ?? []
         serverCapabilities = initResult.capabilities
         if service == nil {
             service = serverName

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -83,6 +83,12 @@ public final actor MCPServerProxy {
     public internal(set) var serverName: String?
     public internal(set) var serverVersion: String?
     public internal(set) var serverDescription: String?
+    /// The server's human-friendly display title, if it advertised one (2025-06-18+).
+    public internal(set) var serverTitle: String?
+    /// The server's website URL, if it advertised one (2025-06-18+).
+    public internal(set) var serverWebsiteUrl: URL?
+    /// The server's display icons (2025-06-18+); empty when none were advertised.
+    public internal(set) var serverIcons: [Icon] = []
     public internal(set) var serverCapabilities: ServerCapabilities?
 
     internal var notificationHandlers: [String: NotificationHandlerBox] = [:]

--- a/Sources/SwiftMCP/MCPMacros.swift
+++ b/Sources/SwiftMCP/MCPMacros.swift
@@ -142,6 +142,8 @@ public macro MCPAppIntentTool(
         named(__mcpServerName),
         named(__mcpServerVersion),
         named(__mcpServerDescription),
+        named(__mcpServerTitle),
+        named(__mcpServerWebsiteUrl),
         named(mcpResourceMetadata),
         named(mcpResources),
         named(mcpStaticResources),
@@ -162,6 +164,8 @@ public macro MCPServer(
     name: String? = nil,
     version: String? = nil,
     description: String? = nil,
+    title: String? = nil,
+    websiteUrl: String? = nil,
     toolNaming: MCPToolNaming = .functionName,
     generateClient: Bool = true
 ) = #externalMacro(module: "SwiftMCPMacros", type: "MCPServerMacro")

--- a/Sources/SwiftMCP/Models/Initialization/Icon.swift
+++ b/Sources/SwiftMCP/Models/Initialization/Icon.swift
@@ -25,6 +25,22 @@ public struct Icon: Codable, Sendable {
     public var sizes: [Size]?
 
     public var theme: Theme?
+
+    public init(src: URL, mimeType: String? = nil, sizes: [Size]? = nil, theme: Theme? = nil) {
+        self.src = src
+        self.mimeType = mimeType
+        self.sizes = sizes
+        self.theme = theme
+    }
+
+    /// Convenience initializer from a string URL. Traps on a malformed URL —
+    /// intended for compile-time-constant icon URLs.
+    public init(_ src: String, mimeType: String? = nil, sizes: [Size]? = nil, theme: Theme? = nil) {
+        guard let url = URL(string: src) else {
+            preconditionFailure("Invalid icon URL: \(src)")
+        }
+        self.init(src: url, mimeType: mimeType, sizes: sizes, theme: theme)
+    }
 }
 
 extension Icon.Size: Codable {

--- a/Sources/SwiftMCP/Models/Initialization/Implementation.swift
+++ b/Sources/SwiftMCP/Models/Initialization/Implementation.swift
@@ -19,4 +19,22 @@ public struct Implementation: Codable, Sendable {
     public var description: String?
 
     public var websiteUrl: URL?
+
+    // Parameter order mirrors the synthesized memberwise initializer so existing
+    // call sites keep compiling; `name`/`version` are required, the rest optional.
+    public init(
+        icons: [Icon]? = nil,
+        name: String,
+        title: String? = nil,
+        version: String,
+        description: String? = nil,
+        websiteUrl: URL? = nil
+    ) {
+        self.icons = icons
+        self.name = name
+        self.title = title
+        self.version = version
+        self.description = description
+        self.websiteUrl = websiteUrl
+    }
 }

--- a/Sources/SwiftMCP/Models/InitializeResult.swift
+++ b/Sources/SwiftMCP/Models/InitializeResult.swift
@@ -16,27 +16,15 @@ public struct InitializeResult: Codable, Sendable {
     public let capabilities: ServerCapabilities
 
     /// Information about the server
-    public let serverInfo: ServerInfo
+    public let serverInfo: Implementation
 
-    /// Server information structure
-    public struct ServerInfo: Codable, Sendable {
-        /// The name of the server
-        public let name: String
+    /// Server identity. The spec models both client and server info as
+    /// `Implementation`; this alias preserves the `InitializeResult.ServerInfo`
+    /// spelling while unifying onto the full type (name, title, version,
+    /// description, icons, websiteUrl).
+    public typealias ServerInfo = Implementation
 
-        /// The version of the server
-        public let version: String
-
-        /// An optional description of the server
-        public let description: String?
-
-        public init(name: String, version: String, description: String? = nil) {
-            self.name = name
-            self.version = version
-            self.description = description
-        }
-    }
-
-    public init(protocolVersion: String, capabilities: ServerCapabilities, serverInfo: ServerInfo) {
+    public init(protocolVersion: String, capabilities: ServerCapabilities, serverInfo: Implementation) {
         self.protocolVersion = protocolVersion
         self.capabilities = capabilities
         self.serverInfo = serverInfo

--- a/Sources/SwiftMCP/Protocols/HasIcons.swift
+++ b/Sources/SwiftMCP/Protocols/HasIcons.swift
@@ -1,0 +1,26 @@
+//
+//  HasIcons.swift
+//  SwiftMCP
+//
+//  Opt-in capability for advertising display icons in `serverInfo`.
+//
+
+import Foundation
+
+/// Conform an `@MCPServer` type to `HasIcons` to advertise display icons in its
+/// `serverInfo`.
+///
+/// Icons are part of the server identity from protocol version `2025-06-18`.
+/// Most servers have none, so this is an explicit opt-in rather than a member of
+/// the base ``MCPServer`` surface — a conforming server simply returns its icons:
+///
+/// ```swift
+/// @MCPServer(name: "weather", title: "Weather Tools")
+/// final class WeatherServer: HasIcons {
+///     var icons: [Icon] { [Icon("https://example.com/icon.png", mimeType: "image/png")] }
+/// }
+/// ```
+public protocol HasIcons {
+    /// The display icons for this server. An empty array means none.
+    var icons: [Icon] { get }
+}

--- a/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
@@ -73,10 +73,19 @@ public extension MCPServer {
     ) async -> JSONRPCMessage {
         let capabilities = await buildServerCapabilities()
 
-        let serverInfo = InitializeResult.ServerInfo(
+        // `title` / `icons` / `websiteUrl` are richer serverInfo identity fields
+        // introduced in 2025-06-18; include them only for clients negotiating
+        // that revision or later (they share the `.titleField` gate).
+        let includeRichIdentity = MCPProtocolVersion.profile(for: protocolVersion)?.has(.titleField) ?? false
+        let icons = (self as? HasIcons)?.icons ?? []
+
+        let serverInfo = Implementation(
+            icons: includeRichIdentity && !icons.isEmpty ? icons : nil,
             name: serverName,
+            title: includeRichIdentity ? serverTitle : nil,
             version: serverVersion,
-            description: serverDescription
+            description: serverDescription,
+            websiteUrl: includeRichIdentity ? serverWebsiteUrl : nil
         )
 
         let result = InitializeResult(

--- a/Sources/SwiftMCP/Protocols/MCPServer.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer.swift
@@ -35,6 +35,17 @@ public protocol MCPServer {
     var serverDescription: String? { get }
 
     /**
+     A human-friendly display name for the server, distinct from `serverName`
+     (a programmatic identifier). Introduced in protocol version `2025-06-18`.
+     */
+    var serverTitle: String? { get }
+
+    /**
+     A URL for the server's website or homepage. Introduced in protocol version `2025-06-18`.
+     */
+    var serverWebsiteUrl: URL? { get }
+
+    /**
      Handles a JSON-RPC message and generates an appropriate response.
 
      - Parameter message: The JSON-RPC message to handle
@@ -70,6 +81,25 @@ public extension MCPServer {
     var serverDescription: String? {
         Mirror(reflecting: self).children
             .first(where: { $0.label == "__mcpServerDescription" })?.value as? String
+    }
+
+    /**
+     The server's display title, derived from the `@MCPServer(title:)` macro argument.
+     */
+    var serverTitle: String? {
+        Mirror(reflecting: self).children
+            .first(where: { $0.label == "__mcpServerTitle" })?.value as? String
+    }
+
+    /**
+     The server's website URL, derived from the `@MCPServer(websiteUrl:)` macro argument.
+     */
+    var serverWebsiteUrl: URL? {
+        // The macro stores the URL as a String (so generated code needs no
+        // Foundation import in the consumer); convert here.
+        (Mirror(reflecting: self).children
+            .first(where: { $0.label == "__mcpServerWebsiteUrl" })?.value as? String)
+            .flatMap(URL.init(string:))
     }
 
     /// Handles the roots list changed notification by retrieving the updated roots list.

--- a/Sources/SwiftMCPMacros/MCPServerMacro+Helpers.swift
+++ b/Sources/SwiftMCPMacros/MCPServerMacro+Helpers.swift
@@ -16,6 +16,8 @@ extension MCPServerMacro {
         let version: String
         let descriptionLiteral: String
         let serverDescriptionText: String?
+        let titleLiteral: String
+        let websiteUrlLiteral: String
         let generateClient: Bool
         let toolNaming: String?
     }
@@ -60,6 +62,8 @@ extension MCPServerMacro {
             version: serverVersion,
             descriptionLiteral: serverDescription,
             serverDescriptionText: serverDescriptionText,
+            titleLiteral: parsed.titleArg ?? "nil",
+            websiteUrlLiteral: parsed.websiteUrlArg ?? "nil",
             generateClient: parsed.generateClient,
             toolNaming: parsed.toolNaming
         )
@@ -68,6 +72,8 @@ extension MCPServerMacro {
     private struct ParsedLabeledArguments {
         var descriptionArg: String?
         var serverDescriptionText: String?
+        var titleArg: String?
+        var websiteUrlArg: String?
         var generateClient = false
         var toolNaming: String?
     }
@@ -81,6 +87,12 @@ extension MCPServerMacro {
                 let stringValue = stringLiteral.segments.description
                 parsed.descriptionArg = "\"\(stringValue.escapedForSwiftString)\""
                 parsed.serverDescriptionText = stringValue
+            } else if argument.label?.text == "title",
+                      let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self) {
+                parsed.titleArg = "\"\(stringLiteral.segments.description.escapedForSwiftString)\""
+            } else if argument.label?.text == "websiteUrl",
+                      let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self) {
+                parsed.websiteUrlArg = "\"\(stringLiteral.segments.description.escapedForSwiftString)\""
             } else if argument.label?.text == "generateClient",
                       let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self) {
                 parsed.generateClient = boolLiteral.literal.text == "true"

--- a/Sources/SwiftMCPMacros/MCPServerMacro.swift
+++ b/Sources/SwiftMCPMacros/MCPServerMacro.swift
@@ -199,10 +199,14 @@ public struct MCPServerMacro: MemberMacro, ExtensionMacro, MemberAttributeMacro 
         let nameProperty = "private let __mcpServerName = \"\(serverArgs.name)\""
         let versionProperty = "private let __mcpServerVersion = \"\(serverArgs.version)\""
         let descriptionProperty = "private let __mcpServerDescription: String? = \(serverArgs.descriptionLiteral)"
+        let titleProperty = "private let __mcpServerTitle: String? = \(serverArgs.titleLiteral)"
+        let websiteUrlProperty = "private let __mcpServerWebsiteUrl: String? = \(serverArgs.websiteUrlLiteral)"
         return [
             DeclSyntax(stringLiteral: nameProperty),
             DeclSyntax(stringLiteral: versionProperty),
-            DeclSyntax(stringLiteral: descriptionProperty)
+            DeclSyntax(stringLiteral: descriptionProperty),
+            DeclSyntax(stringLiteral: titleProperty),
+            DeclSyntax(stringLiteral: websiteUrlProperty)
         ]
     }
 }

--- a/Tests/SwiftMCPTests/ProxyGeneratorDocCommentTests.swift
+++ b/Tests/SwiftMCPTests/ProxyGeneratorDocCommentTests.swift
@@ -52,4 +52,26 @@ struct ProxyGeneratorDocCommentTests {
         // The type doc comment prefers the title over the programmatic name.
         #expect(source.contains("A generated proxy for the Weather Tools MCP server (1.0)."))
     }
+
+    @Test("Server titles with special characters are escaped in the generated literal")
+    func escapesSpecialCharactersInTitle() throws {
+        let metadata = ProxyGenerator.HeaderMetadata(
+            fileName: "P.swift",
+            serverName: "p",
+            serverVersion: "1.0",
+            serverDescription: nil,
+            source: nil,
+            openAPI: nil,
+            serverTitle: "a\"b\\c\nd"   // quote, backslash, newline
+        )
+
+        let source = ProxyGenerator.generate(
+            typeName: "P",
+            tools: [],
+            headerMetadata: metadata
+        ).description
+
+        // " -> \", \ -> \\, newline -> \n : a valid Swift literal, not a malformed one.
+        #expect(source.contains(#"a\"b\\c\nd"#))
+    }
 }

--- a/Tests/SwiftMCPTests/ProxyGeneratorDocCommentTests.swift
+++ b/Tests/SwiftMCPTests/ProxyGeneratorDocCommentTests.swift
@@ -25,4 +25,31 @@ struct ProxyGeneratorDocCommentTests {
         #expect(source.contains("/// Line \"two\"."))
         #expect(source.contains("/// Line three."))
     }
+
+    @Test("Metadata section embeds title, websiteUrl and icon URLs")
+    func metadataSectionEmbedsServerIdentity() throws {
+        let metadata = ProxyGenerator.HeaderMetadata(
+            fileName: "WeatherProxy.swift",
+            serverName: "weather",
+            serverVersion: "1.0",
+            serverDescription: nil,
+            source: nil,
+            openAPI: nil,
+            serverTitle: "Weather Tools",
+            serverWebsiteUrl: "https://example.com/weather",
+            serverIconURLs: ["https://example.com/icon.png"]
+        )
+
+        let source = ProxyGenerator.generate(
+            typeName: "WeatherProxy",
+            tools: [],
+            headerMetadata: metadata
+        ).description
+
+        #expect(source.contains(#"public static let serverTitle: String? = "Weather Tools""#))
+        #expect(source.contains(#"public static let serverWebsiteUrl: String? = "https://example.com/weather""#))
+        #expect(source.contains(#"public static let serverIconURLs: [String] = ["https://example.com/icon.png"]"#))
+        // The type doc comment prefers the title over the programmatic name.
+        #expect(source.contains("A generated proxy for the Weather Tools MCP server (1.0)."))
+    }
 }

--- a/Tests/SwiftMCPTests/ServerInfoIdentityTests.swift
+++ b/Tests/SwiftMCPTests/ServerInfoIdentityTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import SwiftMCP
+
+@MCPServer(name: "weather", title: "Weather Tools", websiteUrl: "https://example.com/weather")
+final class RichIdentityServer: HasIcons {
+    var icons: [Icon] { [Icon("https://example.com/icon.png", mimeType: "image/png")] }
+
+    @MCPTool(description: "Ping")
+    func ping() -> String { "pong" }
+}
+
+@MCPServer(name: "plain")
+final class PlainIdentityServer {
+    @MCPTool(description: "Ping")
+    func ping() -> String { "pong" }
+}
+
+@Suite("serverInfo identity")
+struct ServerInfoIdentityTests {
+
+    // MARK: - Authoring (macro args / HasIcons -> protocol surface)
+
+    @Test("@MCPServer(title:websiteUrl:) populates the protocol properties")
+    func macroArgsPopulateProperties() {
+        let server = RichIdentityServer()
+        #expect(server.serverName == "weather")
+        #expect(server.serverTitle == "Weather Tools")
+        #expect(server.serverWebsiteUrl == URL(string: "https://example.com/weather"))
+        #expect(server.icons.count == 1)
+    }
+
+    @Test("A plain server has no title / websiteUrl / icons")
+    func plainServerDefaults() {
+        let server = PlainIdentityServer()
+        #expect(server.serverTitle == nil)
+        #expect(server.serverWebsiteUrl == nil)
+        #expect((server as? HasIcons) == nil)
+    }
+
+    // MARK: - Emission (version-gated)
+
+    private func serverInfo<S: MCPServer>(
+        version: String,
+        make: @Sendable @escaping () -> S
+    ) async -> JSONDictionary? {
+        let request = JSONRPCMessage.request(
+            id: 1,
+            method: "initialize",
+            params: [
+                "protocolVersion": .string(version),
+                "capabilities": .object([:]),
+                "clientInfo": .object(["name": .string("C"), "version": .string("1.0")])
+            ]
+        )
+        let session = Session(id: UUID())
+        let response = await session.work { _ in await make().handleMessage(request) }
+        guard case .response(let data)? = response,
+              let result = data.result,
+              let info = result["serverInfo"]?.dictionaryValue else {
+            return nil
+        }
+        return info
+    }
+
+    @Test("serverInfo includes title / icons / websiteUrl for 2025-06-18")
+    func emitsRichIdentityForModern() async throws {
+        let info = try #require(await serverInfo(version: "2025-06-18") { RichIdentityServer() })
+        #expect(info["name"]?.stringValue == "weather")
+        #expect(info["title"]?.stringValue == "Weather Tools")
+        #expect(info["websiteUrl"]?.stringValue == "https://example.com/weather")
+        #expect((info["icons"]?.value as? [[String: Any]])?.count == 1)
+    }
+
+    @Test("serverInfo omits title / icons / websiteUrl for 2025-03-26")
+    func omitsRichIdentityForLegacy() async throws {
+        let info = try #require(await serverInfo(version: "2025-03-26") { RichIdentityServer() })
+        #expect(info["name"]?.stringValue == "weather")    // name always present
+        #expect(info["title"] == nil)
+        #expect(info["websiteUrl"] == nil)
+        #expect(info["icons"] == nil)
+    }
+
+    @Test("serverInfo omits empty icons even when the version supports them")
+    func omitsEmptyIcons() async throws {
+        let info = try #require(await serverInfo(version: "2025-11-25") { PlainIdentityServer() })
+        #expect(info["icons"] == nil)
+        #expect(info["title"] == nil)
+    }
+}

--- a/Tests/SwiftMCPTests/ServerInfoIdentityTests.swift
+++ b/Tests/SwiftMCPTests/ServerInfoIdentityTests.swift
@@ -87,4 +87,32 @@ struct ServerInfoIdentityTests {
         #expect(info["icons"] == nil)
         #expect(info["title"] == nil)
     }
+
+    // MARK: - Read path (decode -> Implementation, as MCPServerProxy does)
+
+    @Test("Emitted serverInfo decodes back into InitializeResult (proxy read path)")
+    func roundTripsToInitializeResult() async throws {
+        let request = JSONRPCMessage.request(
+            id: 1,
+            method: "initialize",
+            params: [
+                "protocolVersion": .string("2025-06-18"),
+                "capabilities": .object([:]),
+                "clientInfo": .object(["name": .string("C"), "version": .string("1.0")])
+            ]
+        )
+        let session = Session(id: UUID())
+        let response = await session.work { _ in await RichIdentityServer().handleMessage(request) }
+        guard case .response(let data)? = response, let result = data.result else {
+            Issue.record("Expected an initialize response")
+            return
+        }
+
+        // Exactly what MCPServerProxy does to capture the server's identity.
+        let initResult = try result.decoded(InitializeResult.self)
+        #expect(initResult.serverInfo.title == "Weather Tools")
+        #expect(initResult.serverInfo.websiteUrl == URL(string: "https://example.com/weather"))
+        #expect(initResult.serverInfo.icons?.count == 1)
+        #expect(initResult.serverInfo.icons?.first?.src == URL(string: "https://example.com/icon.png"))
+    }
 }

--- a/Utilities/SwiftMCPUtility/GenerateProxyCommand.swift
+++ b/Utilities/SwiftMCPUtility/GenerateProxyCommand.swift
@@ -87,6 +87,9 @@ struct GenerateProxyCommand: AsyncParsableCommand {
         let serverName: String?
         let serverVersion: String?
         let serverDescription: String?
+        let serverTitle: String?
+        let serverWebsiteUrl: String?
+        let serverIconURLs: [String]
     }
 
     private func collectServerSurfaces(proxy: MCPServerProxy) async throws -> ServerSurfaces {
@@ -99,6 +102,9 @@ struct GenerateProxyCommand: AsyncParsableCommand {
         let serverName = await proxy.serverName
         let serverVersion = await proxy.serverVersion
         let serverDescription = await proxy.serverDescription
+        let serverTitle = await proxy.serverTitle
+        let serverWebsiteUrl = await proxy.serverWebsiteUrl?.absoluteString
+        let serverIconURLs = await proxy.serverIcons.map { $0.src.absoluteString }
         return ServerSurfaces(
             tools: tools,
             resources: resources,
@@ -108,7 +114,10 @@ struct GenerateProxyCommand: AsyncParsableCommand {
             supportsPrompts: supportsPrompts,
             serverName: serverName,
             serverVersion: serverVersion,
-            serverDescription: serverDescription
+            serverDescription: serverDescription,
+            serverTitle: serverTitle,
+            serverWebsiteUrl: serverWebsiteUrl,
+            serverIconURLs: serverIconURLs
         )
     }
 
@@ -140,7 +149,10 @@ struct GenerateProxyCommand: AsyncParsableCommand {
             serverVersion: surfaces.serverVersion,
             serverDescription: surfaces.serverDescription,
             source: connectionSourceDescription(),
-            openAPI: openapi
+            openAPI: openapi,
+            serverTitle: surfaces.serverTitle,
+            serverWebsiteUrl: surfaces.serverWebsiteUrl,
+            serverIconURLs: surfaces.serverIconURLs
         )
     }
 

--- a/Utilities/SwiftMCPUtilityCore/ProxyGenerator+ActorSource.swift
+++ b/Utilities/SwiftMCPUtilityCore/ProxyGenerator+ActorSource.swift
@@ -56,8 +56,15 @@ extension ProxyGenerator {
     }
 
     private static func appendMetadataSection(metadata: HeaderMetadata, into lines: inout [String]) {
+        let name = swiftOptionalStringLiteral(metadata.serverName)
+        let title = swiftOptionalStringLiteral(metadata.serverTitle)
+        let website = swiftOptionalStringLiteral(metadata.serverWebsiteUrl)
+        let icons = metadata.serverIconURLs.map { swiftOptionalStringLiteral($0) }.joined(separator: ", ")
         lines.append("    // MARK: - Metadata")
-        lines.append("    public static let serverName: String? = \(swiftOptionalStringLiteral(metadata.serverName))")
+        lines.append("    public static let serverName: String? = \(name)")
+        lines.append("    public static let serverTitle: String? = \(title)")
+        lines.append("    public static let serverWebsiteUrl: String? = \(website)")
+        lines.append("    public static let serverIconURLs: [String] = [\(icons)]")
         lines.append("")
     }
 

--- a/Utilities/SwiftMCPUtilityCore/ProxyGenerator+ActorSource.swift
+++ b/Utilities/SwiftMCPUtilityCore/ProxyGenerator+ActorSource.swift
@@ -177,9 +177,16 @@ extension ProxyGenerator {
 
     static func swiftOptionalStringLiteral(_ value: String?) -> String {
         guard let value else { return "nil" }
+        // Escape for embedding as a Swift double-quoted string literal. Server
+        // metadata (e.g. a free-form title) is untrusted display text, so it may
+        // contain backslashes, quotes or newlines. Backslash MUST be escaped
+        // first so the backslashes introduced below are not double-escaped.
         let escaped = value
-            .replacingOccurrences(of: "\\\\", with: "\\\\\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\\\"")
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
         return "\"\(escaped)\""
     }
 

--- a/Utilities/SwiftMCPUtilityCore/ProxyGenerator+Header.swift
+++ b/Utilities/SwiftMCPUtilityCore/ProxyGenerator+Header.swift
@@ -41,13 +41,16 @@ extension ProxyGenerator {
     }
 
     private static func typeDocSummary(metadata: HeaderMetadata) -> String {
+        // Prefer the human-friendly title when present, falling back to name.
+        let title = metadata.serverTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let name = metadata.serverName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let displayName = title.isEmpty ? name : title
         let version = metadata.serverVersion?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !name.isEmpty {
+        if !displayName.isEmpty {
             if !version.isEmpty {
-                return "A generated proxy for the \(name) MCP server (\(version))."
+                return "A generated proxy for the \(displayName) MCP server (\(version))."
             }
-            return "A generated proxy for the \(name) MCP server."
+            return "A generated proxy for the \(displayName) MCP server."
         }
         return "A generated MCP server proxy."
     }

--- a/Utilities/SwiftMCPUtilityCore/ProxyGenerator.swift
+++ b/Utilities/SwiftMCPUtilityCore/ProxyGenerator.swift
@@ -14,6 +14,9 @@ public enum ProxyGenerator {
         public let serverDescription: String?
         public let source: String?
         public let openAPI: String?
+        public let serverTitle: String?
+        public let serverWebsiteUrl: String?
+        public let serverIconURLs: [String]
 
         public init(
             fileName: String,
@@ -21,7 +24,10 @@ public enum ProxyGenerator {
             serverVersion: String?,
             serverDescription: String?,
             source: String?,
-            openAPI: String?
+            openAPI: String?,
+            serverTitle: String? = nil,
+            serverWebsiteUrl: String? = nil,
+            serverIconURLs: [String] = []
         ) {
             self.fileName = fileName
             self.serverName = serverName
@@ -29,6 +35,9 @@ public enum ProxyGenerator {
             self.serverDescription = serverDescription
             self.source = source
             self.openAPI = openAPI
+            self.serverTitle = serverTitle
+            self.serverWebsiteUrl = serverWebsiteUrl
+            self.serverIconURLs = serverIconURLs
         }
     }
 


### PR DESCRIPTION
## Summary

Implements #141 — the **serverInfo identity round-trip**. Server identity (`title` / `icons` / `websiteUrl`, the richer `Implementation` fields the spec defines from 2025-06-18) now flows symmetrically through all four surfaces instead of falling off at each one.

```
@MCPServer(…) / HasIcons  →  serverInfo emit  →  MCPServerProxy read  →  generated proxy
```

## What's in it

| Layers | Change |
|---|---|
| **1–3 (server)** | `serverInfo` unified onto `Implementation` (`InitializeResult.ServerInfo` kept as a source-compat typealias); `@MCPServer(title:websiteUrl:)` macro args + `HasIcons` opt-in for icons; `createInitializeResponse` emits the rich identity **version-gated** (only for 2025-06-18+; empty icons omitted) |
| **4 (client read)** | `MCPServerProxy` gains `serverTitle` / `serverWebsiteUrl` / `serverIcons` (`[Icon]`, empty when none), populated from the decoded serverInfo |
| **5 (generated proxy)** | the generator embeds `serverTitle` / `serverWebsiteUrl` / `serverIconURLs` statics in the proxy's metadata section, and the type doc comment prefers `title` over `name` |

## Developer experience

- **`title` / `websiteUrl`** → `@MCPServer` macro args (common scalars). `websiteUrl` is stored as a `String` and converted to `URL` in the protocol default, so generated code needs no `Foundation` import in consumer files.
- **`icons`** → opt-in `protocol HasIcons { var icons: [Icon] }` — non-optional (`[]` = none), conformed only when a server has icons, keeping the base `MCPServer` surface clean. Plus a public `Icon(_ urlString:…)` convenience init.

```swift
@MCPServer(name: "weather", title: "Weather Tools", websiteUrl: "https://example.com")
final class WeatherServer: HasIcons {
    var icons: [Icon] { [Icon("https://example.com/icon.png", mimeType: "image/png")] }
}
```

`Icon` / `Implementation` also gained public inits so external authors can construct them.

## Testing
- New: `ServerInfoIdentityTests` (macro args → protocol props, `HasIcons`, version-gated emission, and an emit→decode round-trip exercising the proxy read path) + generator metadata-embedding assertions.
- Full suite **464 tests in 78 suites**, green; `swiftlint --strict` clean.

## Notes / deferred
- The optional **client-send** step (have `MCPServerProxy` advertise its *own* `clientInfo` title/icons/websiteUrl — it currently sends only name+version) is left as a follow-up, as flagged in #141.
- The checked-in example proxies (`XcodeProxy.swift`, `ToolsProxy.swift`) will gain the new metadata statics on their next regeneration against a live server.

Implements #141. Part of #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
