### PR TITLE
Make JWT issuer-verification test offline (seed JWKS cache)

### DIFF
--- a/Sources/SwiftMCP/Transport/OAuth/JSONWebKeySet.swift
+++ b/Sources/SwiftMCP/Transport/OAuth/JSONWebKeySet.swift
@@ -62,8 +62,25 @@ public actor JWKSCache {
         return jwks
     }
 
+    /// Seed the cache with a pre-fetched JWKS for an issuer.
+    ///
+    /// Stores `jwks` as the cached key set for `issuer` so a subsequent
+    /// `getJWKS(for:)` returns it without performing a network fetch (subject to
+    /// the normal cache-validity window). This is useful for warming the cache
+    /// from a key set obtained out-of-band, and for exercising verification in
+    /// tests without depending on a live issuer endpoint.
+    ///
+    /// - Parameters:
+    ///   - jwks: The key set to cache.
+    ///   - issuer: The issuer URL to associate the key set with.
+    ///   - date: The fetch timestamp to record (defaults to now); the entry
+    ///     stays valid for `cacheValidityDuration` after this time.
+    func seed(_ jwks: JSONWebKeySet, for issuer: URL, at date: Date = Date()) {
+        cache[issuer] = (jwks, date)
+    }
+
     /// Clear all cached JWKS entries
-    /// 
+    ///
     /// Use this method to force fresh JWKS fetches on the next request.
     func clearCache() {
         cache.removeAll()

--- a/Tests/SwiftMCPTests/JSONWebTokenTests.swift
+++ b/Tests/SwiftMCPTests/JSONWebTokenTests.swift
@@ -173,9 +173,17 @@ struct JSONWebTokenTests {
     func testVerifyUsingIssuer() async throws {
         let jwt = try JSONWebToken(token: Self.accessToken)
 
+        // Seed a JWKS cache with the embedded test key set so verification runs
+        // offline. This exercises the same `verify(using: issuer:)` -> claims +
+        // RSA signature-verification path without a live network request to the
+        // issuer's discovery/JWKS endpoint (which was intermittently timing out
+        // on CI and must not gate a unit test).
+        let cache = JWKSCache()
+        await cache.seed(try loadTestJWKS(), for: Self.issuerURL)
+
         // Verify using issuer with valid time
         let validDate = Date(timeIntervalSince1970: 1751206127) // iat time
-        let isValid = try await jwt.verify(using: Self.issuerURL, at: validDate)
+        let isValid = try await jwt.verify(using: Self.issuerURL, at: validDate, jwksCache: cache)
         #expect(isValid == true)
     }
 


### PR DESCRIPTION
## Problem

`testVerifyUsingIssuer()` in `Tests/SwiftMCPTests/JSONWebTokenTests.swift` called `jwt.verify(using: issuerURL, …)`, which walks `JWKSCache.getJWKS` → `JSONWebKeySet(fromIssuer:)` → a live `URLSession.shared.data(from:)` GET to the issuer's `.well-known/jwks.json`.

On CI this intermittently failed with `NSURLErrorDomain Code=-1001 "The request timed out"` after ~60s (observed on the `macos-latest` runner for #153; Linux/Android happened to reach the endpoint and passed). A unit test should not depend on a live network endpoint.

## Fix

Use an in-memory test double for the fetch instead of hitting the network:

- **`JSONWebKeySet.swift`** — add an internal `JWKSCache.seed(_:for:at:)` helper that pre-populates the cache for an issuer. It follows the actor's existing internal-method convention (`getJWKS`, `clearCache`, `removeFromCache` are all internal, reachable via `@testable import`) and is also genuinely useful for warming the cache from a key set obtained out-of-band.
- **`JSONWebTokenTests.swift`** — `testVerifyUsingIssuer()` now seeds a cache with the embedded `loadTestJWKS()` key set and passes it through the pre-existing `jwksCache:` parameter. `getJWKS` returns the cached entry and never touches the network.

The seeded cache short-circuits **only** the HTTP fetch — the test still drives the exact same downstream path (`validateClaims` + `verifySignature(using:)` performing real RSA-PKCS1v1.5 verification against the actual embedded public key), so the assertion remains meaningful.

## Why not a `URLProtocol` stub

A `URLProtocol` mock would require threading a non-`Sendable` `URLSession` across the `JWKSCache` actor boundary under Swift 6 strict-concurrency, and its cross-platform behavior on the Linux/Android runners couldn't be verified locally. Seeding the cache is pure in-memory and behaves identically on every platform. The task explicitly lists "a test double for the network fetch" as an acceptable option.

## Verification

All 11 tests in the `JSONWebToken` suite pass with the default trait set (`Server`, `Client`, `OpenAPI`). The previously-flaky `"Verify token using issuer directly"` now completes in ~4ms instead of a ~60s network timeout. The JWKS JSON-decode path stays covered by the sibling `testVerifySignatureUsingJWKS` / `testVerifyWithClaimsValidation` tests, which use the same `loadTestJWKS()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)