### PR TITLE
De-flake polling HTTP tests: raise waitForCondition failure bound to 15s

### DIFF
--- a/Tests/SwiftMCPTests/HTTPTransportTestHelpers.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTestHelpers.swift
@@ -133,8 +133,17 @@ enum HTTPTransportTestHelpers {
         return HTTPTransportStreamCapture(response: responseBox, events: eventsBox, task: task)
     }
 
+    /// Polls until `condition` holds or the deadline passes.
+    ///
+    /// The default deadline is a *failure* bound, not a wait: the helper returns
+    /// the moment the condition holds, so a healthy run costs only the actual
+    /// event latency. It is sized generously because every caller is a positive
+    /// wait racing real localhost networking (URLSession cold start + TCP connect
+    /// + SSE delivery), which can far exceed a tight bound on a loaded CI runner —
+    /// a 2s deadline made `expiredRequestStreamResume` flake on macos-latest.
+    /// Do NOT use this helper to assert a condition *stays* false.
     static func waitForCondition(
-        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        timeoutNanoseconds: UInt64 = 15_000_000_000,
         pollNanoseconds: UInt64 = 50_000_000,
         _ condition: @escaping @Sendable () -> Bool
     ) async -> Bool {

--- a/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
+++ b/Tests/SwiftMCPTests/MCPServerProxyStreamableHTTPTests.swift
@@ -138,8 +138,11 @@ struct MCPServerProxyStreamableHTTPTests {
         #expect(!tools.isEmpty)
     }
 
+    /// Async-condition sibling of `HTTPTransportTestHelpers.waitForCondition`; the
+    /// generous deadline is a failure bound, not a wait (returns as soon as the
+    /// condition holds) — sized for loaded CI runners racing real localhost I/O.
     private func waitForCondition(
-        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        timeoutNanoseconds: UInt64 = 15_000_000_000,
         pollNanoseconds: UInt64 = 50_000_000,
         _ condition: @escaping @Sendable () async -> Bool
     ) async -> Bool {


### PR DESCRIPTION
`expiredRequestStreamResume` flaked on the macos-latest runner (seen on #155): the `notifications/progress` event from `slowPing` didn't arrive within `waitForCondition`'s **2-second default**, which races URLSession cold start + TCP connect + POST dispatch + per-request stream open + the tool's 150ms sleeps + SSE delivery over real localhost — comfortably exceedable on a loaded CI machine. It passes locally and on Linux/Android consistently.

**Fix:** raise the default deadline to **15s** in both helpers (`HTTPTransportTestHelpers.waitForCondition` and the async-condition sibling in `MCPServerProxyStreamableHTTPTests`), with doc comments. The deadline is a *failure* bound, not a wait: all 19 call sites are positive waits and the helper returns the moment the condition holds — healthy runs are unaffected (full suite still ~0.84s), only genuinely failing or stalled runs wait longer. Also documented that the helper must not be used to assert a condition *stays* false.

Deliberately **not** restructuring `openStreamingRequest` to await events deterministically — the polling shape is shared and fine; the only defect was the tight deadline. Retention-expiry semantics under test are untouched (the 404 is time-based; a slower runner only makes the stream *more* expired).

**Verification:** 12 consecutive full-suite runs green (544 tests each, ~0.84s); `swiftlint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)