### PR TITLE
Version-conditional conformance: gate elicitation, fix client protocol-version header, down-negotiate initialize

### DIFF
--- a/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
@@ -13,6 +13,10 @@ extension MCPServerProxy {
         isDisconnecting = false
         streamFailure = nil
         endpointURL = nil
+        // Clear any version carried over from a previous connection so the
+        // re-`initialize` below proposes `latest` afresh rather than echoing a
+        // stale negotiated version in its `MCP-Protocol-Version` header.
+        negotiatedProtocolVersion = nil
 
         // Reset the session identity so a reconnect after `.sessionInvalidated`
         // starts clean. The stdio/TCP cases immediately assign a fresh
@@ -219,6 +223,9 @@ extension MCPServerProxy {
 
         let rawServerDescription = extractServerDescription(from: result)
         let initResult = try Self.decodeJSONPayload(result, as: InitializeResult.self)
+        // The server echoes the agreed revision, which may be older than the
+        // `latest` we proposed; from here on the client acts on this version.
+        negotiatedProtocolVersion = initResult.protocolVersion
         serverName = initResult.serverInfo.name
         serverVersion = initResult.serverInfo.version
         serverDescription = initResult.serverInfo.description ?? rawServerDescription

--- a/Sources/SwiftMCP/Client/MCPServerProxy+SSE.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+SSE.swift
@@ -37,10 +37,32 @@ extension MCPServerProxy {
     }
 
     internal func applyStreamableProtocolHeaders(_ request: inout URLRequest) {
-        request.setValue(MCPProtocolVersion.latest, forHTTPField: .mcpProtocolVersion)
+        // After the handshake the client MUST echo the *negotiated* revision,
+        // not the `latest` it proposed (2025-06-18 transport rules). Passing
+        // `nil` omits the header entirely, which is what a pre-2025-06-18
+        // negotiated revision requires (the header postdates it).
+        request.setValue(mcpProtocolVersionHeaderValue, forHTTPField: .mcpProtocolVersion)
         if let sessionID {
             request.setValue(sessionID, forHTTPField: .mcpSessionID)
         }
+    }
+
+    /// The value for the `MCP-Protocol-Version` header on streamable-HTTP
+    /// requests: the negotiated revision once known, otherwise the `latest` the
+    /// client is about to propose on the `initialize` request.
+    internal var mcpProtocolVersionHeaderValue: String? {
+        Self.mcpProtocolVersionHeader(for: negotiatedProtocolVersion ?? MCPProtocolVersion.latest)
+    }
+
+    /// The `MCP-Protocol-Version` header value for `version`: the revision
+    /// itself when it includes the header feature (`2025-06-18`+), otherwise
+    /// `nil` so the header is omitted for revisions that predate it. Unknown
+    /// revisions are treated permissively (sent as-is).
+    internal static func mcpProtocolVersionHeader(for version: String) -> String? {
+        guard MCPProtocolVersion.profile(for: version)?.has(.protocolVersionHeader) ?? true else {
+            return nil
+        }
+        return version
     }
 
     internal func configureSSEPOSTRequest(

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -91,6 +91,14 @@ public final actor MCPServerProxy {
     public internal(set) var serverIcons: [Icon] = []
     public internal(set) var serverCapabilities: ServerCapabilities?
 
+    /// The protocol revision negotiated with the server during `initialize`
+    /// (the value the server echoed back, which may be older than the `latest`
+    /// the client proposed). `nil` until the handshake completes. The client
+    /// honors this when acting on the connection — notably the
+    /// `MCP-Protocol-Version` header it sends on subsequent streamable-HTTP
+    /// requests.
+    public internal(set) var negotiatedProtocolVersion: String?
+
     internal var notificationHandlers: [String: NotificationHandlerBox] = [:]
 
     /// Optional handler for log notifications from the server.

--- a/Sources/SwiftMCP/Errors/MCPServerError.swift
+++ b/Sources/SwiftMCP/Errors/MCPServerError.swift
@@ -17,6 +17,11 @@ public enum MCPServerError: LocalizedError {
     /// The client does not support elicitation functionality.
     case clientHasNoElicitationSupport
 
+    /// The negotiated protocol revision does not include the requested feature,
+    /// so the server must not exercise it (e.g. `elicitation/create` against a
+    /// client that negotiated a pre-`2025-06-18` revision).
+    case featureUnavailableInNegotiatedVersion(feature: MCPFeature, version: String)
+
     /// Client returned an error response with specific code and message.
     case clientError(code: Int, message: String)
 
@@ -35,6 +40,8 @@ public enum MCPServerError: LocalizedError {
             return "Client does not support sampling functionality"
         case .clientHasNoElicitationSupport:
             return "Client does not support elicitation functionality"
+        case .featureUnavailableInNegotiatedVersion(let feature, let version):
+            return "The negotiated protocol version \(version) does not support \(feature.rawValue)"
         case .clientError(let code, let message):
             return "Client error \(code): \(message)"
         case .unexpectedMessageType(let method):

--- a/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
@@ -15,14 +15,16 @@ public extension MCPServer {
         _ request: JSONRPCMessage.JSONRPCRequestData
     ) async -> JSONRPCMessage? {
         await Session.current?.markInitializeRequestReceived()
-        let negotiatedProtocolVersion = request.params?["protocolVersion"]?.stringValue
+        // MCP lifecycle negotiation: echo the requested revision when we support
+        // it, otherwise respond with the latest revision we *do* support — never
+        // reject the handshake. A client that proposed something we don't know
+        // (typically a newer revision) then decides whether it can speak our
+        // latest. Absent any proposal we assume our latest.
+        let requestedProtocolVersion = request.params?["protocolVersion"]?.stringValue
             ?? MCPProtocolVersion.latest
-        guard MCPProtocolVersion.supported.contains(negotiatedProtocolVersion) else {
-            return JSONRPCMessage.errorResponse(
-                id: request.id,
-                error: .init(code: -32602, message: "Unsupported protocol version: \(negotiatedProtocolVersion)")
-            )
-        }
+        let negotiatedProtocolVersion = MCPProtocolVersion.supported.contains(requestedProtocolVersion)
+            ? requestedProtocolVersion
+            : MCPProtocolVersion.latest
         await Session.current?.setNegotiatedProtocolVersion(negotiatedProtocolVersion)
         await extractAndStoreCapabilities(request)
         await extractAndStoreClientInfo(request)

--- a/Sources/SwiftMCP/Transport/RequestContext.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext.swift
@@ -204,6 +204,21 @@ public final class RequestContext: Sendable {
             throw MCPServerError.noActiveSession
         }
 
+        // Elicitation was introduced in 2025-06-18. If the session negotiated an
+        // earlier revision, the feature is not part of the agreed protocol —
+        // refuse rather than emitting an `elicitation/create` the client cannot
+        // understand. Gate on the negotiated profile, not just the advertised
+        // capability, so a client that over-declares the capability on an older
+        // revision is still held to what it negotiated.
+        if let version = await session.negotiatedProtocolVersion,
+           let profile = MCPProtocolVersion.profile(for: version),
+           !profile.has(.elicitation) {
+            throw MCPServerError.featureUnavailableInNegotiatedVersion(
+                feature: .elicitation,
+                version: version
+            )
+        }
+
         // Check if client supports elicitation
         let capabilities = await session.clientCapabilities
         guard capabilities?.elicitation != nil else {

--- a/Tests/SwiftMCPTests/ClientProtocolVersionHeaderTests.swift
+++ b/Tests/SwiftMCPTests/ClientProtocolVersionHeaderTests.swift
@@ -1,0 +1,40 @@
+#if Client
+import Testing
+@testable import SwiftMCP
+
+/// The client must echo the *negotiated* protocol revision in the
+/// `MCP-Protocol-Version` header — and omit the header entirely for revisions
+/// that predate it (it is a 2025-06-18 feature). This mirrors the server's
+/// `validateHTTPProtocolVersion`, which rejects a header disagreeing with the
+/// negotiated session version, so echoing a stale `latest` would break a
+/// down-negotiated connection.
+@Suite("Client MCP-Protocol-Version header")
+struct ClientProtocolVersionHeaderTests {
+
+    @Test(
+        "Revisions that define the header echo their own version",
+        arguments: ["2025-06-18", "2025-11-25"]
+    )
+    func sendsHeaderForHeaderCarryingRevisions(_ version: String) {
+        #expect(MCPServerProxy.mcpProtocolVersionHeader(for: version) == version)
+    }
+
+    @Test("2025-03-26 predates the header, so it is omitted")
+    func omitsHeaderForPre0618() {
+        #expect(MCPServerProxy.mcpProtocolVersionHeader(for: "2025-03-26") == nil)
+    }
+
+    @Test("The proposed latest carries the header (the pre-negotiation default)")
+    func latestSendsHeader() {
+        #expect(
+            MCPServerProxy.mcpProtocolVersionHeader(for: MCPProtocolVersion.latest)
+                == MCPProtocolVersion.latest
+        )
+    }
+
+    @Test("An unknown revision is treated permissively (sent as-is)")
+    func unknownRevisionSentAsIs() {
+        #expect(MCPServerProxy.mcpProtocolVersionHeader(for: "2099-01-01") == "2099-01-01")
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/ElicitationVersionGatingTests.swift
+++ b/Tests/SwiftMCPTests/ElicitationVersionGatingTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import SwiftMCP
+
+/// `elicitation/create` is a 2025-06-18 feature. The server must gate it on the
+/// *negotiated* protocol version — not merely the client's advertised
+/// capability — so a session that negotiated an earlier revision can never be
+/// driven into an elicitation round-trip, even if the client over-declares the
+/// capability.
+@Suite("Elicitation version gating")
+struct ElicitationVersionGatingTests {
+
+    /// A Sendable summary of how `elicit` resolved, so the assertion can run
+    /// outside the `Session.work` closure without moving a non-Sendable error
+    /// across the boundary.
+    private enum Outcome: Sendable, Equatable {
+        case returned
+        case versionGated(feature: String, version: String)
+        case clientUnsupported
+        case other(String)
+    }
+
+    private let schema = JSONSchema.object(JSONSchema.Object(
+        properties: [
+            "name": .string(title: nil, description: "Name", format: nil, minLength: nil, maxLength: nil)
+        ],
+        required: ["name"]
+    ))
+
+    /// Calls `elicit` with `Session.current` bound to a session that negotiated
+    /// `version` (when non-nil) and advertised `elicitation` per
+    /// `clientSupportsElicitation`, reducing the result to an ``Outcome``.
+    private func elicitOutcome(
+        negotiating version: String?,
+        clientSupportsElicitation: Bool
+    ) async -> Outcome {
+        let session = Session(id: UUID())
+        if let version {
+            await session.setNegotiatedProtocolVersion(version)
+        }
+        if clientSupportsElicitation {
+            await session.setClientCapabilities(
+                ClientCapabilities(elicitation: ClientCapabilities.ElicitationCapabilities())
+            )
+        }
+
+        let context = RequestContext(message: .request(id: 1, method: "tools/call"))
+        let schema = schema
+        return await session.work { _ in
+            do {
+                _ = try await context.elicit(message: "Provide your name", schema: schema)
+                return .returned
+            } catch MCPServerError.featureUnavailableInNegotiatedVersion(let feature, let version) {
+                return .versionGated(feature: feature.rawValue, version: version)
+            } catch MCPServerError.clientHasNoElicitationSupport {
+                return .clientUnsupported
+            } catch {
+                return .other(String(describing: error))
+            }
+        }
+    }
+
+    @Test("A 2025-03-26 session is refused even when the client advertises elicitation")
+    func refusedForPre0618() async {
+        let outcome = await elicitOutcome(negotiating: "2025-03-26", clientSupportsElicitation: true)
+        #expect(outcome == .versionGated(feature: MCPFeature.elicitation.rawValue, version: "2025-03-26"))
+    }
+
+    @Test(
+        "Revisions that include elicitation clear the version gate",
+        arguments: ["2025-06-18", "2025-11-25"]
+    )
+    func passesVersionGateForElicitationVersions(_ version: String) async {
+        // With no elicitation capability the version gate must pass and the
+        // *capability* check must be what rejects — proving the gate does not
+        // fire for revisions that genuinely include elicitation.
+        let outcome = await elicitOutcome(negotiating: version, clientSupportsElicitation: false)
+        #expect(outcome == .clientUnsupported)
+    }
+
+    @Test("A session without a negotiated version is not version-gated")
+    func ungatedWithoutNegotiation() async {
+        // Preserves the pre-gating behavior for sessions that never negotiated a
+        // legacy version: it falls through to the capability check.
+        let outcome = await elicitOutcome(negotiating: nil, clientSupportsElicitation: false)
+        #expect(outcome == .clientUnsupported)
+    }
+}

--- a/Tests/SwiftMCPTests/HTTPTransportTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTests.swift
@@ -98,8 +98,8 @@ struct HTTPTransportTests {
         #endif
     }
 
-    @Test("POST /mcp: initialize rejects unsupported protocol version")
-    func initializeRejectsUnsupportedProtocolVersion() async throws {
+    @Test("POST /mcp: initialize down-negotiates an unsupported protocol version to the server's latest")
+    func initializeDownNegotiatesUnsupportedProtocolVersion() async throws {
         #if canImport(FoundationNetworking)
         return
         #else
@@ -112,6 +112,9 @@ struct HTTPTransportTests {
                 id: 1,
                 method: "initialize",
                 params: [
+                    // A revision the server doesn't support (here an older,
+                    // profile-only one). Per the MCP lifecycle the server must
+                    // offer a version it *does* support rather than reject.
                     "protocolVersion": .string("2024-11-05"),
                     "capabilities": .object([:]),
                     "clientInfo": .object([
@@ -125,15 +128,15 @@ struct HTTPTransportTests {
         let (response, events) = try await HTTPTransportTestHelpers.readFiniteSSEResponse(request)
         #expect(response.statusCode == 200)
 
-        let initEvent = try #require(HTTPTransportTestHelpers.errorResponseEvent(events, id: 1))
+        let initEvent = try #require(HTTPTransportTestHelpers.responseEvent(events, id: 1))
         let message = try #require(try HTTPTransportTestHelpers.decodeEventMessage(initEvent))
-        guard case .errorResponse(let errorData) = message else {
-            Issue.record("Expected initialize error response")
+        guard case .response(let responseData) = message else {
+            Issue.record("Expected a successful initialize response")
             return
         }
 
-        #expect(errorData.error.code == -32602)
-        #expect(errorData.error.message.contains("Unsupported protocol version"))
+        // The handshake succeeds and the server advertises its latest revision.
+        #expect(responseData.result?["protocolVersion"]?.stringValue == MCPProtocolVersion.latest)
         #endif
     }
 

--- a/Tests/SwiftMCPTests/InitializeNegotiationTests.swift
+++ b/Tests/SwiftMCPTests/InitializeNegotiationTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import SwiftMCP
+
+/// The `initialize` handshake must follow the MCP lifecycle negotiation rules:
+/// echo a supported revision, otherwise respond with the server's latest
+/// supported revision rather than rejecting the handshake (so a client that
+/// proposes a newer revision can still connect at the highest the server
+/// offers).
+@Suite("Initialize protocol-version negotiation")
+struct InitializeNegotiationTests {
+
+    private func negotiatedVersion(proposing version: String?) async throws -> String {
+        var params: JSONDictionary = [
+            "capabilities": .object([:]),
+            "clientInfo": .object(["name": .string("TestClient"), "version": .string("1.0")])
+        ]
+        if let version {
+            params["protocolVersion"] = .string(version)
+        }
+        let request = JSONRPCMessage.request(id: 1, method: "initialize", params: params)
+
+        let message = try #require(await Calculator().handleMessage(request))
+        guard case .response(let response) = message else {
+            throw TestError("expected a success response, got \(message)")
+        }
+        let result = try #require(response.result)
+        return try #require(result["protocolVersion"]?.stringValue)
+    }
+
+    @Test("A supported revision is echoed back unchanged", arguments: ["2025-03-26", "2025-06-18", "2025-11-25"])
+    func echoesSupportedRevision(_ version: String) async throws {
+        let negotiated = try await negotiatedVersion(proposing: version)
+        #expect(negotiated == version)
+    }
+
+    @Test("A newer/unsupported revision down-negotiates to the server's latest")
+    func downNegotiatesUnsupportedRevision() async throws {
+        // A revision the server doesn't know (e.g. a future modern one) must not
+        // fail the handshake — the server offers its latest instead.
+        let negotiated = try await negotiatedVersion(proposing: "2099-01-01")
+        #expect(negotiated == MCPProtocolVersion.latest)
+
+        let modern = try await negotiatedVersion(proposing: MCPProtocolVersion.modern)
+        #expect(modern == MCPProtocolVersion.latest)
+    }
+
+    @Test("An absent protocolVersion assumes the server's latest")
+    func absentRevisionAssumesLatest() async throws {
+        let negotiated = try await negotiatedVersion(proposing: nil)
+        #expect(negotiated == MCPProtocolVersion.latest)
+    }
+}

--- a/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
@@ -29,6 +29,27 @@ struct MCPServerProxyStreamableHTTPTests {
         #expect(!tools.isEmpty)
     }
 
+    @Test("Proxy captures the negotiated protocol version and keeps sending matching headers")
+    func capturesNegotiatedVersion() async throws {
+        let (transport, url) = try await startTransport()
+        defer { Task { try? await transport.stop() } }
+
+        let proxy = MCPServerProxy(config: .sse(config: MCPServerSseConfig(url: url)))
+        defer { Task { await proxy.disconnect() } }
+
+        try await proxy.connect()
+
+        // The server echoes the version the client proposed (`latest`).
+        let negotiated = await proxy.negotiatedProtocolVersion
+        #expect(negotiated == MCPProtocolVersion.latest)
+
+        // A follow-up request now carries the negotiated version in its
+        // `MCP-Protocol-Version` header. If the client still sent a mismatching
+        // value the server's `validateHTTPProtocolVersion` guard would reject it
+        // with HTTP 400, so a successful ping proves the header agrees.
+        try await proxy.ping()
+    }
+
     @Test("Proxy receives list-changed notifications over the general GET stream")
     func receivesToolsListChanged() async throws {
         let (transport, url) = try await startTransport()


### PR DESCRIPTION
## Summary

Continues the **§1c "cross-version feature deltas"** track of #137 — after #139 (profile foundation), #142 (batching / structured-output / resource-link gating) and #143 (serverInfo identity) — and tightens the **lifecycle negotiation** in both directions. Everything keys off the negotiated `ProtocolVersionProfile`; legacy behavior at `2025-11-25` is unchanged.

The session started as an audit ("does the runtime adhere to the matrix for every negotiable version, and is functionality gated by the agreed profile?") and surfaced three real gaps.

## Changes

### Server
- **Elicitation is now version-gated, not just capability-gated.** [`RequestContext.elicit(_:)`](Sources/SwiftMCP/Transport/RequestContext.swift) checked only the client's advertised `elicitation` capability. A client that negotiated `2025-03-26` but over-declared the capability could be driven into an `elicitation/create` the protocol never defined (it's a `2025-06-18` feature). It now also checks `profile.has(.elicitation)` and throws `MCPServerError.featureUnavailableInNegotiatedVersion(feature: .elicitation, version:)`.
- **`initialize` down-negotiates instead of rejecting.** Per the MCP lifecycle spec, the server must echo a supported revision or otherwise respond with one it *does* support (its latest) — not reject. [`MCPServer+Initialize.swift`](Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift) previously returned `-32602` for any unsupported proposed version; it now offers `MCPProtocolVersion.latest`, so a newer client connects at the highest the server can speak. The HTTP `MCP-Protocol-Version` **header** validation path (malformed header → 400) is deliberately untouched.

### Client (`MCPServerProxy`)
- **Captures the negotiated revision** the server echoes back into a new public `negotiatedProtocolVersion` (cleared on reconnect).
- **Sends the negotiated revision** in the `MCP-Protocol-Version` header on streamable-HTTP requests instead of a hard-coded `latest`, and **omits the header** for a pre-`2025-06-18` negotiated revision (the header postdates it). Echoing a stale `latest` would otherwise trip the server's own negotiated-version mismatch guard on a down-negotiated session. The generated proxy still proposes `latest` and simply adopts whatever the server offers — no configurable version, by design.

## Adherence result (negotiable set `{2025-03-26, 2025-06-18, 2025-11-25}`)

| Feature varying across negotiable versions | Status |
|---|---|
| `jsonRPCBatching`, `structuredToolOutput`, `resourceLinks`, `titleField` | already gated (#142/#143) |
| `elicitation` | **gated here** |
| `protocolVersionHeader` (client emit) | **fixed here** (was hard-coded `latest`) |
| handshake down-negotiation | **fixed here** (was `-32602`) |

`toolAnnotations` / `audioContent` / `completionsCapability` are present in all negotiable versions (they differ only at the non-negotiable `2024-11-05`), so they need no negotiation gate. Tool/prompt models carry no `title`, so there is nothing to gate there.

## Tests
- New: `ElicitationVersionGatingTests`, `ClientProtocolVersionHeaderTests`, `InitializeNegotiationTests`.
- Updated: streamable-HTTP suite gains a negotiated-version capture assertion; the former *"initialize rejects unsupported protocol version"* HTTP test now asserts down-negotiation to `latest`.
- **Full suite: 476 tests / 81 suites green.**

## Follow-up (not in this PR)
Over HTTP, body down-negotiation is reachable only when the client doesn't pre-send a *newer* `MCP-Protocol-Version` header on the `initialize` request (a spec-compliant client sends that header only on post-init requests; stdio/TCP have no header so it always applies). Letting the HTTP transport also tolerate a newer header on the initial `initialize` is a separate, slightly larger change to header validation — left for its own PR. This is squarely the kind of thing **Phase 1/2** of #137 will formalize (`UnsupportedProtocolVersionError` `-32004`, modern header rules).

Refs #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)