### PR TITLE
MCP 2026-07-28 Phase 2c: non-resumable modern SSE, X-Accel-Buffering, unknown-method 404

### DIFF
--- a/Sources/SwiftMCP/Protocols/MCPServer+Handlers.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Handlers.swift
@@ -89,6 +89,9 @@ public extension MCPServer {
     }
 
     /// Handles `initialize` / `ping` requests.
+    ///
+    /// See ``ModernRequestMethods`` below for the modern-era request surface the
+    /// HTTP route layer checks before dispatch.
     private func dispatchInitializationOrMetaRequest(
         _ requestData: JSONRPCMessage.JSONRPCRequestData
     ) async -> JSONRPCMessage? {
@@ -226,4 +229,26 @@ public extension MCPServer {
         }
         return nil
     }
+}
+
+/// The request methods a modern (`2026-07-28`) client may call — the closed
+/// modern-era surface of the dispatch functions above. The HTTP route layer
+/// consults this *before* dispatch so an unknown modern method can be answered
+/// with HTTP `404` + `-32601` (the per-request SSE stream commits the status
+/// before dispatch completes, so the decision cannot wait for the in-band
+/// fallback).
+///
+/// Deliberately excluded (legacy-only per `ProtocolVersionProfile`):
+/// `initialize`, `ping`, `logging/setLevel`, `resources/subscribe` /
+/// `resources/unsubscribe`. `subscriptions/listen` joins when Phase 4 implements
+/// it. Keep in sync with the `dispatch*Request` functions — the
+/// "modern method surface matches the dispatcher" test enforces this.
+enum ModernRequestMethods {
+    static let known: Set<String> = [
+        "server/discover",
+        "tools/list", "tools/call",
+        "resources/list", "resources/templates/list", "resources/read",
+        "prompts/list", "prompts/get",
+        "completion/complete"
+    ]
 }

--- a/Sources/SwiftMCP/Protocols/MCPServer+Tools.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Tools.swift
@@ -44,8 +44,13 @@ public extension MCPServer {
 
         guard let params = request.params,
               let toolName = params["name"]?.stringValue else {
-            // Invalid request: missing tool name
-            return nil
+            // The method itself is known — a missing/non-string tool name is an
+            // Invalid Params error, not the "Method not found" the nil
+            // fallthrough used to produce.
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32602, message: "Invalid params: missing tool name")
+            )
         }
 
         // Extract arguments from the request

--- a/Sources/SwiftMCP/Transport/HTTPFieldName+MCP.swift
+++ b/Sources/SwiftMCP/Transport/HTTPFieldName+MCP.swift
@@ -31,4 +31,8 @@ extension HTTPField.Name {
 	/// `Last-Event-ID` — the SSE resumption cursor used to resume a broken
 	/// streamable-HTTP / legacy-SSE stream.
 	public static let lastEventID = Self("Last-Event-ID")!
+
+	/// `X-Accel-Buffering` — set to `no` on modern per-request SSE responses so
+	/// buffering reverse proxies (nginx et al.) pass events through immediately.
+	public static let xAccelBuffering = Self("X-Accel-Buffering")!
 }

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport+SSE.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport+SSE.swift
@@ -4,8 +4,12 @@ import Foundation
 extension HTTPSSETransport {
     // MARK: - Handling SSE Connections
 
-    func createSSEStream(sessionID: UUID, kind: SSEStreamKind) async -> (AsyncStream<Data>, StreamRouteResponseInfo) {
-        await sessionManager.createStream(sessionID: sessionID, kind: kind)
+    func createSSEStream(
+        sessionID: UUID,
+        kind: SSEStreamKind,
+        resumable: Bool = true
+    ) async -> (AsyncStream<Data>, StreamRouteResponseInfo) {
+        await sessionManager.createStream(sessionID: sessionID, kind: kind, resumable: resumable)
     }
 
     func resumeSSEStream(

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes+ModernHeaders.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes+ModernHeaders.swift
@@ -11,6 +11,35 @@ import HTTPTypes
 /// only invoked for requests classified modern by their body `_meta`.
 extension HTTPSSETransport {
 
+	/// The full modern pre-dispatch gate: required-header validation (`400` +
+	/// `-32001`) and the unknown-method check (`404` + `-32601`), in that order.
+	/// Both must be decided *before* dispatch — the per-request SSE stream commits
+	/// the HTTP status, so an in-band error can't produce the spec-required codes.
+	func modernPreflightResponse<Body: Sendable>(
+		request: HTTPRouteRequest<Body>,
+		messages: [JSONRPCMessage]
+	) -> RouteResponse? {
+		if let headerError = validateModernHeaders(request: request, messages: messages) {
+			return headerError
+		}
+		return modernUnknownMethodResponse(messages: messages)
+	}
+
+	/// A `404` + `-32601` for a modern *request* whose method is outside the
+	/// modern-era surface (``ModernRequestMethods``). Notifications never 404
+	/// (they get a `202` as usual); legacy keeps its in-band `-32601` over `200`.
+	private func modernUnknownMethodResponse(messages: [JSONRPCMessage]) -> RouteResponse? {
+		guard let message = messages.first, message.isRequest,
+		      let method = message.method, !ModernRequestMethods.known.contains(method) else {
+			return nil
+		}
+		let error = JSONRPCMessage.errorResponse(
+			id: message.id,
+			error: .init(code: -32601, message: "Method not found: \(method)")
+		)
+		return .json(error, status: .notFound, sessionId: nil)
+	}
+
 	/// Validates the modern required headers against the decoded message, returning
 	/// a `-32001` response on the first missing/mismatched header, or `nil` when all
 	/// match. Modern is a single message (``SessionInitializationGate/batchIsModern``

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes+ModernHeaders.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes+ModernHeaders.swift
@@ -11,14 +11,24 @@ import HTTPTypes
 /// only invoked for requests classified modern by their body `_meta`.
 extension HTTPSSETransport {
 
-	/// The full modern pre-dispatch gate: required-header validation (`400` +
-	/// `-32001`) and the unknown-method check (`404` + `-32601`), in that order.
-	/// Both must be decided *before* dispatch — the per-request SSE stream commits
-	/// the HTTP status, so an in-band error can't produce the spec-required codes.
+	/// The full modern pre-dispatch gate, in order: batch-framing rejection
+	/// (`400` + `-32600`), required-header validation (`400` + `-32001`), then the
+	/// unknown-method check (`404` + `-32601`). All must be decided *before*
+	/// dispatch — the per-request SSE stream commits the HTTP status, so an
+	/// in-band error can't produce the spec-required codes.
 	func modernPreflightResponse<Body: Sendable>(
 		request: HTTPRouteRequest<Body>,
+		body: Data,
 		messages: [JSONRPCMessage]
 	) -> RouteResponse? {
+		// Modern forbids JSON-RPC batching, so a top-level array — even with a
+		// single element (which still classifies as modern) — is malformed
+		// *framing*. It must be rejected here, first, or the header validation /
+		// unknown-method checks below would mask the required -32600.
+		if JSONRPCMessage.batchingRejected(body: body, version: MCPProtocolVersion.modern) {
+			let error = JSONRPCMessage.batchingRejectionResponse(version: MCPProtocolVersion.modern)
+			return .json(error, status: .badRequest, sessionId: nil)
+		}
 		if let headerError = validateModernHeaders(request: request, messages: messages) {
 			return headerError
 		}

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -59,10 +59,10 @@ extension HTTPSSETransport {
 			// sessionless path and being served as legacy.
 			let isModern = SessionInitializationGate.batchIsModern(messages)
 
-			// Modern POSTs carry redundant headers (MCP-Protocol-Version / Mcp-Method
-			// / Mcp-Name) that must match the body; a mismatch is a 400 + -32001.
-			if isModern, let headerError = validateModernHeaders(request: request, messages: messages) {
-				return headerError
+			// Modern preflight: required-header validation (400 + -32001) and the
+			// unknown-method check (404 + -32601), both decided before dispatch.
+			if isModern, let preflightError = modernPreflightResponse(request: request, messages: messages) {
+				return preflightError
 			}
 
 			// Modern is sessionless (no inbound Mcp-Session-Id), so a malformed /
@@ -249,7 +249,12 @@ extension HTTPSSETransport {
 
 			let session = await sessionManager.session(id: context.sessionID)
 			await bindBearerTokenIfNeeded(token, to: context.sessionID)
-			let (stream, streamInfo) = await createSSEStream(sessionID: context.sessionID, kind: .request)
+			// Modern per-request streams are non-resumable: no replay buffer, no
+			// `id:` resume anchors on the wire (resume itself is GET-only, which
+			// modern already answers with 405).
+			let (stream, streamInfo) = await createSSEStream(
+				sessionID: context.sessionID, kind: .request, resumable: !context.isModern
+			)
 			let streamContext = OutboundStreamContext(streamID: streamInfo.streamID, kind: .request)
 
 			Task {
@@ -276,8 +281,12 @@ extension HTTPSSETransport {
 				.cacheControl: "no-cache",
 				.connection: "keep-alive"
 			]
-			// Modern is sessionless — never echo Mcp-Session-Id.
-			if !context.isModern {
+			// Modern is sessionless (no Mcp-Session-Id echoed) and tells buffering
+			// reverse proxies to pass per-request events through immediately; legacy
+			// keeps echoing the session id.
+			if context.isModern {
+				headerFields[.xAccelBuffering] = "no"
+			} else {
 				headerFields[.mcpSessionID] = sid
 			}
 

--- a/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
+++ b/Sources/SwiftMCP/Transport/Routing/MCPRoutes.swift
@@ -59,9 +59,10 @@ extension HTTPSSETransport {
 			// sessionless path and being served as legacy.
 			let isModern = SessionInitializationGate.batchIsModern(messages)
 
-			// Modern preflight: required-header validation (400 + -32001) and the
-			// unknown-method check (404 + -32601), both decided before dispatch.
-			if isModern, let preflightError = modernPreflightResponse(request: request, messages: messages) {
+			// Modern preflight: batch-framing rejection (400 + -32600), required-
+			// header validation (400 + -32001), then the unknown-method check
+			// (404 + -32601) — all decided before dispatch.
+			if isModern, let preflightError = modernPreflightResponse(request: request, body: body, messages: messages) {
 				return preflightError
 			}
 

--- a/Sources/SwiftMCP/Transport/SessionManager+Streams.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+Streams.swift
@@ -11,7 +11,16 @@ extension SessionManager {
     }
 
     /// Create a new SSE stream for the given session and return the AsyncStream to write to the response.
-    func createStream(sessionID: UUID, kind: SSEStreamKind) async -> (AsyncStream<Data>, StreamRouteResponseInfo) {
+    ///
+    /// `resumable: false` (the modern era's per-request streams) opens the hub
+    /// stream without a replay buffer or priming anchor: no `id:` fields reach the
+    /// wire and nothing is retained for a `Last-Event-ID` resume — modern streams
+    /// must not advertise or support resumability.
+    func createStream(
+        sessionID: UUID,
+        kind: SSEStreamKind,
+        resumable: Bool = true
+    ) async -> (AsyncStream<Data>, StreamRouteResponseInfo) {
         await cleanupExpiredState()
         let session = await session(id: sessionID)
         await session.touchActivity()
@@ -21,8 +30,8 @@ extension SessionManager {
         // legacy general streams are fire-and-forget; request streams stop
         // accepting once finished; general streams keep accepting.
         let (stream, streamID) = hub.open(
-            replayable: kind != .legacyGeneral,
-            primed: kind != .legacyGeneral,
+            replayable: resumable && kind != .legacyGeneral,
+            primed: resumable && kind != .legacyGeneral,
             rejectsSendAfterCompletion: kind == .request
         )
         streamMeta[streamID] = StreamMeta(sessionID: sessionID, kind: kind)

--- a/Tests/SwiftMCPTests/Connection/ModernResponseShapeTests.swift
+++ b/Tests/SwiftMCPTests/Connection/ModernResponseShapeTests.swift
@@ -1,0 +1,161 @@
+#if Server
+import Testing
+import Foundation
+import HTTPTypes
+@testable import SwiftMCP
+
+/// Exercises the modern (`2026-07-28`) response shape over the socket-free
+/// ``InMemoryHTTPServerAdapter``: per-request SSE streams are non-resumable (no
+/// `id:` anchors), carry `X-Accel-Buffering: no`, and an unknown method is
+/// answered `404` + `-32601` before dispatch.
+@Suite("Modern response shape (non-resumable SSE, 404)")
+struct ModernResponseShapeTests {
+
+    private func modernBody(method: String, extra: [String: JSONValue] = [:]) throws -> Data {
+        var params: JSONDictionary = [
+            "_meta": .object(["io.modelcontextprotocol/protocolVersion": .string("2026-07-28")])
+        ]
+        for (key, value) in extra { params[key] = value }
+        return try HTTPTransportTestHelpers.encode(
+            JSONRPCMessage.request(id: 1, method: method, params: .object(params))
+        )
+    }
+
+    private func modernHeaders(method: String, name: String? = nil) -> HTTPFields {
+        var headers: HTTPFields = [
+            .accept: "application/json, text/event-stream", .contentType: "application/json",
+            .mcpProtocolVersion: "2026-07-28", .mcpMethod: method
+        ]
+        if let name { headers[.mcpName] = name }
+        return headers
+    }
+
+    private func drain(_ exchange: InMemoryHTTPServerAdapter.Exchange) async -> String {
+        guard case .sse(let stream) = exchange.body else { return "" }
+        var data = Data()
+        for await chunk in stream { data.append(chunk) }
+        return String(bytes: data, encoding: .utf8) ?? ""
+    }
+
+    private func bufferedText(_ exchange: InMemoryHTTPServerAdapter.Exchange) -> String {
+        guard case .buffered(let data?) = exchange.body else { return "" }
+        return String(bytes: data, encoding: .utf8) ?? ""
+    }
+
+    @Test("Modern SSE reply is non-resumable: no id: anchors, X-Accel-Buffering: no")
+    func modernStreamShape() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+        let exchange = await adapter.send(
+            method: .post, path: "/mcp",
+            headerFields: modernHeaders(method: "tools/list"),
+            body: try modernBody(method: "tools/list")
+        )
+
+        #expect(exchange.status == .ok)
+        #expect(exchange.headerFields[.xAccelBuffering] == "no")
+        #expect(exchange.headerFields[.mcpSessionID] == nil)
+
+        let text = await drain(exchange)
+        #expect(text.contains("tools"))     // the result arrived
+        // No resume anchors: an SSE `id` field is a *line* starting with "id:",
+        // so check line-anchored (a JSON body's "id":1 can never false-positive).
+        let anchorLines = text.split(separator: "\n").filter { $0.hasPrefix("id:") }
+        #expect(anchorLines.isEmpty)
+    }
+
+    @Test("Legacy SSE reply keeps its resume anchors and gets no X-Accel-Buffering")
+    func legacyStreamShapeUnchanged() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+        let headers: HTTPFields = [
+            .accept: "application/json, text/event-stream", .contentType: "application/json"
+        ]
+        let body = try HTTPTransportTestHelpers.encode(HTTPTransportTestHelpers.initializeRequest())
+        let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: headers, body: body)
+
+        #expect(exchange.status == .ok)
+        #expect(exchange.headerFields[.xAccelBuffering] == nil)
+        let text = await drain(exchange)
+        #expect(text.contains("id: "))      // priming anchor still present for legacy
+    }
+
+    @Test("Modern legacy-only and unknown methods → 404 + -32601")
+    func modernUnknownMethodIs404() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        for method in ["ping", "resources/subscribe", "frobnicate/run"] {
+            let exchange = await adapter.send(
+                method: .post, path: "/mcp",
+                headerFields: modernHeaders(method: method),
+                body: try modernBody(method: method)
+            )
+            #expect(exchange.status == .notFound, "expected 404 for \(method)")
+            let text = bufferedText(exchange)
+            #expect(text.contains("-32601"), "expected -32601 for \(method)")
+        }
+    }
+
+    @Test("Legacy unknown method stays an in-band -32601 over 200")
+    func legacyUnknownMethodInBand() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+        let headers: HTTPFields = [
+            .accept: "application/json, text/event-stream", .contentType: "application/json"
+        ]
+
+        let initBody = try HTTPTransportTestHelpers.encode(HTTPTransportTestHelpers.initializeRequest())
+        let initExchange = await adapter.send(method: .post, path: "/mcp", headerFields: headers, body: initBody)
+        let sessionID = try #require(initExchange.headerFields[.mcpSessionID])
+        _ = await drain(initExchange)
+
+        var readHeaders = headers
+        readHeaders[.mcpSessionID] = sessionID
+        let body = try HTTPTransportTestHelpers.encode(
+            JSONRPCMessage.request(id: 2, method: "frobnicate/run", params: nil)
+        )
+        let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: readHeaders, body: body)
+        #expect(exchange.status == .ok)
+        let text = await drain(exchange)
+        #expect(text.contains("-32601"))
+    }
+
+    @Test("A modern notification with an unknown method still gets 202")
+    func modernUnknownNotificationIs202() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+        let note = JSONRPCMessage.notification(
+            method: "notifications/whatever",
+            params: .object(["_meta": .object(["io.modelcontextprotocol/protocolVersion": .string("2026-07-28")])])
+        )
+        let exchange = await adapter.send(
+            method: .post, path: "/mcp",
+            headerFields: modernHeaders(method: "notifications/whatever"),
+            body: try HTTPTransportTestHelpers.encode(note)
+        )
+        #expect(exchange.status == .accepted)
+    }
+
+    @Test("The modern method surface matches the dispatcher (no drift)")
+    func modernMethodSurfaceMatchesDispatcher() async throws {
+        let server = Calculator()
+        // Every method in the set must dispatch to something other than the
+        // -32601 fallback (malformed-params errors are fine — they prove the
+        // method itself is routed).
+        for method in ModernRequestMethods.known {
+            let response = await server.handleMessage(.request(id: 1, method: method, params: nil))
+            if case .errorResponse(let err) = response {
+                #expect(err.error.code != -32601, "\(method) fell through to -32601 — set is stale")
+            }
+        }
+        // And a made-up method must fall through, proving the fallback works.
+        let unknown = await server.handleMessage(.request(id: 2, method: "frobnicate/run", params: nil))
+        guard case .errorResponse(let err) = unknown else {
+            Issue.record("expected -32601 for an unknown method")
+            return
+        }
+        #expect(err.error.code == -32601)
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/Connection/ModernResponseShapeTests.swift
+++ b/Tests/SwiftMCPTests/Connection/ModernResponseShapeTests.swift
@@ -121,6 +121,35 @@ struct ModernResponseShapeTests {
         #expect(text.contains("-32601"))
     }
 
+    @Test("A single-element array is rejected -32600 for modern, never masked by 404 or headers")
+    func modernSingleElementArrayIsBatchRejected() async throws {
+        let transport = HTTPSSETransport(server: Calculator())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        // A one-element top-level array still classifies as modern (count == 1
+        // after decoding), but modern forbids batching: the framing rejection
+        // (-32600) must win over both the unknown-method 404 and the header
+        // validation -32001.
+        for method in ["frobnicate/run", "tools/list"] {
+            let single = JSONRPCMessage.request(
+                id: 1, method: method,
+                params: .object([
+                    "_meta": .object(["io.modelcontextprotocol/protocolVersion": .string("2026-07-28")])
+                ])
+            )
+            let body = try JSONEncoder().encode([single])   // top-level array
+            let exchange = await adapter.send(
+                method: .post, path: "/mcp",
+                headerFields: modernHeaders(method: method),
+                body: body
+            )
+            #expect(exchange.status == .badRequest, "expected -32600 rejection for \(method)")
+            let text = bufferedText(exchange)
+            #expect(text.contains("-32600"), "expected -32600 for \(method), got \(text)")
+            #expect(!text.contains("-32601"))
+        }
+    }
+
     @Test("A modern notification with an unknown method still gets 202")
     func modernUnknownNotificationIs202() async throws {
         let transport = HTTPSSETransport(server: Calculator())


### PR DESCRIPTION
Third slice of **Phase 2 — Modern Streamable HTTP** (issue #137), completing the modern per-request **response shape**. 2a (#153) made the modern path reachable/sessionless; 2b (#155) added required-header validation. Legacy is unchanged throughout; `2026-07-28` stays out of `supported` (unadvertised).

## Non-resumable modern streams
`createSSEStream`/`createStream` gain `resumable: Bool = true`; a modern request-bearing POST opens its per-request stream with `replayable: false, primed: false` — **no replay buffer retained, no `id:` resume anchors on the wire**. Resume itself is GET-only, which modern already answers `405` (2a), so this closes the *state-building* half. Delivery is unaffected (the JF hub yields into the response stream regardless of replay flags — its own test suite proves delivery without buffering). The stream kind stays `.request`; legacy streams keep their anchors and replay behavior byte-identically.

## `X-Accel-Buffering: no`
Set on modern SSE responses (new `HTTPField.Name.xAccelBuffering`) so buffering reverse proxies (nginx et al.) pass per-request events through immediately. Legacy responses unchanged.

## Unknown method → `404` + `-32601` (modern only)
Decided **before** dispatch — the per-request SSE stream commits the HTTP status, so the in-band fallback can't produce the spec-required `404`. The modern-era request surface is a curated `ModernRequestMethods.known` set living next to the dispatch functions, **pinned to the dispatcher by a consistency test** (every listed method must dispatch to non-`-32601`; a nonsense method must fall through). Legacy-only methods (`initialize`, `ping`, `logging/setLevel`, `resources/subscribe`/`unsubscribe`) get `404` for modern; `subscriptions/listen` joins the set when Phase 4 implements it. Notifications never `404` (still `202`); legacy keeps its in-band `-32601` over `200`. The 2b header validation + the 404 check are folded into one `modernPreflightResponse`.

## Incidental conformance fix (exposed by the consistency test)
`handleToolCall` returned `nil` for a missing/non-string `params.name`, cascading to a misleading `-32601` "Method not found" — it now answers **`-32602` Invalid params** (the method exists; the params are wrong).

## Deferred (slice 2d)
`x-mcp-header`, `Origin` → `403` (needs a config-policy decision), and later the `supported` flip.

## Testing
- Modern stream: no line-anchored `id:` fields, carries `X-Accel-Buffering: no`, no `Mcp-Session-Id`; legacy regression keeps the priming anchor and gets no `X-Accel-Buffering`.
- Modern `ping` / `resources/subscribe` / nonsense method → `404` + `-32601`; the same nonsense on a legacy session → in-band `-32601` over `200`; modern unknown-method notification → `202`.
- Method-surface consistency test (set ↔ dispatcher, both directions).
- **543 tests pass**; NIO-free trait matrix builds; `swiftlint --strict` clean.

> Adversarially reviewed before commit: the stream-delivery semantics (non-replayable streams still deliver; cleanup via the 2a `removeSession` path verified) and the 404 surface came back clean; two minor cleanups were applied. Codex has been rate-limited, so the substitute review pass is the primary independent reviewer on this PR.

Part of #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)