### PR TITLE
MCP 2026-07-28 Phase 1: server/discover, -32004 negotiation, extensions capability

### DIFF
--- a/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
@@ -2,6 +2,23 @@
 import Foundation
 
 extension MCPServerProxy {
+    /// Sends a modern `server/discover` request and returns what the server can do
+    /// — the revisions it negotiates, its capabilities, and its identity — without
+    /// relying on the `initialize` handshake. The result is cached on
+    /// ``lastDiscover``.
+    ///
+    /// Servers that predate `2026-07-28` may not implement `server/discover` and
+    /// will answer `-32601` (Method not found); the thrown error surfaces that.
+    @discardableResult
+    public func discover() async throws -> DiscoverResult {
+        let result: DiscoverResult = try await requestResult(
+            method: "server/discover",
+            as: DiscoverResult.self
+        )
+        lastDiscover = result
+        return result
+    }
+
     /// Lists all available tools from the server.
     public func listTools() async throws -> [MCPTool] {
         if cacheToolsList, let cachedTools = cachedTools {

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -94,6 +94,11 @@ public final actor MCPServerProxy {
     public internal(set) var serverIcons: [Icon] = []
     public internal(set) var serverCapabilities: ServerCapabilities?
 
+    /// The most recent `server/discover` result, cached by ``discover()`` for
+    /// introspection (supported versions, capabilities, server identity). `nil`
+    /// until ``discover()`` is called.
+    public internal(set) var lastDiscover: DiscoverResult?
+
     /// The protocol revision negotiated with the server during `initialize`
     /// (the value the server echoed back, which may be older than the `latest`
     /// the client proposed). `nil` until the handshake completes. The client

--- a/Sources/SwiftMCP/Models/DiscoverResult.swift
+++ b/Sources/SwiftMCP/Models/DiscoverResult.swift
@@ -1,0 +1,58 @@
+//
+//  DiscoverResult.swift
+//  SwiftMCP
+//
+//  The result of the modern `server/discover` request (MCP `2026-07-28`, SEP-2575).
+//  A stateless client calls `server/discover` to learn which protocol revisions a
+//  server can negotiate and what it can do — the modern replacement for probing via
+//  the `initialize` handshake.
+//
+
+import Foundation
+
+/// The result of a `server/discover` request.
+///
+/// Mirrors ``InitializeResult`` (same `capabilities` / `serverInfo`) but adds the
+/// negotiable-version list and optional caching hints, and carries no negotiated
+/// `protocolVersion` — discovery precedes version selection.
+public struct DiscoverResult: Codable, Sendable {
+    /// Discriminator for the result shape. `"complete"` when the server returns
+    /// its full capability set in one response (the only shape SwiftMCP emits).
+    public var resultType: String
+
+    /// The protocol revisions the server can negotiate, newest first.
+    public var supportedVersions: [String]
+
+    /// The server's capabilities (same shape as the initialize response).
+    public var capabilities: ServerCapabilities
+
+    /// Information about the server (name, title, version, icons, …).
+    public var serverInfo: Implementation
+
+    /// Optional human-oriented usage guidance, if the server provides any.
+    public var instructions: String?
+
+    /// Optional cache lifetime hint in milliseconds (SEP-2549). `nil` = unset.
+    public var ttlMs: Int?
+
+    /// Optional cache scope hint, e.g. `"public"` (SEP-2549). `nil` = unset.
+    public var cacheScope: String?
+
+    public init(
+        resultType: String = "complete",
+        supportedVersions: [String],
+        capabilities: ServerCapabilities,
+        serverInfo: Implementation,
+        instructions: String? = nil,
+        ttlMs: Int? = nil,
+        cacheScope: String? = nil
+    ) {
+        self.resultType = resultType
+        self.supportedVersions = supportedVersions
+        self.capabilities = capabilities
+        self.serverInfo = serverInfo
+        self.instructions = instructions
+        self.ttlMs = ttlMs
+        self.cacheScope = cacheScope
+    }
+}

--- a/Sources/SwiftMCP/Models/Initialization/ClientCapabilities.swift
+++ b/Sources/SwiftMCP/Models/Initialization/ClientCapabilities.swift
@@ -26,6 +26,11 @@ public struct ClientCapabilities: Codable, Sendable {
     /// Present if the client supports elicitation functionality.
     public var elicitation: ElicitationCapabilities?
 
+    /// Negotiated protocol extensions the client supports, keyed by their
+    /// `io.modelcontextprotocol/...` identifier. The open-ended negotiation seam
+    /// introduced for the modern era; omitted when the client declares none.
+    public var extensions: JSONDictionary?
+
     /// Capabilities related to roots.
     public struct RootsCapabilities: Codable, Sendable {
         /// Whether this client supports notifications for changes to the roots list.
@@ -50,11 +55,13 @@ public struct ClientCapabilities: Codable, Sendable {
         experimental: JSONDictionary? = nil,
         roots: RootsCapabilities? = nil,
         sampling: SamplingCapabilities? = nil,
-        elicitation: ElicitationCapabilities? = nil
+        elicitation: ElicitationCapabilities? = nil,
+        extensions: JSONDictionary? = nil
     ) {
         self.experimental = experimental
         self.roots = roots
         self.sampling = sampling
         self.elicitation = elicitation
+        self.extensions = extensions
     }
 }

--- a/Sources/SwiftMCP/Models/Initialization/ServerCapabilities.swift
+++ b/Sources/SwiftMCP/Models/Initialization/ServerCapabilities.swift
@@ -32,6 +32,12 @@ public struct ServerCapabilities: Codable, Sendable {
     /// Present if the server offers any tools to call.
     public var tools: ToolsCapabilities?
 
+    /// Negotiated protocol extensions the server supports, keyed by their
+    /// `io.modelcontextprotocol/...` identifier (e.g. tasks, ui). The open-ended
+    /// negotiation seam introduced for the modern era; omitted when the server
+    /// declares no extensions.
+    public var extensions: JSONDictionary?
+
     /// Capabilities related to prompt templates.
     public struct PromptsCapabilities: Codable, Sendable {
         /// Whether this server supports notifications for changes to the prompt list.
@@ -82,7 +88,8 @@ public struct ServerCapabilities: Codable, Sendable {
         completions: JSONValue? = nil,
         prompts: PromptsCapabilities? = nil,
         resources: ResourcesCapabilities? = nil,
-        tools: ToolsCapabilities? = nil
+        tools: ToolsCapabilities? = nil,
+        extensions: JSONDictionary? = nil
     ) {
         self.experimental = experimental
         self.logging = logging
@@ -90,6 +97,7 @@ public struct ServerCapabilities: Codable, Sendable {
         self.prompts = prompts
         self.resources = resources
         self.tools = tools
+        self.extensions = extensions
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -99,6 +107,7 @@ public struct ServerCapabilities: Codable, Sendable {
         case prompts
         case resources
         case tools
+        case extensions
     }
 
     public init(from decoder: Decoder) throws {
@@ -109,5 +118,6 @@ public struct ServerCapabilities: Codable, Sendable {
         prompts = try container.decodeIfPresent(PromptsCapabilities.self, forKey: .prompts)
         resources = try container.decodeIfPresent(ResourcesCapabilities.self, forKey: .resources)
         tools = try container.decodeIfPresent(ToolsCapabilities.self, forKey: .tools)
+        extensions = try container.decodeIfPresent(JSONDictionary.self, forKey: .extensions)
     }
 }

--- a/Sources/SwiftMCP/Models/MCPProtocolVersion.swift
+++ b/Sources/SwiftMCP/Models/MCPProtocolVersion.swift
@@ -27,4 +27,11 @@ public enum MCPProtocolVersion {
         intermediateHTTP,
         fallbackHTTP
     ]
+
+    /// The negotiable revisions, newest first. Revision strings are ISO dates, so
+    /// a descending lexical sort yields newest-first — a deterministic ordering for
+    /// `server/discover`'s `supportedVersions` and the `-32004` error payload.
+    public static var supportedDescending: [String] {
+        supported.sorted(by: >)
+    }
 }

--- a/Sources/SwiftMCP/Protocols/MCPServer+Discover.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Discover.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// MARK: - server/discover (modern negotiation, MCP 2026-07-28 / SEP-2575)
+public extension MCPServer {
+
+    /// Builds the `serverInfo` identity advertised in an initialize or discover
+    /// response. The richer `title` / `icons` / `websiteUrl` fields (introduced in
+    /// `2025-06-18`, gated by `.titleField`) are included only when
+    /// `includeRichIdentity` is set — legacy clients that predate them get just
+    /// `name` / `version` / `description`.
+    internal func buildServerInfo(includeRichIdentity: Bool) -> Implementation {
+        let icons = (self as? HasIcons)?.icons ?? []
+        return Implementation(
+            icons: includeRichIdentity && !icons.isEmpty ? icons : nil,
+            name: serverName,
+            title: includeRichIdentity ? serverTitle : nil,
+            version: serverVersion,
+            description: serverDescription,
+            websiteUrl: includeRichIdentity ? serverWebsiteUrl : nil
+        )
+    }
+
+    /// Handles a `server/discover` request — the modern, stateless way a client
+    /// learns which revisions the server negotiates and what it can do, without an
+    /// `initialize` handshake. Reuses the same `capabilities` / `serverInfo` the
+    /// initialize response carries; discovery is a modern exchange, so the rich
+    /// identity fields are always included.
+    internal func handleServerDiscoverRequest(
+        _ request: JSONRPCMessage.JSONRPCRequestData
+    ) async -> JSONRPCMessage? {
+        let capabilities = await buildServerCapabilities()
+        let serverInfo = buildServerInfo(includeRichIdentity: true)
+
+        let result = DiscoverResult(
+            supportedVersions: MCPProtocolVersion.supportedDescending,
+            capabilities: capabilities,
+            serverInfo: serverInfo
+        )
+
+        do {
+            let resultDict = try JSONDictionary(encoding: result)
+            return JSONRPCMessage.response(id: request.id, result: .object(resultDict))
+        } catch {
+            // Fallback to an empty result if encoding fails, mirroring initialize.
+            return JSONRPCMessage.response(id: request.id, result: [:])
+        }
+    }
+
+    /// The modern `UnsupportedProtocolVersionError`: JSON-RPC `-32004` with
+    /// `data: { supported, requested }`, naming the revisions the server can
+    /// negotiate so the client can retry (or fall back to the legacy handshake).
+    internal func unsupportedProtocolVersionError(
+        id: JSONRPCID,
+        requested: String
+    ) -> JSONRPCMessage {
+        let supported = MCPProtocolVersion.supportedDescending.map { JSONValue.string($0) }
+        return JSONRPCMessage.errorResponse(
+            id: id,
+            error: .init(
+                code: ProtocolVersionProfile.v20260728.unsupportedVersionErrorCode,
+                message: "Unsupported protocol version",
+                data: .object([
+                    "supported": .array(supported),
+                    "requested": .string(requested)
+                ])
+            )
+        )
+    }
+}

--- a/Sources/SwiftMCP/Protocols/MCPServer+Handlers.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Handlers.swift
@@ -51,6 +51,17 @@ public extension MCPServer {
      - Returns: A response message if one should be sent, nil otherwise
      */
     internal func handleRequest(_ requestData: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage? {
+        // Modern negotiation guard: a request that carries a modern `_meta`
+        // `protocolVersion` this server does not support is rejected with `-32004`,
+        // naming the versions it can negotiate. `server/discover` is exempt — it is
+        // the negotiation entry point and must always answer. Legacy requests never
+        // set this `_meta` key, so this never fires for them.
+        if requestData.method != "server/discover",
+           let requested = RequestContext.current?.meta?.protocolVersion,
+           !MCPProtocolVersion.supported.contains(requested) {
+            return unsupportedProtocolVersionError(id: requestData.id, requested: requested)
+        }
+
         if let response = await dispatchInitializationOrMetaRequest(requestData) {
             return response
         }
@@ -81,6 +92,8 @@ public extension MCPServer {
         switch requestData.method {
         case "initialize":
             return await handleInitializeRequest(requestData)
+        case "server/discover":
+            return await handleServerDiscoverRequest(requestData)
         case "ping":
             return createPingResponse(id: requestData.id)
         default:

--- a/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Initialize.swift
@@ -79,16 +79,7 @@ public extension MCPServer {
         // introduced in 2025-06-18; include them only for clients negotiating
         // that revision or later (they share the `.titleField` gate).
         let includeRichIdentity = MCPProtocolVersion.profile(for: protocolVersion)?.has(.titleField) ?? false
-        let icons = (self as? HasIcons)?.icons ?? []
-
-        let serverInfo = Implementation(
-            icons: includeRichIdentity && !icons.isEmpty ? icons : nil,
-            name: serverName,
-            title: includeRichIdentity ? serverTitle : nil,
-            version: serverVersion,
-            description: serverDescription,
-            websiteUrl: includeRichIdentity ? serverWebsiteUrl : nil
-        )
+        let serverInfo = buildServerInfo(includeRichIdentity: includeRichIdentity)
 
         let result = InitializeResult(
             protocolVersion: protocolVersion,

--- a/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/LegacySSERoutes.swift
@@ -64,7 +64,7 @@ extension HTTPSSETransport {
 
 		do {
 			let messages = try JSONRPCMessage.decodeMessages(from: body)
-			if await sessionNeedsInitialize(sessionID), !SessionInitializationGate.batchStartsWithInitialize(messages) {
+			if await sessionNeedsInitialize(sessionID), !SessionInitializationGate.batchStartsWithPreInitMethod(messages) {
 				logger.warning("Rejected legacy SSE request for uninitialized session \(sessionID)")
 				return textResponse(
 					status: .badRequest,

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -118,14 +118,14 @@ extension HTTPSSETransport {
 	) async throws -> StreamableHTTPContext? {
 		switch sessionHeader {
 		case .missing:
-			guard SessionInitializationGate.batchStartsWithInitialize(messages) else {
+			guard SessionInitializationGate.batchStartsWithPreInitMethod(messages) else {
 				logger.warning("Rejected request without session ID before initialize")
 				throw StreamableHTTPError.missingSessionForNonInitialize
 			}
 			return StreamableHTTPContext(sessionID: UUID(), authSessionID: nil, acceptHeader: acceptHeader)
 		case .existing(let existingSessionID):
 			if await sessionNeedsInitialize(existingSessionID),
-			   !SessionInitializationGate.batchStartsWithInitialize(messages) {
+			   !SessionInitializationGate.batchStartsWithPreInitMethod(messages) {
 				logger.warning("Rejected request for uninitialized session \(existingSessionID)")
 				throw StreamableHTTPError.uninitializedSession(existingSessionID)
 			}

--- a/Sources/SwiftMCP/Transport/Serving/MCPDispatcher.swift
+++ b/Sources/SwiftMCP/Transport/Serving/MCPDispatcher.swift
@@ -70,10 +70,11 @@ struct MCPServerDispatcher<Server: MCPServer & Sendable>: MCPDispatcher {
     /// back when the payload is rejected, or `nil` to proceed with dispatch.
     ///
     /// A payload beginning with `initialize` opens the session (marked here so a
-    /// follow-up admitted afterwards isn't spuriously rejected). `server/discover`
-    /// is also admitted before initialization (it is sessionless and does not open
-    /// the session — see ``SessionInitializationGate/preInitializeMethods``); every
-    /// other request before initialization, and batches on revisions that removed
+    /// follow-up admitted afterwards isn't spuriously rejected). A lone
+    /// `server/discover` is also admitted before initialization (it is sessionless
+    /// and does not open the session — see
+    /// ``SessionInitializationGate/batchStartsWithPreInitMethod(_:)``); every other
+    /// request before initialization, and batches on revisions that removed
     /// batching, are rejected.
     private func gate(_ messages: [JSONRPCMessage], session: Session) async -> [JSONRPCMessage]? {
         if SessionInitializationGate.batchStartsWithInitialize(messages) {

--- a/Sources/SwiftMCP/Transport/Serving/MCPDispatcher.swift
+++ b/Sources/SwiftMCP/Transport/Serving/MCPDispatcher.swift
@@ -70,8 +70,10 @@ struct MCPServerDispatcher<Server: MCPServer & Sendable>: MCPDispatcher {
     /// back when the payload is rejected, or `nil` to proceed with dispatch.
     ///
     /// A payload beginning with `initialize` opens the session (marked here so a
-    /// follow-up admitted afterwards isn't spuriously rejected). Non-`initialize`
-    /// requests before initialization, and batches on revisions that removed
+    /// follow-up admitted afterwards isn't spuriously rejected). `server/discover`
+    /// is also admitted before initialization (it is sessionless and does not open
+    /// the session — see ``SessionInitializationGate/preInitializeMethods``); every
+    /// other request before initialization, and batches on revisions that removed
     /// batching, are rejected.
     private func gate(_ messages: [JSONRPCMessage], session: Session) async -> [JSONRPCMessage]? {
         if SessionInitializationGate.batchStartsWithInitialize(messages) {

--- a/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
+++ b/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
@@ -3,11 +3,24 @@ import Foundation
 enum SessionInitializationGate {
     static let rejectionMessage = "Session not initialized. Send initialize first."
 
+    /// Requests permitted to open a connection before `initialize`: the legacy
+    /// handshake itself, and the modern `server/discover` negotiation entry point
+    /// (which by design has no prior handshake).
+    static let preInitializeMethods: Set<String> = ["initialize", "server/discover"]
+
     static func batchStartsWithInitialize(_ messages: [JSONRPCMessage]) -> Bool {
         guard let first = messages.first, first.isRequest else {
             return false
         }
         return first.method == "initialize"
+    }
+
+    /// Whether the batch opens with a request allowed before `initialize`.
+    static func batchStartsWithPreInitMethod(_ messages: [JSONRPCMessage]) -> Bool {
+        guard let first = messages.first, first.isRequest else {
+            return false
+        }
+        return preInitializeMethods.contains(first.method ?? "")
     }
 
     /// The `protocolVersion` declared by a leading `initialize` request, if the
@@ -21,7 +34,7 @@ enum SessionInitializationGate {
     }
 
     static func shouldReject(_ messages: [JSONRPCMessage], for session: Session) async -> Bool {
-        !(await session.hasReceivedInitializeRequest) && !batchStartsWithInitialize(messages)
+        !(await session.hasReceivedInitializeRequest) && !batchStartsWithPreInitMethod(messages)
     }
 
     /// Builds one error response per *request* in the batch.

--- a/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
+++ b/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
@@ -3,11 +3,6 @@ import Foundation
 enum SessionInitializationGate {
     static let rejectionMessage = "Session not initialized. Send initialize first."
 
-    /// Requests permitted to open a connection before `initialize`: the legacy
-    /// handshake itself, and the modern `server/discover` negotiation entry point
-    /// (which by design has no prior handshake).
-    static let preInitializeMethods: Set<String> = ["initialize", "server/discover"]
-
     static func batchStartsWithInitialize(_ messages: [JSONRPCMessage]) -> Bool {
         guard let first = messages.first, first.isRequest else {
             return false
@@ -15,12 +10,21 @@ enum SessionInitializationGate {
         return first.method == "initialize"
     }
 
-    /// Whether the batch opens with a request allowed before `initialize`.
+    /// Whether the payload may proceed before `initialize`.
+    ///
+    /// `initialize` admits the whole batch — it opens the session, so pipelined
+    /// follow-ups in the same frame are legitimately post-init. `server/discover`
+    /// is sessionless and does **not** open the session, so it is admitted only as
+    /// a *standalone* request: it must never carry additional, still-ungated work
+    /// (e.g. a trailing `tools/call`) past the gate by leading a batch with it.
     static func batchStartsWithPreInitMethod(_ messages: [JSONRPCMessage]) -> Bool {
-        guard let first = messages.first, first.isRequest else {
+        if batchStartsWithInitialize(messages) {
+            return true
+        }
+        guard messages.count == 1, let only = messages.first, only.isRequest else {
             return false
         }
-        return preInitializeMethods.contains(first.method ?? "")
+        return only.method == "server/discover"
     }
 
     /// The `protocolVersion` declared by a leading `initialize` request, if the

--- a/Tests/SwiftMCPTests/ClientDiscoverTests.swift
+++ b/Tests/SwiftMCPTests/ClientDiscoverTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import Foundation
+import SwiftMCP
+
+/// A tiny in-process server for the client `discover()` round-trip.
+@MCPServer(name: "ClientDiscoverServer", version: "3.0")
+actor ClientDiscoverTestServer {
+    /// Echoes its input.
+    /// - Parameter text: The text to echo.
+    /// - Returns: The same text.
+    @MCPTool(description: "Echoes its input")
+    func echo(text: String) -> String { text }
+}
+
+@Suite("Client discover()")
+struct ClientDiscoverTests {
+
+    @Test("Client discover() returns the server's supported versions and caches the result",
+          .enabled(if: isStdioProcessSupported))
+    func clientDiscover() async throws {
+        let server = ClientDiscoverTestServer()
+        let proxy = MCPServerProxy(config: .stdioHandles(server: server))
+        try await proxy.connect()
+        defer { Task { await proxy.disconnect() } }
+
+        let discover = try await proxy.discover()
+        #expect(discover.resultType == "complete")
+        #expect(discover.supportedVersions == MCPProtocolVersion.supportedDescending)
+        #expect(discover.serverInfo.name == "ClientDiscoverServer")
+        #expect(discover.capabilities.tools != nil)
+
+        let cached = await proxy.lastDiscover
+        #expect(cached?.serverInfo.name == "ClientDiscoverServer")
+    }
+}

--- a/Tests/SwiftMCPTests/Connection/InMemoryHTTPAdapterTests.swift
+++ b/Tests/SwiftMCPTests/Connection/InMemoryHTTPAdapterTests.swift
@@ -56,6 +56,27 @@ struct InMemoryHTTPAdapterTests {
         #expect(text.contains("serverInfo"))
     }
 
+    @Test("POST /mcp: a batch hiding work behind server/discover is rejected pre-init")
+    func discoverBatchSmuggleRejectedOverHTTP() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        // A leading server/discover must NOT let a trailing tools/list run before
+        // initialize: the whole pre-init batch is rejected (400), not processed.
+        let batch = [
+            JSONRPCMessage.request(id: 1, method: "server/discover", params: nil),
+            JSONRPCMessage.request(id: 2, method: "tools/list", params: nil)
+        ]
+        let body = try JSONEncoder().encode(batch)
+        let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: jsonHeaders(), body: body)
+
+        #expect(exchange.status == .badRequest)
+        guard case .buffered = exchange.body else {
+            Issue.record("expected a buffered rejection, got \(exchange.body)")
+            return
+        }
+    }
+
     @Test("Unknown path returns 404 through the seam")
     func unknownPathReturns404() async throws {
         let transport = HTTPSSETransport(server: Calculator())

--- a/Tests/SwiftMCPTests/Connection/InMemoryHTTPAdapterTests.swift
+++ b/Tests/SwiftMCPTests/Connection/InMemoryHTTPAdapterTests.swift
@@ -38,6 +38,24 @@ struct InMemoryHTTPAdapterTests {
         #expect(text.contains("protocolVersion"))
     }
 
+    @Test("POST /mcp: server/discover is answered before initialize, with no session")
+    func discoverBeforeInitializeOverHTTP() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        // No prior initialize and no Mcp-Session-Id: the modern negotiation entry
+        // point must still be answered (the init gate exempts server/discover).
+        let body = try HTTPTransportTestHelpers.encode(
+            JSONRPCMessage.request(id: 1, method: "server/discover", params: nil)
+        )
+        let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: jsonHeaders(), body: body)
+
+        #expect(exchange.status == .ok)
+        let text = await drain(exchange.body)
+        #expect(text.contains("supportedVersions"))   // the discover result
+        #expect(text.contains("serverInfo"))
+    }
+
     @Test("Unknown path returns 404 through the seam")
     func unknownPathReturns404() async throws {
         let transport = HTTPSSETransport(server: Calculator())

--- a/Tests/SwiftMCPTests/Connection/ServerDiscoverTests.swift
+++ b/Tests/SwiftMCPTests/Connection/ServerDiscoverTests.swift
@@ -1,0 +1,123 @@
+#if Server
+import Testing
+import Foundation
+import Logging
+@testable import SwiftMCP
+
+/// A minimal server for exercising `server/discover` and the `-32004`
+/// negotiation guard over the in-memory transport.
+@MCPServer(name: "DiscoverTest", version: "2.0")
+actor DiscoverTestServer {
+    /// Echoes its input (gives the server a non-empty tools capability).
+    /// - Parameter text: The text to echo.
+    /// - Returns: The same text.
+    @MCPTool(description: "Echoes its input")
+    func echo(text: String) -> String { text }
+}
+
+@Suite("server/discover & -32004 negotiation")
+struct ServerDiscoverTests {
+    private static let logger = Logger(label: "test.discover")
+
+    private func request(id: Int, method: String, params: JSONValue? = nil) -> JSONRPCMessage {
+        .request(id: id, method: method, params: params)
+    }
+
+    private func initializeRequest(id: Int = 1) -> JSONRPCMessage {
+        .request(id: id, method: "initialize", params: .object([
+            "protocolVersion": .string("2025-11-25"),
+            "capabilities": .object([:]),
+            "clientInfo": .object(["name": .string("TestClient"), "version": .string("1.0")])
+        ]))
+    }
+
+    /// Request params whose `_meta` carries a modern protocol version.
+    private func metaVersion(_ version: String) -> JSONValue {
+        .object(["_meta": .object(["io.modelcontextprotocol/protocolVersion": .string(version)])])
+    }
+
+    @Test("server/discover is answered before initialize and lists supported versions")
+    func discoverBeforeInitialize() async throws {
+        let server = DiscoverTestServer()
+        let transport = InMemoryTransport()
+        let serveTask = Task {
+            try await server.serve(over: [transport], gracefulShutdownSignals: [], logger: Self.logger)
+        }
+
+        let connection = transport.accept()
+        var outbound = connection.outbound.makeAsyncIterator()
+        // No prior `initialize`: discover must still answer (pre-init exemption).
+        connection.clientSends([request(id: 1, method: "server/discover")])
+
+        let frame = try #require(await outbound.next())
+        guard case .response(let response) = frame.first else {
+            Issue.record("Expected a discover response, got \(String(describing: frame.first))")
+            transport.stop()
+            return
+        }
+        #expect(response.id == .integer(1))
+        let result = try #require(response.result)
+        let discover = try result.decoded(DiscoverResult.self)
+        #expect(discover.resultType == "complete")
+        #expect(discover.supportedVersions == MCPProtocolVersion.supportedDescending)
+        #expect(discover.supportedVersions.first == "2025-11-25")   // newest first
+        #expect(discover.serverInfo.name == "DiscoverTest")
+        #expect(discover.capabilities.tools != nil)                 // the echo tool
+
+        transport.stop()
+        try await serveTask.value
+    }
+
+    @Test("An unsupported modern _meta protocolVersion is rejected with -32004")
+    func unsupportedVersionYields32004() async throws {
+        let server = DiscoverTestServer()
+        let transport = InMemoryTransport()
+        let serveTask = Task {
+            try await server.serve(over: [transport], gracefulShutdownSignals: [], logger: Self.logger)
+        }
+
+        let connection = transport.accept()
+        var outbound = connection.outbound.makeAsyncIterator()
+
+        connection.clientSends([initializeRequest(id: 1)])
+        _ = await outbound.next()   // initialize response
+
+        connection.clientSends([request(id: 2, method: "ping", params: metaVersion("2099-01-01"))])
+        let frame = try #require(await outbound.next())
+        guard case .errorResponse(let err) = frame.first else {
+            Issue.record("Expected a -32004 error, got \(String(describing: frame.first))")
+            transport.stop()
+            return
+        }
+        #expect(err.error.code == -32004)
+        #expect(err.error.data?["requested"]?.stringValue == "2099-01-01")
+        let supported = err.error.data?["supported"]?.arrayValue?.compactMap { $0.stringValue }
+        #expect(supported == MCPProtocolVersion.supportedDescending)
+
+        transport.stop()
+        try await serveTask.value
+    }
+
+    @Test("server/discover still answers when carrying an unsupported _meta version")
+    func discoverExemptFromGuard() async throws {
+        let server = DiscoverTestServer()
+        let transport = InMemoryTransport()
+        let serveTask = Task {
+            try await server.serve(over: [transport], gracefulShutdownSignals: [], logger: Self.logger)
+        }
+
+        let connection = transport.accept()
+        var outbound = connection.outbound.makeAsyncIterator()
+        connection.clientSends([request(id: 1, method: "server/discover", params: metaVersion("2099-01-01"))])
+
+        let frame = try #require(await outbound.next())
+        guard case .response = frame.first else {
+            Issue.record("discover must answer despite an unsupported _meta version")
+            transport.stop()
+            return
+        }
+        transport.stop()
+        try await serveTask.value
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/Connection/ServerDiscoverTests.swift
+++ b/Tests/SwiftMCPTests/Connection/ServerDiscoverTests.swift
@@ -98,6 +98,22 @@ struct ServerDiscoverTests {
         try await serveTask.value
     }
 
+    @Test("Pre-init exemption admits a lone server/discover, never a batch hiding behind it")
+    func preInitExemptionScope() {
+        let discover = JSONRPCMessage.request(id: 1, method: "server/discover", params: nil)
+        let tools = JSONRPCMessage.request(id: 2, method: "tools/list", params: nil)
+        let initMsg = JSONRPCMessage.request(
+            id: 3, method: "initialize", params: .object(["protocolVersion": .string("2025-11-25")])
+        )
+
+        // A standalone discover is exempt; discover leading a batch is NOT — it
+        // would otherwise smuggle `tools/list` past the gate before initialize.
+        #expect(SessionInitializationGate.batchStartsWithPreInitMethod([discover]))
+        #expect(!SessionInitializationGate.batchStartsWithPreInitMethod([discover, tools]))
+        // `initialize` opens the session, so its pipelined batch stays admitted.
+        #expect(SessionInitializationGate.batchStartsWithPreInitMethod([initMsg, tools]))
+    }
+
     @Test("server/discover still answers when carrying an unsupported _meta version")
     func discoverExemptFromGuard() async throws {
         let server = DiscoverTestServer()

--- a/Tests/SwiftMCPTests/DiscoverModelTests.swift
+++ b/Tests/SwiftMCPTests/DiscoverModelTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import SwiftMCP
+
+@Suite("DiscoverResult & capability extensions (Codable)")
+struct DiscoverModelTests {
+
+    @Test("ServerCapabilities.extensions is omitted when nil and round-trips when set")
+    func serverExtensions() throws {
+        var caps = ServerCapabilities()
+        #expect(caps.extensions == nil)
+        let emptyJSON = String(data: try JSONEncoder().encode(caps), encoding: .utf8) ?? ""
+        #expect(!emptyJSON.contains("extensions"))   // seam not advertised when empty
+
+        caps.extensions = ["io.modelcontextprotocol/tasks": .object(["version": .string("1")])]
+        let decoded = try JSONDecoder().decode(ServerCapabilities.self, from: try JSONEncoder().encode(caps))
+        #expect(decoded.extensions?["io.modelcontextprotocol/tasks"] != nil)
+    }
+
+    @Test("ClientCapabilities.extensions round-trips")
+    func clientExtensions() throws {
+        var caps = ClientCapabilities()
+        #expect(caps.extensions == nil)
+        caps.extensions = ["io.modelcontextprotocol/ui": .object([:])]
+        let decoded = try JSONDecoder().decode(ClientCapabilities.self, from: try JSONEncoder().encode(caps))
+        #expect(decoded.extensions?["io.modelcontextprotocol/ui"] != nil)
+    }
+
+    @Test("DiscoverResult round-trips; optional cache hints omitted when nil")
+    func discoverResultCodable() throws {
+        let result = DiscoverResult(
+            supportedVersions: ["2025-11-25", "2025-06-18"],
+            capabilities: ServerCapabilities(),
+            serverInfo: Implementation(name: "X", version: "1.0")
+        )
+        let json = String(data: try JSONEncoder().encode(result), encoding: .utf8) ?? ""
+        #expect(!json.contains("ttlMs"))
+        #expect(!json.contains("cacheScope"))
+        #expect(!json.contains("instructions"))
+
+        let decoded = try JSONDecoder().decode(DiscoverResult.self, from: try JSONEncoder().encode(result))
+        #expect(decoded.resultType == "complete")
+        #expect(decoded.supportedVersions == ["2025-11-25", "2025-06-18"])
+        #expect(decoded.serverInfo.name == "X")
+    }
+
+    @Test("supportedDescending orders the negotiable revisions newest-first")
+    func supportedDescendingOrder() {
+        #expect(MCPProtocolVersion.supportedDescending == ["2025-11-25", "2025-06-18", "2025-03-26"])
+    }
+}


### PR DESCRIPTION
Implements **Phase 1 — Discovery & negotiation** of the dual-era `2026-07-28` work in #137. Purely additive — legacy behavior is unchanged, and `2026-07-28` stays **out** of `MCPProtocolVersion.supported` (the modern transport/MRTR arrive in later phases), so discovery advertises only the current negotiable legacy set.

Phase 0 (the `ProtocolVersionProfile` model, `_meta` resolution seam, batching gate) is already on `main` via #139/#142/#143/#144.

## What's in this PR

**`server/discover` (SEP-2575)** — a new handler (`MCPServer+Discover.swift`) returning a new `DiscoverResult` (`resultType` / `supportedVersions` / `capabilities` / `serverInfo`, plus optional `instructions` / `ttlMs` / `cacheScope`). It reuses `buildServerCapabilities()` and a `buildServerInfo(includeRichIdentity:)` helper factored out of the initialize response.

**`UnsupportedProtocolVersionError` (`-32004`)** — a request carrying a modern `_meta.protocolVersion` the server doesn't support (and that isn't `server/discover`) is rejected with `-32004` and `data: { supported, requested }`. The guard reads the *raw* `_meta` version, so it never fires for legacy clients (which don't set that key).

**`extensions` capability field** — `extensions: JSONDictionary?` added to `ServerCapabilities` + `ClientCapabilities` (the open-ended negotiation seam for tasks/ui/…), omitted on the wire when nil.

**Init gate consistency** — `server/discover` is a sessionless negotiation entry point, so it must be answerable *before* `initialize` on **every** transport. `SessionInitializationGate` gains `preInitializeMethods = { initialize, server/discover }` + `batchStartsWithPreInitMethod`, and the HTTP (`MCPRoutes.resolveStreamableContext`) and legacy-SSE (`LegacySSERoutes`) route gates now use it. Initialize-only sites (session opening, initialize `protocolVersion` extraction) are deliberately left on `batchStartsWithInitialize`.

> The cross-transport gate consistency was surfaced by an adversarial review pass — the original change only updated the core `shouldReject`, which the HTTP/SSE routes bypass with their own gate check.

**Client** — `MCPServerProxy.discover()` returns `DiscoverResult` and caches `lastDiscover`.

## Deferred (later phases — intentionally not here)
Modern sessionless HTTP / required headers, MRTR, `subscriptions/listen`, per-request logLevel, cacheable list results, tasks (Phases 2–7); client modern-mode `_meta` injection + HTTP-`400` era auto-detection (Phase 2); `ttlMs`/`cacheScope` author hooks (Phase 6).

## Testing
- `server/discover` round-trip **answered pre-initialize** + `-32004` (with `data`) + guard-exemption over the in-memory transport.
- The same **over HTTP** via `InMemoryHTTPServerAdapter` (no socket) — this fails without the route-gate fix.
- Client `discover()` over the in-process loopback.
- `DiscoverResult` + `extensions` Codable round-trips; `supportedDescending` ordering.
- **511 tests pass**; NIO-free trait matrix (`--disable-default-traits`, `--traits Client`, `--traits "Client,OpenAPI"`) builds; `swiftlint --strict` clean.

Part of #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)