### PR TITLE
MCP 2026-07-28 Phase 2a: reachable modern Streamable HTTP (sessionless POST, GET/DELETE→405)

### DIFF
--- a/Sources/SwiftMCP/Models/ProtocolVersionProfile.swift
+++ b/Sources/SwiftMCP/Models/ProtocolVersionProfile.swift
@@ -244,4 +244,21 @@ public extension MCPProtocolVersion {
     static func profile(for version: String) -> ProtocolVersionProfile? {
         allKnownProfiles.first { $0.version == version }
     }
+
+    /// Whether `version` is a known **modern** (stateless, per-request-metadata)
+    /// revision — currently `2026-07-28`.
+    static func isModern(_ version: String) -> Bool {
+        profile(for: version)?.isModern ?? false
+    }
+
+    /// Whether the server will **process** a request declaring `version`, as
+    /// opposed to what it will **advertise** (``supported``). A version is
+    /// servable when it is negotiable (in ``supported``) *or* a known modern
+    /// revision: the modern era is functional-but-unadvertised as it is built, so
+    /// a modern client that declares `2026-07-28` reaches the modern path even
+    /// though `2026-07-28` is not yet in ``supported`` / `server/discover`. The
+    /// final "flip" that advertises modern is simply adding it to ``supported``.
+    static func isServable(_ version: String) -> Bool {
+        supported.contains(version) || isModern(version)
+    }
 }

--- a/Sources/SwiftMCP/Protocols/MCPServer+Handlers.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Handlers.swift
@@ -51,14 +51,17 @@ public extension MCPServer {
      - Returns: A response message if one should be sent, nil otherwise
      */
     internal func handleRequest(_ requestData: JSONRPCMessage.JSONRPCRequestData) async -> JSONRPCMessage? {
-        // Modern negotiation guard: a request that carries a modern `_meta`
-        // `protocolVersion` this server does not support is rejected with `-32004`,
-        // naming the versions it can negotiate. `server/discover` is exempt — it is
-        // the negotiation entry point and must always answer. Legacy requests never
-        // set this `_meta` key, so this never fires for them.
+        // Modern negotiation guard: a request that carries a `_meta`
+        // `protocolVersion` this server cannot serve is rejected with `-32004`,
+        // naming the versions it can negotiate. "Servable" is broader than
+        // "advertised": a known modern revision (`2026-07-28`) reaches the modern
+        // path even while it is kept out of `supported`, so only unknown /
+        // non-negotiable versions are rejected here. `server/discover` is exempt —
+        // it is the negotiation entry point and must always answer. Legacy requests
+        // never set this `_meta` key, so this never fires for them.
         if requestData.method != "server/discover",
            let requested = RequestContext.current?.meta?.protocolVersion,
-           !MCPProtocolVersion.supported.contains(requested) {
+           !MCPProtocolVersion.isServable(requested) {
             return unsupportedProtocolVersionError(id: requestData.id, requested: requested)
         }
 

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes+SSE.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes+SSE.swift
@@ -18,6 +18,14 @@ extension HTTPSSETransport {
 	/// stream by `Session.sendSSE`.
 	func handleSSE(request: HTTPRouteRequest<Data?>) async throws -> RouteResponse {
 		let isLegacy = request.path == "/sse"
+
+		// The standalone GET SSE stream is a legacy feature (absent in the modern
+		// era). A modern client hitting GET /mcp gets 405; the legacy GET /mcp and
+		// GET /sse streams are unchanged.
+		if !isLegacy, requestDeclaresModern(request) {
+			return textResponse(status: .methodNotAllowed, body: "GET is not supported for stateless (modern) requests.")
+		}
+
 		let sessionHeader = await resolveSessionHeader(for: request)
 
 		let resolved = resolveSSESession(sessionHeader: sessionHeader, isLegacy: isLegacy)

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -26,12 +26,19 @@ extension HTTPSSETransport {
 		let sessionID: UUID
 		let authSessionID: UUID?
 		let acceptHeader: String
+		/// A modern (stateless) request: no `Mcp-Session-Id` is required inbound or
+		/// echoed outbound; `sessionID` is an ephemeral id used only to route this
+		/// request's SSE stream internally.
+		let isModern: Bool
 	}
 
 	/// Handle POST /mcp — streamable HTTP endpoint.
 	func handleStreamableHTTP(request: HTTPRouteRequest<Data?>) async throws -> RouteResponse {
+		let isModern = requestDeclaresModern(request)
 		let sessionHeader = await resolveSessionHeader(for: request)
-		if let earlyResponse = streamableEarlyRejection(for: sessionHeader) {
+		// Modern is sessionless: any inbound Mcp-Session-Id is ignored entirely, so
+		// a malformed/unknown session header must not reject a modern request.
+		if !isModern, let earlyResponse = streamableEarlyRejection(for: sessionHeader) {
 			return earlyResponse
 		}
 
@@ -53,7 +60,8 @@ extension HTTPSSETransport {
 			guard let context = try await resolveStreamableContext(
 				sessionHeader: sessionHeader,
 				messages: messages,
-				acceptHeader: acceptHeader
+				acceptHeader: acceptHeader,
+				isModern: isModern
 			) else {
 				return textResponse(status: .internalServerError, body: "Session validation failed.")
 			}
@@ -114,15 +122,27 @@ extension HTTPSSETransport {
 	private func resolveStreamableContext(
 		sessionHeader: SessionHeaderResolution,
 		messages: [JSONRPCMessage],
-		acceptHeader: String
+		acceptHeader: String,
+		isModern: Bool
 	) async throws -> StreamableHTTPContext? {
+		// Modern is stateless: no inbound session is required and none is surfaced.
+		// An ephemeral id backs this request's SSE-stream routing only. The init
+		// gate does not apply (modern has no `initialize`).
+		if isModern {
+			return StreamableHTTPContext(
+				sessionID: UUID(), authSessionID: nil, acceptHeader: acceptHeader, isModern: true
+			)
+		}
+
 		switch sessionHeader {
 		case .missing:
 			guard SessionInitializationGate.batchStartsWithPreInitMethod(messages) else {
 				logger.warning("Rejected request without session ID before initialize")
 				throw StreamableHTTPError.missingSessionForNonInitialize
 			}
-			return StreamableHTTPContext(sessionID: UUID(), authSessionID: nil, acceptHeader: acceptHeader)
+			return StreamableHTTPContext(
+				sessionID: UUID(), authSessionID: nil, acceptHeader: acceptHeader, isModern: false
+			)
 		case .existing(let existingSessionID):
 			if await sessionNeedsInitialize(existingSessionID),
 			   !SessionInitializationGate.batchStartsWithPreInitMethod(messages) {
@@ -132,7 +152,8 @@ extension HTTPSSETransport {
 			return StreamableHTTPContext(
 				sessionID: existingSessionID,
 				authSessionID: existingSessionID,
-				acceptHeader: acceptHeader
+				acceptHeader: acceptHeader,
+				isModern: false
 			)
 		case .malformed, .unknown:
 			return nil
@@ -224,21 +245,38 @@ extension HTTPSSETransport {
 				}
 
 				await self.finishSSEStream(streamInfo.streamID)
+
+				// Modern is sessionless: once this request's stream is done, drop the
+				// ephemeral session so modern traffic doesn't accumulate `Session`
+				// objects (there is no client `DELETE` to reclaim them).
+				if context.isModern {
+					await self.sessionManager.removeSession(id: context.sessionID)
+				}
 			}
 
-			let headerFields: HTTPFields = [
+			var headerFields: HTTPFields = [
 				.contentType: "text/event-stream",
 				.cacheControl: "no-cache",
-				.connection: "keep-alive",
-				.mcpSessionID: sid
+				.connection: "keep-alive"
 			]
+			// Modern is sessionless — never echo Mcp-Session-Id.
+			if !context.isModern {
+				headerFields[.mcpSessionID] = sid
+			}
 
 			return RouteResponse(status: .ok, headerFields: headerFields, bodyStream: stream, streamInfo: streamInfo)
 		}
 
 		_ = await session.work { _ in await self.processInbound(messages) }
 
-		return RouteResponse(status: .accepted, headerFields: [.mcpSessionID: sid])
+		// Modern is sessionless: reclaim the ephemeral session immediately (a
+		// notification-only request opens no stream, so nothing else would).
+		if context.isModern {
+			await sessionManager.removeSession(id: context.sessionID)
+		}
+
+		let ackHeaders: HTTPFields = context.isModern ? [:] : [.mcpSessionID: sid]
+		return RouteResponse(status: .accepted, headerFields: ackHeaders)
 	}
 
 	/// Process an inbound HTTP payload: through the connected ``MCPDispatcher``
@@ -295,6 +333,12 @@ extension HTTPSSETransport {
 
 	/// Handle DELETE /mcp — remove a session.
 	func handleDeleteSession(request: HTTPRouteRequest<Data?>) async throws -> RouteResponse {
+		// DELETE is a session-teardown verb; the modern (sessionless) era has no
+		// sessions, so a modern client using it gets 405 Method Not Allowed.
+		if requestDeclaresModern(request) {
+			return textResponse(status: .methodNotAllowed, body: "DELETE is not supported for stateless (modern) requests.")
+		}
+
 		switch await resolveSessionHeader(for: request) {
 		case .missing, .malformed:
 			return textResponse(status: .badRequest, body: "Valid Mcp-Session-Id header required.")

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -34,13 +34,7 @@ extension HTTPSSETransport {
 
 	/// Handle POST /mcp — streamable HTTP endpoint.
 	func handleStreamableHTTP(request: HTTPRouteRequest<Data?>) async throws -> RouteResponse {
-		let isModern = requestDeclaresModern(request)
 		let sessionHeader = await resolveSessionHeader(for: request)
-		// Modern is sessionless: any inbound Mcp-Session-Id is ignored entirely, so
-		// a malformed/unknown session header must not reject a modern request.
-		if !isModern, let earlyResponse = streamableEarlyRejection(for: sessionHeader) {
-			return earlyResponse
-		}
 
 		// Validate Accept header
 		let acceptHeader = request.header("accept") ?? request.header("Accept") ?? ""
@@ -56,6 +50,21 @@ extension HTTPSSETransport {
 		do {
 			let messages = try JSONRPCMessage.decodeMessages(from: body)
 			let token = request.bearerToken
+
+			// A request is modern iff its body's `_meta` declares a modern version —
+			// the authoritative per-request identity, matching how the handler
+			// resolves the era. A modern `MCP-Protocol-Version` header without a
+			// matching `_meta` therefore falls to the legacy path (and its
+			// header/session mismatch is rejected there), rather than taking the
+			// sessionless path and being served as legacy.
+			let isModern = SessionInitializationGate.batchIsModern(messages)
+
+			// Modern is sessionless (no inbound Mcp-Session-Id), so a malformed /
+			// unknown session header only rejects a legacy request. A well-formed
+			// modern request sends no session header, so this is a no-op for it.
+			if !isModern, let earlyResponse = streamableEarlyRejection(for: sessionHeader) {
+				return earlyResponse
+			}
 
 			guard let context = try await resolveStreamableContext(
 				sessionHeader: sessionHeader,
@@ -218,20 +227,22 @@ extension HTTPSSETransport {
 		token: String?,
 		context: StreamableHTTPContext
 	) async -> RouteResponse {
-		let session = await sessionManager.session(id: context.sessionID)
-		await bindBearerTokenIfNeeded(token, to: context.sessionID)
 		let sid = context.sessionID.uuidString
 
 		if batchContainsRequests(messages) {
+			// Validate Accept BEFORE materializing a session, so a rejection mints
+			// nothing (and, for modern, exposes no Mcp-Session-Id).
 			guard "text/event-stream".matchesAcceptHeader(context.acceptHeader)
 				|| "*/*".matchesAcceptHeader(context.acceptHeader) else {
 				return textResponse(
 					status: .badRequest,
 					body: "Client must accept text/event-stream.",
-					sessionID: context.sessionID
+					sessionID: context.isModern ? nil : context.sessionID
 				)
 			}
 
+			let session = await sessionManager.session(id: context.sessionID)
+			await bindBearerTokenIfNeeded(token, to: context.sessionID)
 			let (stream, streamInfo) = await createSSEStream(sessionID: context.sessionID, kind: .request)
 			let streamContext = OutboundStreamContext(streamID: streamInfo.streamID, kind: .request)
 
@@ -267,6 +278,8 @@ extension HTTPSSETransport {
 			return RouteResponse(status: .ok, headerFields: headerFields, bodyStream: stream, streamInfo: streamInfo)
 		}
 
+		let session = await sessionManager.session(id: context.sessionID)
+		await bindBearerTokenIfNeeded(token, to: context.sessionID)
 		_ = await session.work { _ in await self.processInbound(messages) }
 
 		// Modern is sessionless: reclaim the ephemeral session immediately (a

--- a/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
+++ b/Sources/SwiftMCP/Transport/Routing/SessionRouteHelpers.swift
@@ -26,6 +26,17 @@ extension HTTPSSETransport {
         return .unknown(sessionID)
     }
 
+    /// Whether an inbound HTTP request declares the modern era, from its
+    /// `MCP-Protocol-Version` header. Modern is stateless/sessionless, so the
+    /// header (not a session) is the reliable per-request era signal at the
+    /// transport layer, before any body `_meta` is parsed.
+    func requestDeclaresModern<Body: Sendable>(_ request: HTTPRouteRequest<Body>) -> Bool {
+        guard let headerVersion = request.header("MCP-Protocol-Version") else {
+            return false
+        }
+        return MCPProtocolVersion.isModern(headerVersion)
+    }
+
     func sessionNeedsInitialize(_ sessionID: UUID) async -> Bool {
         guard let session = await sessionManager.existingSession(id: sessionID) else {
             return false
@@ -48,7 +59,7 @@ extension HTTPSSETransport {
         sessionID: UUID?
     ) async -> RouteResponse? {
         if let headerVersion = request.header("MCP-Protocol-Version") {
-            guard MCPProtocolVersion.supported.contains(headerVersion) else {
+            guard MCPProtocolVersion.isServable(headerVersion) else {
                 return textResponse(status: .badRequest, body: "Invalid or unsupported MCP-Protocol-Version header.")
             }
 
@@ -75,7 +86,7 @@ extension HTTPSSETransport {
         messages: [JSONRPCMessage] = []
     ) async -> String {
         if let headerVersion = request.header("MCP-Protocol-Version"),
-           MCPProtocolVersion.supported.contains(headerVersion) {
+           MCPProtocolVersion.isServable(headerVersion) {
             return headerVersion
         }
 

--- a/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
+++ b/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
@@ -37,15 +37,19 @@ enum SessionInitializationGate {
         return messages.first?.params?["protocolVersion"]?.stringValue
     }
 
-    /// Whether the payload declares the modern era via the leading request's
-    /// `_meta` protocol version. Modern is stateless and has no `initialize`
-    /// handshake, so such requests must not be held by the init gate. This is
-    /// safe against batch-smuggling: modern revisions forbid JSON-RPC batching, so
-    /// a multi-item modern payload is independently rejected by the batching gate
-    /// (which runs after this check).
+    /// Whether the payload is a single modern-era message, identified by its
+    /// `_meta` protocol version. This is the authoritative per-request era signal
+    /// (matching `RequestContext.effectiveProtocolVersion`), used both to exempt
+    /// modern requests from the init gate (they are stateless, with no
+    /// `initialize`) and to route the modern transport.
+    ///
+    /// Modern applies to a request **or** a notification (both carry `_meta`).
+    /// Requiring a *lone* message keeps it smuggle-safe: modern revisions forbid
+    /// JSON-RPC batching, so a modern-tagged leading item can never carry sibling
+    /// batch work past the gate.
     static func batchIsModern(_ messages: [JSONRPCMessage]) -> Bool {
-        guard let first = messages.first, first.isRequest,
-              let version = first.params?["_meta"]?[MCPMetaKey.protocolVersion]?.stringValue else {
+        guard messages.count == 1, let only = messages.first,
+              let version = only.params?["_meta"]?[MCPMetaKey.protocolVersion]?.stringValue else {
             return false
         }
         return MCPProtocolVersion.isModern(version)

--- a/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
+++ b/Sources/SwiftMCP/Transport/SessionInitializationGate.swift
@@ -37,8 +37,25 @@ enum SessionInitializationGate {
         return messages.first?.params?["protocolVersion"]?.stringValue
     }
 
+    /// Whether the payload declares the modern era via the leading request's
+    /// `_meta` protocol version. Modern is stateless and has no `initialize`
+    /// handshake, so such requests must not be held by the init gate. This is
+    /// safe against batch-smuggling: modern revisions forbid JSON-RPC batching, so
+    /// a multi-item modern payload is independently rejected by the batching gate
+    /// (which runs after this check).
+    static func batchIsModern(_ messages: [JSONRPCMessage]) -> Bool {
+        guard let first = messages.first, first.isRequest,
+              let version = first.params?["_meta"]?[MCPMetaKey.protocolVersion]?.stringValue else {
+            return false
+        }
+        return MCPProtocolVersion.isModern(version)
+    }
+
     static func shouldReject(_ messages: [JSONRPCMessage], for session: Session) async -> Bool {
-        !(await session.hasReceivedInitializeRequest) && !batchStartsWithPreInitMethod(messages)
+        guard !(await session.hasReceivedInitializeRequest) else {
+            return false
+        }
+        return !batchStartsWithPreInitMethod(messages) && !batchIsModern(messages)
     }
 
     /// Builds one error response per *request* in the batch.

--- a/Tests/SwiftMCPTests/Connection/InMemoryHTTPAdapterTests.swift
+++ b/Tests/SwiftMCPTests/Connection/InMemoryHTTPAdapterTests.swift
@@ -77,6 +77,72 @@ struct InMemoryHTTPAdapterTests {
         }
     }
 
+    @Test("POST /mcp: a modern request is served sessionless (no Mcp-Session-Id, not -32004)")
+    func modernPostServedSessionless() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        // A modern client: MCP-Protocol-Version header + matching `_meta`, no session.
+        let toolsList = JSONRPCMessage.request(
+            id: 1, method: "tools/list",
+            params: .object(["_meta": .object(["io.modelcontextprotocol/protocolVersion": .string("2026-07-28")])])
+        )
+        var headers = jsonHeaders()
+        headers[.mcpProtocolVersion] = "2026-07-28"
+        let body = try HTTPTransportTestHelpers.encode(toolsList)
+        let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: headers, body: body)
+
+        #expect(exchange.status == .ok)
+        #expect(exchange.headerFields[.mcpSessionID] == nil)   // sessionless: no session echoed
+        let text = await drain(exchange.body)
+        #expect(text.contains("tools"))       // the tools/list result was served
+        #expect(!text.contains("-32004"))     // not rejected as an unsupported version
+    }
+
+    @Test("A modern notification leaves no session behind (sessionless cleanup)")
+    func modernNotificationIsSessionless() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+        var headers = jsonHeaders()
+        headers[.mcpProtocolVersion] = "2026-07-28"
+
+        let note = JSONRPCMessage.notification(
+            method: "notifications/cancelled",
+            params: .object(["_meta": .object(["io.modelcontextprotocol/protocolVersion": .string("2026-07-28")])])
+        )
+        let body = try HTTPTransportTestHelpers.encode(note)
+        let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: headers, body: body)
+
+        #expect(exchange.status == .accepted)
+        #expect(exchange.headerFields[.mcpSessionID] == nil)
+        // The ephemeral session minted for routing is reclaimed synchronously, so
+        // modern traffic accumulates no Session objects.
+        let sessionCount = await transport.sessionManager.sessions.count
+        #expect(sessionCount == 0)
+    }
+
+    @Test("GET /mcp declaring modern is 405 (standalone stream is legacy-only)")
+    func modernGetIs405() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        let exchange = await adapter.send(
+            method: .get, path: "/mcp", headerFields: [.mcpProtocolVersion: "2026-07-28"]
+        )
+        #expect(exchange.status == .methodNotAllowed)
+    }
+
+    @Test("DELETE /mcp declaring modern is 405 (sessionless has no teardown)")
+    func modernDeleteIs405() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        let exchange = await adapter.send(
+            method: .delete, path: "/mcp", headerFields: [.mcpProtocolVersion: "2026-07-28"]
+        )
+        #expect(exchange.status == .methodNotAllowed)
+    }
+
     @Test("Unknown path returns 404 through the seam")
     func unknownPathReturns404() async throws {
         let transport = HTTPSSETransport(server: Calculator())

--- a/Tests/SwiftMCPTests/Connection/InMemoryHTTPAdapterTests.swift
+++ b/Tests/SwiftMCPTests/Connection/InMemoryHTTPAdapterTests.swift
@@ -99,6 +99,51 @@ struct InMemoryHTTPAdapterTests {
         #expect(!text.contains("-32004"))     // not rejected as an unsupported version
     }
 
+    @Test("POST /mcp: a modern header without matching _meta is not served sessionless")
+    func modernHeaderWithoutMetaIsNotSessionless() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        // Modern MCP-Protocol-Version header, but the body carries NO modern _meta.
+        // The authoritative signal is _meta, so this must NOT take the sessionless
+        // path; it falls to the legacy gate (missing session) and is rejected —
+        // without minting an ephemeral session.
+        var headers = jsonHeaders()
+        headers[.mcpProtocolVersion] = "2026-07-28"
+        let body = try HTTPTransportTestHelpers.encode(
+            JSONRPCMessage.request(id: 1, method: "tools/list", params: nil)
+        )
+        let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: headers, body: body)
+
+        #expect(exchange.status == .badRequest)
+        let count = await transport.sessionManager.sessions.count
+        #expect(count == 0)
+    }
+
+    @Test("POST /mcp: a modern request with a non-SSE Accept is rejected cleanly")
+    func modernRequestNonSSEAcceptIsClean() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        // Accept: application/json (passes the JSON accept gate but not the SSE
+        // requirement for a request-bearing POST). The rejection must mint no
+        // session and expose no Mcp-Session-Id.
+        let toolsList = JSONRPCMessage.request(
+            id: 1, method: "tools/list",
+            params: .object(["_meta": .object(["io.modelcontextprotocol/protocolVersion": .string("2026-07-28")])])
+        )
+        let headers: HTTPFields = [
+            .accept: "application/json", .contentType: "application/json", .mcpProtocolVersion: "2026-07-28"
+        ]
+        let body = try HTTPTransportTestHelpers.encode(toolsList)
+        let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: headers, body: body)
+
+        #expect(exchange.status == .badRequest)
+        #expect(exchange.headerFields[.mcpSessionID] == nil)   // no session exposed
+        let count = await transport.sessionManager.sessions.count
+        #expect(count == 0)                                    // no session leaked
+    }
+
     @Test("A modern notification leaves no session behind (sessionless cleanup)")
     func modernNotificationIsSessionless() async throws {
         let transport = HTTPSSETransport(server: Calculator())

--- a/Tests/SwiftMCPTests/Connection/ServerDiscoverTests.swift
+++ b/Tests/SwiftMCPTests/Connection/ServerDiscoverTests.swift
@@ -135,5 +135,41 @@ struct ServerDiscoverTests {
         transport.stop()
         try await serveTask.value
     }
+
+    @Test("batchIsModern detects a leading modern _meta request")
+    func batchIsModernDetection() {
+        let modern = JSONRPCMessage.request(id: 1, method: "tools/list", params: metaVersion("2026-07-28"))
+        let legacy = JSONRPCMessage.request(id: 2, method: "tools/list", params: nil)
+        #expect(SessionInitializationGate.batchIsModern([modern]))
+        #expect(!SessionInitializationGate.batchIsModern([legacy]))
+    }
+
+    @Test("A modern _meta request is served before initialize (gate exemption + reachability)")
+    func modernRequestServedPreInitialize() async throws {
+        let server = DiscoverTestServer()
+        let transport = InMemoryTransport()
+        let serveTask = Task {
+            try await server.serve(over: [transport], gracefulShutdownSignals: [], logger: Self.logger)
+        }
+
+        let connection = transport.accept()
+        var outbound = connection.outbound.makeAsyncIterator()
+        // A modern client: no initialize handshake, a tools/list carrying the
+        // modern `_meta` protocol version. It must be served (not gate-rejected,
+        // not -32004'd), proving `2026-07-28` is reachable while unadvertised.
+        connection.clientSends([request(id: 1, method: "tools/list", params: metaVersion("2026-07-28"))])
+
+        let frame = try #require(await outbound.next())
+        guard case .response(let response) = frame.first else {
+            Issue.record("modern tools/list should be served, got \(String(describing: frame.first))")
+            transport.stop()
+            return
+        }
+        #expect(response.id == .integer(1))
+        #expect(response.result?["tools"] != nil)   // the tools list, not a rejection
+
+        transport.stop()
+        try await serveTask.value
+    }
 }
 #endif

--- a/Tests/SwiftMCPTests/Connection/ServerDiscoverTests.swift
+++ b/Tests/SwiftMCPTests/Connection/ServerDiscoverTests.swift
@@ -136,12 +136,15 @@ struct ServerDiscoverTests {
         try await serveTask.value
     }
 
-    @Test("batchIsModern detects a leading modern _meta request")
+    @Test("batchIsModern classifies a lone modern _meta message, never a batch")
     func batchIsModernDetection() {
         let modern = JSONRPCMessage.request(id: 1, method: "tools/list", params: metaVersion("2026-07-28"))
         let legacy = JSONRPCMessage.request(id: 2, method: "tools/list", params: nil)
         #expect(SessionInitializationGate.batchIsModern([modern]))
         #expect(!SessionInitializationGate.batchIsModern([legacy]))
+        // Smuggle-safe: a modern-tagged message leading a batch is NOT modern, so
+        // it can't carry sibling items past the gate.
+        #expect(!SessionInitializationGate.batchIsModern([modern, legacy]))
     }
 
     @Test("A modern _meta request is served before initialize (gate exemption + reachability)")

--- a/Tests/SwiftMCPTests/DiscoverModelTests.swift
+++ b/Tests/SwiftMCPTests/DiscoverModelTests.swift
@@ -48,4 +48,24 @@ struct DiscoverModelTests {
     func supportedDescendingOrder() {
         #expect(MCPProtocolVersion.supportedDescending == ["2025-11-25", "2025-06-18", "2025-03-26"])
     }
+
+    @Test("isModern / isServable split advertised from processable versions")
+    func modernAndServable() {
+        // 2026-07-28 is a known modern revision, servable, but NOT advertised.
+        #expect(MCPProtocolVersion.isModern("2026-07-28"))
+        #expect(MCPProtocolVersion.isServable("2026-07-28"))
+        #expect(!MCPProtocolVersion.supported.contains("2026-07-28"))
+
+        // Negotiable legacy revisions: servable, not modern.
+        #expect(!MCPProtocolVersion.isModern("2025-11-25"))
+        #expect(MCPProtocolVersion.isServable("2025-11-25"))
+
+        // A known-but-non-negotiable legacy revision (2024-11-05) is neither.
+        #expect(!MCPProtocolVersion.isModern("2024-11-05"))
+        #expect(!MCPProtocolVersion.isServable("2024-11-05"))
+
+        // An unknown version is neither modern nor servable.
+        #expect(!MCPProtocolVersion.isModern("2099-01-01"))
+        #expect(!MCPProtocolVersion.isServable("2099-01-01"))
+    }
 }


### PR DESCRIPTION
First slice of **Phase 2 — Modern Streamable HTTP** (issue #137), the dual-era spec's largest transport change. Delivered as a short series of focused PRs; this one makes the modern path **reachable**, additively and profile-gated. Phase 1 (`server/discover`, `-32004`, `extensions`) is on `main` via #152.

`2026-07-28` stays deliberately **out** of `MCPProtocolVersion.supported` (unadvertised); legacy behavior is unchanged throughout.

## Reachability — the foundation
- New `MCPProtocolVersion.isModern(_:)` / `isServable(_:)`. **"Servable" is broader than "advertised":** `supported` ∪ known-modern. A request that declares `2026-07-28` (which has a profile) now reaches modern handling even though it isn't in `supported` / `server/discover`. The eventual "flip" is simply adding it to `supported`.
- The `-32004` guard (`MCPServer+Handlers`) and the HTTP `MCP-Protocol-Version` checks (`SessionRouteHelpers`) key off `isServable`; unknown / non-negotiable versions still get `-32004`.
- `SessionInitializationGate` exempts modern requests (`batchIsModern`) — they are sessionless with no `initialize`. Safe against batch-smuggling: modern forbids JSON-RPC batching, so a multi-item modern payload is rejected by the batching gate that runs *after* the init gate.

## Modern Streamable HTTP shape
- **Sessionless POST** — inbound `Mcp-Session-Id` ignored, none echoed. An ephemeral session backs only this request's SSE stream and is **reclaimed** as soon as the stream finishes (SSE path) or immediately (notification path), so modern traffic accumulates no `Session` objects.
- `GET /mcp` and `DELETE /mcp` declaring modern → **405** (standalone stream / session teardown are legacy-only). Legacy `/mcp` and `/sse` untouched.

## Deferred to later Phase 2 PRs
2b: required `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers + validation (`HeaderMismatch -32001`), unknown-method `404`+`-32601`, `Origin` `403`. 2c: `x-mcp-header`. 2d: per-request non-resumable SSE + `X-Accel-Buffering`. (And the final `supported` flip that advertises modern.)

## Testing
- `isModern`/`isServable` table; `batchIsModern`; a modern request served **pre-initialize** (gate exemption + reachability) over the in-memory transport.
- Over `InMemoryHTTPServerAdapter` (no socket): a modern POST served **sessionless** (no `Mcp-Session-Id`, not `-32004`); modern `GET`/`DELETE` → `405`; a modern notification leaving **no session behind**.
- **520 tests pass**; NIO-free trait matrix builds; `swiftlint --strict` clean.

> The sessionless-cleanup fix (ephemeral `Session` leak) was surfaced by an adversarial review pass before commit; the gate-exemption security and legacy-regression dimensions came back clean.

Part of #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)