### PR TITLE
Fix compiler warnings across macros, extraction, and logging

### DIFF
--- a/Demos/SwiftMCPDemo/Logging/OSLogHandler.swift
+++ b/Demos/SwiftMCPDemo/Logging/OSLogHandler.swift
@@ -40,19 +40,10 @@ struct OSLogHandler: LogHandler {
     }
 
     // Required method for LogHandler protocol
-    // swiftlint:disable:next function_parameter_count
-    func log(
-        level: Logging.Logger.Level,
-        message: Logging.Logger.Message,
-        metadata: Logging.Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+    func log(event: Logging.LogEvent) {
         // Map Swift Logging levels to OSLog types
         let type: OSLogType
-        switch level {
+        switch event.level {
         case .trace, .debug:
             type = .debug
         case .info, .notice:
@@ -66,7 +57,7 @@ struct OSLogHandler: LogHandler {
         }
 
         // Log the message using OSLog
-        os_log("%{public}@", log: log, type: type, message.description)
+        os_log("%{public}@", log: log, type: type, event.message.description)
     }
 }
 

--- a/Demos/SwiftMCPIntentsDemo/Logging/OSLogHandler.swift
+++ b/Demos/SwiftMCPIntentsDemo/Logging/OSLogHandler.swift
@@ -22,18 +22,9 @@ struct OSLogHandler: LogHandler {
         self.log = log
     }
 
-    // swiftlint:disable:next function_parameter_count
-    func log(
-        level: Logging.Logger.Level,
-        message: Logging.Logger.Message,
-        metadata: Logging.Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+    func log(event: Logging.LogEvent) {
         let type: OSLogType
-        switch level {
+        switch event.level {
         case .trace, .debug:
             type = .debug
         case .info, .notice:
@@ -46,7 +37,7 @@ struct OSLogHandler: LogHandler {
             type = .fault
         }
 
-        os_log("%{public}@", log: log, type: type, message.description)
+        os_log("%{public}@", log: log, type: type, event.message.description)
     }
 }
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -78,7 +78,7 @@ let package = Package(
 		// `canImport(AppIntents)` already excludes it on non-Apple platforms.
 	],
 	dependencies: [
-		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+		.package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
 		.package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
 		.package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
 		// Apple's version-independent HTTP currency types (HTTPRequest.Method,

--- a/Sources/SwiftMCP/Extensions/Dictionary+ParameterExtraction.swift
+++ b/Sources/SwiftMCP/Extensions/Dictionary+ParameterExtraction.swift
@@ -70,19 +70,24 @@ public extension Dictionary where Key == String, Value == JSONValue {
             return (jsonValue as! T)
         }
         if T.self == Bool.self {
-            return try (extractBool(named: name) as! T)
+            let value = try extractBool(named: name)
+            return (value as! T)
         }
         if T.self == Date.self {
-            return try (extractDate(named: name) as! T)
+            let value = try extractDate(named: name)
+            return (value as! T)
         }
         if T.self == URL.self {
-            return try (extractURL(named: name) as! T)
+            let value = try extractURL(named: name)
+            return (value as! T)
         }
         if T.self == UUID.self {
-            return try (extractUUID(named: name) as! T)
+            let value = try extractUUID(named: name)
+            return (value as! T)
         }
         if T.self == Data.self {
-            return try (extractData(named: name) as! T)
+            let value = try extractData(named: name)
+            return (value as! T)
         }
         if T.self == String.self, let stringValue = jsonValue.stringValue {
             return (stringValue as! T)

--- a/Sources/SwiftMCPMacros/MCPExtensionMacro.swift
+++ b/Sources/SwiftMCPMacros/MCPExtensionMacro.swift
@@ -80,6 +80,15 @@ public enum \(extensionName) {
         return [DeclSyntax(stringLiteral: nestedEnum)]
     }
 
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        try expansion(of: node, providingMembersOf: declaration, in: context)
+    }
+
     /// Resolves the extension name from the attribute's first string-literal
     /// argument or, when absent, derives it from the source file path.
     private static func resolveExtensionName(

--- a/Sources/SwiftMCPMacros/URITemplateValidator+Expressions.swift
+++ b/Sources/SwiftMCPMacros/URITemplateValidator+Expressions.swift
@@ -152,7 +152,7 @@ extension URITemplateValidator {
 
         let operatorStripResult = stripOperator(expression)
         if let failure = operatorStripResult.failure { return failure }
-        var expr = operatorStripResult.expr
+        let expr = operatorStripResult.expr
         var level = operatorStripResult.level
 
         let variables = expr.split(separator: ",")

--- a/Tests/SwiftMCPTests/NoOpLogHandler.swift
+++ b/Tests/SwiftMCPTests/NoOpLogHandler.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Logging
 
-// swiftlint:disable function_parameter_count unused_setter_value
+// swiftlint:disable unused_setter_value
 // `LogHandler` protocol from swift-log dictates the signatures; we just no-op.
 struct NoOpLogHandler: LogHandler {
 	var logLevel: Logger.Level = .critical
@@ -19,27 +19,8 @@ struct NoOpLogHandler: LogHandler {
 		set { }
 	}
 
-	func log(
-		level: Logger.Level,
-		message: Logger.Message,
-		metadata: Logger.Metadata?,
-		source: String,
-		file: String,
-		function: String,
-		line: UInt
-	) {
-		// Discard all log messages.
-	}
-
-	func log(
-		level: Logger.Level,
-		message: Logger.Message,
-		metadata: Logger.Metadata?,
-		file: String,
-		function: String,
-		line: UInt
-	) {
+	func log(event: LogEvent) {
 		// Discard all log messages.
 	}
 }
-// swiftlint:enable function_parameter_count unused_setter_value
+// swiftlint:enable unused_setter_value


### PR DESCRIPTION
## What

Clears all compiler warnings reported when building the package.

| Warning | Fix |
| --- | --- |
| `variable 'expr' was never mutated` | `URITemplateValidator+Expressions`: `var expr` → `let expr` (only `level` is mutated). |
| `deprecated default implementation … MemberMacro` | `MCPExtensionMacro`: add the non-deprecated `expansion(of:providingMembersOf:conformingTo:in:)` overload that delegates to the existing one. |
| `treating a forced downcast to 'T' as optional will never produce 'nil'` (×5) | `Dictionary+ParameterExtraction`: bind each throwing extractor to a local before the `as! T` cast. |
| `deprecated default implementation … LogHandler.log(event:)` | `OSLogHandler` (both demos) + `NoOpLogHandler` (tests): implement `log(event:)`. |

## Why

- **MemberMacro**: swift-syntax now requires the `conformingTo:` variant of `expansion`; the old 3-arg form is satisfied via a deprecated default. This matches the pattern already used by `MCPServerMacro`, `SchemaMacro`, and `MCPAppIntentToolMacro`.
- **Forced casts**: the warning only fired on the `return try (… as! T)` forms — the two non-`try` casts in the same function never warned. Detaching `try` from the cast (`let value = try …; return (value as! T)`) silences it while preserving the deliberate force-cast intent. The `T.self == X.self` guards make every cast provably safe.
- **LogHandler**: swift-log 1.13.2 deprecated the flat-parameter `log(level:message:metadata:source:file:function:line:)` in favor of a single `log(event: LogEvent)`. The handlers relied on the deprecated default that bridges the old signature. `NoOpLogHandler` also carried the SwiftLog-1.0 6-param compat method; both collapse into one `log(event:)`.

## Notes for reviewers

- Behavior is unchanged everywhere — the OSLog handlers map `event.level`/`event.message.description` exactly as before; the test handler still no-ops.
- Dropped the now-unneeded `function_parameter_count` swiftlint exceptions (the new method has one parameter).
- `swift build --build-tests` is clean except for one **pre-existing, unrelated** `#SendableMetatypes` warning in `ServerInfoIdentityTests.swift:57`, which this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)