### PR TITLE
MCP 2026-07-28 Phase 3: MRTR — input_required round trips with signed requestState

### DIFF
--- a/Sources/SwiftMCP/Models/MRTR.swift
+++ b/Sources/SwiftMCP/Models/MRTR.swift
@@ -1,0 +1,85 @@
+//
+//  MRTR.swift
+//  SwiftMCP
+//
+//  Multi Round-Trip Requests (MCP 2026-07-28, SEP-2322): the modern replacement
+//  for live server→client requests. A `tools/call` / `resources/read` /
+//  `prompts/get` that needs client input answers with an ``InputRequiredResult``;
+//  the client gathers the inputs and retries the original request (new JSON-RPC
+//  id) with `params.inputResponses` keyed by the same ids, echoing
+//  `params.requestState` verbatim.
+//
+
+import Foundation
+
+/// One server→client input request embedded in an ``InputRequiredResult`` —
+/// an `elicitation/create`, `sampling/createMessage`, or `roots/list` request
+/// carried as `{method, params}` (no JSON-RPC envelope).
+public struct InputRequest: Codable, Sendable {
+    public var method: String
+    public var params: JSONValue?
+
+    public init(method: String, params: JSONValue?) {
+        self.method = method
+        self.params = params
+    }
+}
+
+/// The `input_required` result a modern server returns when it needs client
+/// input to finish a request. At least one of `inputRequests` / `requestState`
+/// is always present (SwiftMCP always sends both).
+public struct InputRequiredResult: Codable, Sendable {
+    /// Discriminator: always `"input_required"`.
+    public var resultType: String
+
+    /// Server-assigned ids → the input requests the client must fulfill before
+    /// retrying. Ids are unique within the scope of the originating request.
+    public var inputRequests: [String: InputRequest]?
+
+    /// Opaque, integrity-protected server state the client echoes verbatim on
+    /// retry. Clients must not inspect or modify it.
+    public var requestState: String?
+
+    public init(
+        resultType: String = "input_required",
+        inputRequests: [String: InputRequest]? = nil,
+        requestState: String? = nil
+    ) {
+        self.resultType = resultType
+        self.inputRequests = inputRequests
+        self.requestState = requestState
+    }
+}
+
+/// The result shape of a `roots/list` reply (`{ "roots": [...] }`), used to
+/// decode an MRTR `inputResponses` entry for a `roots/list` input request.
+public struct RootsListResult: Codable, Sendable {
+    public var roots: [Root]
+
+    public init(roots: [Root]) {
+        self.roots = roots
+    }
+}
+
+/// Internal control-flow signal thrown by the era-aware `sample`/`elicit`/
+/// `listRoots` when a modern request needs client input that isn't present in
+/// the retry's `inputResponses`. The MRTR-eligible dispatch handlers catch it
+/// and answer with an ``InputRequiredResult``; it must never escape to a
+/// generic error path for those methods.
+struct InputRequiredSignal: Error {
+    /// The deterministic per-execution ordinal id (`input-N`) — the same call
+    /// site yields the same id on re-execution, so the retry lookup matches.
+    let id: String
+
+    /// The input request to surface to the client.
+    let request: InputRequest
+}
+
+/// Thrown when a retry's `inputResponses` entry exists but cannot be decoded
+/// into the shape the call site expects — a malformed client response (or an
+/// ordinal skew from a handler that isn't deterministic across re-executions).
+/// The MRTR handlers convert it to the spec's `-32602` protocol error.
+struct MRTRInvalidInputResponse: Error {
+    let id: String
+    let underlying: Error
+}

--- a/Sources/SwiftMCP/Protocols/MCPServer+MRTR.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+MRTR.swift
@@ -40,7 +40,7 @@ extension MCPServer {
             guard let payloadData = mrtrRequestStateSigner.verify(state),
                   let payload = try? JSONDecoder().decode(MRTRRequestStatePayload.self, from: payloadData),
                   payload.exp > Date().timeIntervalSince1970,
-                  payload.principal == MRTRRequestState.principal(accessToken: context.meta?.accessToken),
+                  payload.principal == MRTRRequestState.principal(accessToken: await mrtrPrincipalToken(context)),
                   payload.requestDigest == MRTRRequestState.requestDigest(
                     method: request.method, params: request.params
                   ) else {
@@ -61,13 +61,31 @@ extension MCPServer {
         }
 
         if let inputResponses = context.inputResponses {
-            merged.merge(inputResponses) { _, retry in retry }
+            // The signed accumulator is authoritative: an answer already fixed in
+            // `requestState` cannot be overwritten by a later retry resending the
+            // same id with a different value — only ids the state doesn't carry
+            // are taken from the retry.
+            merged.merge(inputResponses) { state, _ in state }
         }
 
         if !merged.isEmpty {
             await context.mrtr.setResponses(merged)
         }
         return nil
+    }
+
+    /// The token identifying the caller for `requestState` principal binding.
+    ///
+    /// Modern HTTP clients authenticate with an `Authorization: Bearer` header,
+    /// which the route layer validates and stores on the (ephemeral) session
+    /// *before* dispatch — `_meta.accessToken` is only a fallback for callers
+    /// that tunnel the token in-band. Both issuance and verification derive the
+    /// principal through this one helper so they can never disagree.
+    internal func mrtrPrincipalToken(_ context: RequestContext) async -> String? {
+        if let sessionToken = await Session.current?.accessToken {
+            return sessionToken
+        }
+        return context.meta?.accessToken
     }
 
     /// Converts an ``MRTRInvalidInputResponse`` into the spec's `-32602`
@@ -101,7 +119,7 @@ extension MCPServer {
             let payload = MRTRRequestStatePayload(
                 iat: now,
                 exp: now + MRTRRequestState.timeToLive,
-                principal: MRTRRequestState.principal(accessToken: context.meta?.accessToken),
+                principal: MRTRRequestState.principal(accessToken: await mrtrPrincipalToken(context)),
                 requestDigest: MRTRRequestState.requestDigest(method: request.method, params: request.params),
                 responses: await context.mrtr.allResponses()
             )

--- a/Sources/SwiftMCP/Protocols/MCPServer+MRTR.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+MRTR.swift
@@ -1,0 +1,124 @@
+//
+//  MCPServer+MRTR.swift
+//  SwiftMCP
+//
+//  The MRTR dispatch glue shared by the three eligible handlers (`tools/call`,
+//  `resources/read`, `prompts/get`): pre-execution verification/merging of a
+//  retry's `requestState` + `inputResponses`, and conversion of an
+//  ``InputRequiredSignal`` into an `input_required` response.
+//
+//  This file lives in the always-on core; the signed-state machinery needs
+//  swift-crypto, which only the `Server` trait links, so those parts are gated
+//  `#if Server`. Without it, MRTR degrades gracefully: `input_required` is
+//  emitted with `inputRequests` only (no `requestState` — the spec allows
+//  either field alone), which covers single-input round trips; multi-input
+//  tools then rely on the spec's re-request loop instead of the accumulator.
+//
+
+import Foundation
+
+extension MCPServer {
+
+    /// Pre-execution MRTR step for an eligible handler: ingests a retry's
+    /// `requestState` / `inputResponses` into the context's execution state.
+    ///
+    /// Returns an error response when the echoed state fails verification
+    /// (signature, expiry, principal, or originating-request digest — the state
+    /// is attacker-controlled input), `nil` to proceed with execution.
+    internal func mrtrPrepareExecution(
+        _ request: JSONRPCMessage.JSONRPCRequestData
+    ) async -> JSONRPCMessage? {
+        guard let context = RequestContext.current,
+              await context.protocolProfile.has(.mrtr) else {
+            return nil
+        }
+
+        var merged: [String: JSONValue] = [:]
+
+        if let state = context.requestState {
+            #if Server
+            guard let payloadData = mrtrRequestStateSigner.verify(state),
+                  let payload = try? JSONDecoder().decode(MRTRRequestStatePayload.self, from: payloadData),
+                  payload.exp > Date().timeIntervalSince1970,
+                  payload.principal == MRTRRequestState.principal(accessToken: context.meta?.accessToken),
+                  payload.requestDigest == MRTRRequestState.requestDigest(
+                    method: request.method, params: request.params
+                  ) else {
+                return JSONRPCMessage.errorResponse(
+                    id: request.id,
+                    error: .init(code: -32602, message: "Invalid params: requestState failed verification")
+                )
+            }
+            merged = payload.responses
+            #else
+            // Without the Server trait there is no signer: this build never
+            // *issued* a requestState, so any echoed one cannot be genuine.
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32602, message: "Invalid params: requestState failed verification")
+            )
+            #endif
+        }
+
+        if let inputResponses = context.inputResponses {
+            merged.merge(inputResponses) { _, retry in retry }
+        }
+
+        if !merged.isEmpty {
+            await context.mrtr.setResponses(merged)
+        }
+        return nil
+    }
+
+    /// Converts an ``MRTRInvalidInputResponse`` into the spec's `-32602`
+    /// protocol error: a present-but-undecodable `inputResponses` entry is
+    /// malformed client input, not a tool failure.
+    internal func mrtrInvalidInputResponse(
+        for invalid: MRTRInvalidInputResponse,
+        request: JSONRPCMessage.JSONRPCRequestData
+    ) -> JSONRPCMessage {
+        JSONRPCMessage.errorResponse(
+            id: request.id,
+            error: .init(
+                code: -32602,
+                message: "Invalid params: malformed inputResponse for '\(invalid.id)'"
+            )
+        )
+    }
+
+    /// Converts an ``InputRequiredSignal`` into the `input_required` response
+    /// for the originating request, signing the accumulated responses into
+    /// `requestState` so the next retry can replay every earlier answer.
+    internal func mrtrInputRequiredResponse(
+        for signal: InputRequiredSignal,
+        request: JSONRPCMessage.JSONRPCRequestData
+    ) async -> JSONRPCMessage {
+        var result = InputRequiredResult(inputRequests: [signal.id: signal.request])
+
+        #if Server
+        if let context = RequestContext.current {
+            let now = Date().timeIntervalSince1970
+            let payload = MRTRRequestStatePayload(
+                iat: now,
+                exp: now + MRTRRequestState.timeToLive,
+                principal: MRTRRequestState.principal(accessToken: context.meta?.accessToken),
+                requestDigest: MRTRRequestState.requestDigest(method: request.method, params: request.params),
+                responses: await context.mrtr.allResponses()
+            )
+            if let payloadData = try? JSONEncoder().encode(payload) {
+                result.requestState = mrtrRequestStateSigner.sign(payloadData)
+            }
+        }
+        #endif
+
+        do {
+            let resultDict = try JSONDictionary(encoding: result)
+            return JSONRPCMessage.response(id: request.id, result: .object(resultDict))
+        } catch {
+            return JSONRPCMessage.errorResponse(
+                id: request.id,
+                error: .init(code: -32603, message: "Failed to encode input_required result")
+            )
+        }
+    }
+}

--- a/Sources/SwiftMCP/Protocols/MCPServer+Prompts.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Prompts.swift
@@ -37,6 +37,12 @@ public extension MCPServer {
 
         let arguments = params["arguments"]?.dictionaryValue ?? [:]
 
+        // MRTR (modern): verify an echoed requestState and stage the retry's
+        // input responses before execution.
+        if let rejection = await mrtrPrepareExecution(request) {
+            return rejection
+        }
+
         do {
             let messages = try await promptProvider.callPrompt(name, arguments: arguments)
             return JSONRPCMessage.response(
@@ -46,6 +52,12 @@ public extension MCPServer {
                     "messages": try JSONValue(encoding: messages)
                 ]
             )
+        } catch let signal as InputRequiredSignal {
+            // MRTR (modern): the prompt needs client input — answer
+            // input_required and let the client retry with the responses.
+            return await mrtrInputRequiredResponse(for: signal, request: request)
+        } catch let invalid as MRTRInvalidInputResponse {
+            return mrtrInvalidInputResponse(for: invalid, request: request)
         } catch {
             return JSONRPCMessage.errorResponse(
                 id: request.id,

--- a/Sources/SwiftMCP/Protocols/MCPServer+RequestState.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+RequestState.swift
@@ -1,0 +1,135 @@
+#if Server
+//
+//  MCPServer+RequestState.swift
+//  SwiftMCP
+//
+//  The MRTR `requestState` machinery (MCP 2026-07-28, SEP-2322). `requestState`
+//  round-trips through the client, so it is attacker-controlled input: the
+//  payload is integrity-protected and carries the claims the spec asks servers
+//  to verify — a short expiry, the authenticated principal, and a digest of the
+//  originating request — plus the accumulated input responses that make
+//  multi-round-trip re-execution stateless.
+//
+
+import Foundation
+import Crypto
+
+/// Signs and verifies the opaque MRTR `requestState` blob.
+///
+/// The default is ``HMACRequestStateSigner``; override
+/// ``MCPServer/mrtrRequestStateSigner`` to supply a custom key (e.g. a shared
+/// key across server instances) or an AEAD scheme.
+public protocol MRTRRequestStateSigner: Sendable {
+    /// Wraps `payload` into the opaque string handed to the client.
+    func sign(_ payload: Data) -> String
+
+    /// Unwraps a client-echoed state, returning the payload only if its
+    /// integrity verifies. `nil` for tampered or malformed input.
+    func verify(_ state: String) -> Data?
+}
+
+/// The default signer: HMAC-SHA256 with an ephemeral per-process key.
+///
+/// A restart invalidates in-flight states — harmless, because a client whose
+/// retry fails verification simply receives a fresh ``InputRequiredResult`` and
+/// starts the round trip over. Deployments running multiple instances behind a
+/// balancer should supply a signer with a shared key instead.
+public struct HMACRequestStateSigner: MRTRRequestStateSigner {
+    private let key: SymmetricKey
+
+    /// The process-wide default instance (ephemeral random key).
+    public static let shared = HMACRequestStateSigner()
+
+    public init(key: SymmetricKey = SymmetricKey(size: .bits256)) {
+        self.key = key
+    }
+
+    public func sign(_ payload: Data) -> String {
+        let mac = HMAC<SHA256>.authenticationCode(for: payload, using: key)
+        return payload.base64URLEncodedString() + "." + Data(mac).base64URLEncodedString()
+    }
+
+    public func verify(_ state: String) -> Data? {
+        let parts = state.split(separator: ".", maxSplits: 1)
+        guard parts.count == 2,
+              let payload = try? Data(base64URLEncoded: String(parts[0])),
+              let mac = try? Data(base64URLEncoded: String(parts[1])) else {
+            return nil
+        }
+        guard HMAC<SHA256>.isValidAuthenticationCode(mac, authenticating: payload, using: key) else {
+            return nil
+        }
+        return payload
+    }
+}
+
+/// The claims inside a `requestState` payload. `responses` is the accumulator
+/// that makes multi-round-trip re-execution stateless: each round's state
+/// carries every input response gathered so far, so the retried handler finds
+/// answers for all earlier `elicit`/`sample` calls and only signals for new ones.
+struct MRTRRequestStatePayload: Codable {
+    /// Issued-at, seconds since 1970.
+    var iat: Double
+    /// Expiry, seconds since 1970 (issued-at + TTL).
+    var exp: Double
+    /// SHA-256 (base64url) of the bearer token, or `"anonymous"`.
+    var principal: String
+    /// SHA-256 (base64url) of the originating request's method + salient params.
+    var requestDigest: String
+    /// Accumulated input responses, keyed by ordinal id (`input-N`).
+    var responses: [String: JSONValue]
+}
+
+public extension MCPServer {
+    /// The signer protecting MRTR `requestState` blobs. Defaults to an
+    /// HMAC-SHA256 signer with an ephemeral per-process key; override to bind a
+    /// persistent or shared key, or an AEAD scheme.
+    var mrtrRequestStateSigner: MRTRRequestStateSigner { HMACRequestStateSigner.shared }
+}
+
+// MARK: - Claims helpers
+
+enum MRTRRequestState {
+    /// How long a `requestState` stays valid. Bounds the replay window; the
+    /// spec's SHOULD is "a short expiry".
+    static let timeToLive: TimeInterval = 5 * 60
+
+    /// The principal claim for the current request: a digest of the bearer
+    /// token when one is present, else `"anonymous"`. Binding the principal
+    /// rejects state replayed by a different caller.
+    static func principal(accessToken: String?) -> String {
+        guard let accessToken else {
+            return "anonymous"
+        }
+        return Data(SHA256.hash(data: Data(accessToken.utf8))).base64URLEncodedString()
+    }
+
+    /// A digest identifying the originating request: the method plus the
+    /// sorted-keys JSON of its salient params — with the MRTR bookkeeping fields
+    /// (`inputResponses`, `requestState`) and `_meta` removed, so the digest is
+    /// stable across retries of the same logical request.
+    static func requestDigest(method: String, params: JSONValue?) -> String {
+        var salient = params?.dictionaryValue ?? [:]
+        salient.removeValue(forKey: "inputResponses")
+        salient.removeValue(forKey: "requestState")
+        salient.removeValue(forKey: "_meta")
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let paramsData = (try? encoder.encode(JSONValue.object(salient))) ?? Data()
+        let digestInput = Data(method.utf8) + Data([0x0A]) + paramsData
+        return Data(SHA256.hash(data: digestInput)).base64URLEncodedString()
+    }
+}
+
+extension Data {
+    /// base64url without padding — the JWT-style counterpart of
+    /// `init(base64URLEncoded:)`.
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+#endif

--- a/Sources/SwiftMCP/Protocols/MCPServer+Resources.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Resources.swift
@@ -67,6 +67,12 @@ public extension MCPServer {
             )
         }
 
+        // MRTR (modern): verify an echoed requestState and stage the retry's
+        // input responses before execution.
+        if let rejection = await mrtrPrepareExecution(request) {
+            return rejection
+        }
+
         do {
             // Try to get the resource content
             let resourceContentArray = try await resourceProvider.getResource(uri: uri)
@@ -78,27 +84,19 @@ public extension MCPServer {
                 // The not-found code is version-sensitive: modern revisions align
                 // with JSON-RPC and use -32602 (Invalid Params); legacy keeps
                 // SwiftMCP's historical -32001.
-                let profile = await RequestContext.current?.protocolProfile ?? .v20251125
-                return JSONRPCMessage.errorResponse(
-                    id: id,
-                    error: .init(
-                        code: profile.resourceNotFoundCode,
-                        message: "Resource not found: \(uri.absoluteString)"
-                    )
-                )
+                return await Self.resourceNotFoundResponse(id: id, uri: uri.absoluteString)
             }
+        } catch let signal as InputRequiredSignal {
+            // MRTR (modern): the resource needs client input — answer
+            // input_required and let the client retry with the responses.
+            return await mrtrInputRequiredResponse(for: signal, request: request)
+        } catch let invalid as MRTRInvalidInputResponse {
+            return mrtrInvalidInputResponse(for: invalid, request: request)
         } catch MCPResourceError.notFound(let missingURI) {
             // A provider that *throws* not-found means the same thing as one that
             // returns no content — both use the version-sensitive not-found code
             // instead of a generic -32000.
-            let profile = await RequestContext.current?.protocolProfile ?? .v20251125
-            return JSONRPCMessage.errorResponse(
-                id: id,
-                error: .init(
-                    code: profile.resourceNotFoundCode,
-                    message: "Resource not found: \(missingURI)"
-                )
-            )
+            return await Self.resourceNotFoundResponse(id: id, uri: missingURI)
         } catch {
             return JSONRPCMessage.errorResponse(
                 id: id,
@@ -108,6 +106,20 @@ public extension MCPServer {
                 )
             )
         }
+    }
+
+    /// The version-sensitive resource-not-found error: modern aligns with
+    /// JSON-RPC (`-32602` Invalid Params); legacy keeps SwiftMCP's historical
+    /// `-32001`.
+    internal static func resourceNotFoundResponse(id: JSONRPCID, uri: String) async -> JSONRPCMessage {
+        let profile = await RequestContext.current?.protocolProfile ?? .v20251125
+        return JSONRPCMessage.errorResponse(
+            id: id,
+            error: .init(
+                code: profile.resourceNotFoundCode,
+                message: "Resource not found: \(uri)"
+            )
+        )
     }
 
     /**

--- a/Sources/SwiftMCP/Protocols/MCPServer+Tools.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Tools.swift
@@ -98,6 +98,12 @@ public extension MCPServer {
             )
         }
 
+        // MRTR (modern): verify an echoed requestState and stage the retry's
+        // input responses before execution.
+        if let rejection = await mrtrPrepareExecution(request) {
+            return rejection
+        }
+
         // Extract arguments from the request
         let arguments = params["arguments"]?.dictionaryValue ?? [:]
 
@@ -121,6 +127,12 @@ public extension MCPServer {
                 includeStructuredContent: includeStructuredContent,
                 includeResourceLinks: includeResourceLinks
             )
+        } catch let signal as InputRequiredSignal {
+            // MRTR (modern): the tool needs client input — answer input_required
+            // instead of an error, and let the client retry with the responses.
+            return await mrtrInputRequiredResponse(for: signal, request: request)
+        } catch let invalid as MRTRInvalidInputResponse {
+            return mrtrInvalidInputResponse(for: invalid, request: request)
         } catch {
             return JSONRPCMessage.response(
                 id: request.id,

--- a/Sources/SwiftMCP/Transport/RequestContext.swift
+++ b/Sources/SwiftMCP/Transport/RequestContext.swift
@@ -60,6 +60,16 @@ public final class RequestContext: Sendable {
     /// Optional metadata for the message.
     public let meta: Meta?
 
+    /// The raw `params.inputResponses` from an MRTR retry (modern, 2026-07-28).
+    public let inputResponses: JSONDictionary?
+    /// The opaque `params.requestState` echoed by an MRTR retry.
+    public let requestState: String?
+
+    /// Per-execution MRTR bookkeeping: the merged input responses the era-aware
+    /// `sample`/`elicit`/`listRoots` consult, and the ordinal counter that gives
+    /// each call site a deterministic id across re-executions.
+    let mrtr = MRTRExecutionState()
+
     /// Creates a new request context for the given message.
     public init(message: JSONRPCMessage) {
         switch message {
@@ -72,6 +82,8 @@ public final class RequestContext: Sendable {
             } else {
                 meta = nil
             }
+            inputResponses = data.params?["inputResponses"]?.dictionaryValue
+            requestState = data.params?["requestState"]?.stringValue
         case .notification(let data):
             id = nil
             method = data.method
@@ -81,19 +93,54 @@ public final class RequestContext: Sendable {
             } else {
                 meta = nil
             }
+            inputResponses = nil
+            requestState = nil
         case .response(let data):
             id = data.id
             method = nil
             meta = nil
+            inputResponses = nil
+            requestState = nil
         case .errorResponse(let data):
             id = data.id
             method = nil
             meta = nil
+            inputResponses = nil
+            requestState = nil
         }
     }
 
     @TaskLocal
     internal static var taskContext: RequestContext?
+
+    /// Mutable MRTR execution state, isolated in an actor so the Sendable
+    /// context can carry it. The ordinal counter makes each `sample`/`elicit`/
+    /// `listRoots` call site yield the same id (`input-N`) on every re-execution
+    /// of the handler, so a retry's responses land at the right call sites.
+    actor MRTRExecutionState {
+        private var ordinal = 0
+        private var responses: [String: JSONValue] = [:]
+
+        /// Installs the merged response map (signed-state accumulator ∪ the
+        /// retry's `inputResponses`) before the handler runs.
+        func setResponses(_ merged: [String: JSONValue]) {
+            responses = merged
+        }
+
+        /// The next deterministic input id.
+        func nextOrdinalID() -> String {
+            defer { ordinal += 1 }
+            return "input-\(ordinal)"
+        }
+
+        func response(for id: String) -> JSONValue? {
+            responses[id]
+        }
+
+        func allResponses() -> [String: JSONValue] {
+            responses
+        }
+    }
 
     /// Accessor for the current context stored in task local storage.
     public static var current: RequestContext! { taskContext }
@@ -103,6 +150,37 @@ public final class RequestContext: Sendable {
         try await Self.$taskContext.withValue(self) {
             try await operation(self)
         }
+    }
+
+    /// MRTR resolution for a modern server→client input request: the call site
+    /// takes its deterministic ordinal id; when the retry (or the signed-state
+    /// accumulator) already carries the answer it is returned immediately,
+    /// otherwise ``InputRequiredSignal`` aborts the handler so the dispatcher
+    /// can reply `input_required`. On the client's retry the handler re-runs and
+    /// the same call site finds its answer under the same id.
+    ///
+    /// - Important: MRTR re-executes the handler from scratch on every retry, so
+    ///   a handler's *sequence* of `sample`/`elicit`/`listRoots` calls must be
+    ///   deterministic with respect to its inputs (no branching on time or
+    ///   randomness before an input call). A skewed sequence makes a stored
+    ///   answer decode into the wrong shape, which rejects the retry with
+    ///   `-32602` rather than silently misdelivering data.
+    func resolveModernInput<Response: Decodable & Sendable>(
+        method: String,
+        params: JSONValue?,
+        as type: Response.Type
+    ) async throws -> Response {
+        let ordinalID = await mrtr.nextOrdinalID()
+        if let answer = await mrtr.response(for: ordinalID) {
+            do {
+                return try answer.decoded(type)
+            } catch {
+                // A present-but-undecodable response is a malformed client
+                // input (spec: protocol error), not a tool failure.
+                throw MRTRInvalidInputResponse(id: ordinalID, underlying: error)
+            }
+        }
+        throw InputRequiredSignal(id: ordinalID, request: InputRequest(method: method, params: params))
     }
 
     /// Send a progress notification if a progress token was provided.
@@ -124,11 +202,25 @@ public final class RequestContext: Sendable {
     /// - Returns: The generated sampling response
     /// - Throws: An error if the sampling request fails
     public func sample(_ request: SamplingCreateMessageRequest) async throws -> SamplingCreateMessageResponse {
+        // Modern (2026-07-28): live server→client requests are illegal — resolve
+        // from the MRTR retry's input responses, or signal `input_required`.
+        // Capabilities come from the request's `_meta` (there is no session).
+        if await protocolProfile.has(.mrtr) {
+            guard await effectiveClientCapabilities?.sampling != nil else {
+                throw MCPServerError.clientHasNoSamplingSupport
+            }
+            let params = try JSONDictionary(encoding: request)
+            return try await resolveModernInput(
+                method: "sampling/createMessage", params: .object(params),
+                as: SamplingCreateMessageResponse.self
+            )
+        }
+
         guard let session = Session.current else {
             throw MCPServerError.noActiveSession
         }
 
-        // Check if client supports sampling  
+        // Check if client supports sampling
         guard await session.clientCapabilities?.sampling != nil else {
             throw MCPServerError.clientHasNoSamplingSupport
         }
@@ -200,6 +292,19 @@ public final class RequestContext: Sendable {
     /// - Returns: The elicitation response with user action and optional content
     /// - Throws: An error if the elicitation request fails
     public func elicit(_ request: ElicitationCreateRequest) async throws -> ElicitationCreateResponse {
+        // Modern (2026-07-28): resolve from the MRTR retry's input responses, or
+        // signal `input_required`. Capability comes from the request's `_meta`.
+        if await protocolProfile.has(.mrtr) {
+            guard await effectiveClientCapabilities?.elicitation != nil else {
+                throw MCPServerError.clientHasNoElicitationSupport
+            }
+            let params = try JSONDictionary(encoding: request)
+            return try await resolveModernInput(
+                method: "elicitation/create", params: .object(params),
+                as: ElicitationCreateResponse.self
+            )
+        }
+
         guard let session = Session.current else {
             throw MCPServerError.noActiveSession
         }

--- a/Sources/SwiftMCP/Transport/Session+Extensions.swift
+++ b/Sources/SwiftMCP/Transport/Session+Extensions.swift
@@ -42,6 +42,20 @@ extension Session {
     /// - Returns: The list of roots available to the client
     /// - Throws: An error if the request fails
     public func listRoots() async throws -> [Root] {
+        // Modern (2026-07-28): live server→client requests are illegal — resolve
+        // from the MRTR retry's input responses, or signal `input_required`.
+        if let context = RequestContext.current, await context.protocolProfile.has(.mrtr) {
+            guard await context.effectiveClientCapabilities?.roots != nil else {
+                // Same lenient posture as legacy: no roots capability → empty.
+                return []
+            }
+            let result = try await context.resolveModernInput(
+                method: "roots/list", params: .object([:]),
+                as: RootsListResult.self
+            )
+            return result.roots
+        }
+
         // Check if client supports roots
         guard clientCapabilities?.roots != nil else {
             // Return empty array when client doesn't support roots

--- a/Tests/SwiftMCPTests/Connection/MRTRSecurityTests.swift
+++ b/Tests/SwiftMCPTests/Connection/MRTRSecurityTests.swift
@@ -7,6 +7,73 @@ import HTTPTypes
 @Suite("MRTR requestState security")
 struct MRTRSecurityTests {
 
+    @Test("A retry cannot overwrite an answer already fixed in the signed state")
+    func accumulatorIsAuthoritative() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        let round1 = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askTwo"),
+                                        body: mrtrCallBody(tool: "askTwo"))
+        let state1 = try #require(round1["requestState"]?.stringValue)
+
+        let round2 = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askTwo"), body: mrtrCallBody(
+            tool: "askTwo",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["a": .string("one")])]),
+                "requestState": .string(state1)
+            ]
+        ))
+        let state2 = try #require(round2["requestState"]?.stringValue)
+
+        // The final retry answers input-1 but ALSO resends input-0 with a
+        // different value — the signed accumulator must win.
+        let final = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askTwo"), body: mrtrCallBody(
+            tool: "askTwo",
+            extraParams: [
+                "inputResponses": .object([
+                    "input-0": mrtrAcceptResponse(["a": .string("evil")]),
+                    "input-1": mrtrAcceptResponse(["b": .string("two")])
+                ]),
+                "requestState": .string(state2)
+            ]
+        ))
+        let content = final["content"]?.arrayValue?.first?.dictionaryValue
+        #expect(content?["text"]?.stringValue == "one+two")
+    }
+
+    @Test("The principal binds to the HTTP bearer token, not just _meta")
+    func httpBearerPrincipalBinding() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        var authedHeaders = mrtrCallHeaders(tool: "askName")
+        authedHeaders[.authorization] = "Bearer tok-A"
+        let first = try await mrtrSend(adapter, headers: authedHeaders, body: mrtrCallBody(tool: "askName"))
+        #expect(first["resultType"]?.stringValue == "input_required")
+        let state = try #require(first["requestState"]?.stringValue)
+
+        // A retry WITHOUT the bearer token is a different principal → rejected.
+        let anonymous = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"), body: mrtrCallBody(
+            tool: "askName",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["name": .string("x")])]),
+                "requestState": .string(state)
+            ]
+        ))
+        #expect(anonymous["__error_code"]?.intValue == -32602)
+
+        // The same bearer token passes.
+        let sameCaller = try await mrtrSend(adapter, headers: authedHeaders, body: mrtrCallBody(
+            tool: "askName",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["name": .string("Oliver")])]),
+                "requestState": .string(state)
+            ]
+        ))
+        let content = sameCaller["content"]?.arrayValue?.first?.dictionaryValue
+        #expect(content?["text"]?.stringValue == "Hello Oliver")
+    }
+
     @Test("Tampered requestState → -32602; state replayed on another tool → -32602")
     func stateVerification() async throws {
         let transport = HTTPSSETransport(server: MRTRTestServer())

--- a/Tests/SwiftMCPTests/Connection/MRTRSecurityTests.swift
+++ b/Tests/SwiftMCPTests/Connection/MRTRSecurityTests.swift
@@ -1,0 +1,246 @@
+#if Server
+import Testing
+import Foundation
+import HTTPTypes
+@testable import SwiftMCP
+
+@Suite("MRTR requestState security")
+struct MRTRSecurityTests {
+
+    @Test("Tampered requestState → -32602; state replayed on another tool → -32602")
+    func stateVerification() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        let first = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"),
+                                   body: mrtrCallBody(tool: "askName"))
+        let state = try #require(first["requestState"]?.stringValue)
+
+        // Corrupt the first character of the payload segment. (Not the last
+        // character: base64url's final char partly encodes ignored padding bits,
+        // so flipping it can decode to identical bytes and still verify.)
+        let tampered = (state.hasPrefix("A") ? "B" : "A") + state.dropFirst()
+        let rejected = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"), body: mrtrCallBody(
+            tool: "askName",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["name": .string("x")])]),
+                "requestState": .string(tampered)
+            ]
+        ))
+        #expect(rejected["__error_code"]?.intValue == -32602)
+
+        // Genuine state, but presented on a different tool (digest mismatch).
+        let crossed = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askTwo"), body: mrtrCallBody(
+            tool: "askTwo",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["a": .string("x")])]),
+                "requestState": .string(state)
+            ]
+        ))
+        #expect(crossed["__error_code"]?.intValue == -32602)
+    }
+
+    @Test("A present-but-undecodable inputResponse → -32602, not a tool error")
+    func malformedInputResponse() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        let first = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"),
+                                   body: mrtrCallBody(tool: "askName"))
+        let state = try #require(first["requestState"]?.stringValue)
+
+        // A bare string cannot decode into an ElicitationCreateResponse.
+        let rejected = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"), body: mrtrCallBody(
+            tool: "askName",
+            extraParams: [
+                "inputResponses": .object(["input-0": .string("not-a-response")]),
+                "requestState": .string(state)
+            ]
+        ))
+        #expect(rejected["__error_code"]?.intValue == -32602)
+        #expect(rejected["__error_message"]?.stringValue?.contains("malformed inputResponse") == true)
+    }
+
+    @Test("A modern _meta request on a legacy session gets modern (MRTR) semantics")
+    func modernMetaTrumpsLegacySession() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+        let plainHeaders: HTTPFields = [
+            .accept: "application/json, text/event-stream", .contentType: "application/json"
+        ]
+
+        // Establish a legacy session first.
+        let initBody = try HTTPTransportTestHelpers.encode(HTTPTransportTestHelpers.initializeRequest())
+        let initExchange = await adapter.send(
+            method: .post, path: "/mcp", headerFields: plainHeaders, body: initBody
+        )
+        let sessionID = try #require(initExchange.headerFields[.mcpSessionID])
+        if case .sse(let stream) = initExchange.body { for await _ in stream {} }
+
+        // Now a request that declares modern in `_meta` — even with the session
+        // header attached, the body identity wins and MRTR semantics apply.
+        var headers = mrtrCallHeaders(tool: "askName")
+        headers[.mcpSessionID] = sessionID
+        let result = try await mrtrSend(adapter, headers: headers, body: mrtrCallBody(tool: "askName"))
+        #expect(result["resultType"]?.stringValue == "input_required")
+    }
+
+    @Test("Expired requestState → -32602")
+    func expiredState() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        // Craft an otherwise-valid payload that expired a minute ago, signed by
+        // the same default signer the server verifies with.
+        let toolParams: JSONValue = .object([
+            "name": .string("askName"), "arguments": .object([:]), "_meta": mrtrModernMeta
+        ])
+        let payload = MRTRRequestStatePayload(
+            iat: Date().timeIntervalSince1970 - 400,
+            exp: Date().timeIntervalSince1970 - 60,
+            principal: MRTRRequestState.principal(accessToken: nil),
+            requestDigest: MRTRRequestState.requestDigest(method: "tools/call", params: toolParams),
+            responses: [:]
+        )
+        let state = HMACRequestStateSigner.shared.sign(try JSONEncoder().encode(payload))
+
+        let rejected = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"), body: mrtrCallBody(
+            tool: "askName",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["name": .string("x")])]),
+                "requestState": .string(state)
+            ]
+        ))
+        #expect(rejected["__error_code"]?.intValue == -32602)
+    }
+
+    @Test("A principal-bound state presented by a different caller → -32602")
+    func principalMismatch() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        // First round authenticated as "tok-A" (via _meta accessToken).
+        let metaA: JSONValue = .object([
+            "io.modelcontextprotocol/protocolVersion": .string("2026-07-28"),
+            "io.modelcontextprotocol/clientCapabilities": .object(["elicitation": .object([:])]),
+            "accessToken": .string("tok-A")
+        ])
+        let first = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"),
+                                   body: mrtrCallBody(tool: "askName", meta: metaA))
+        let state = try #require(first["requestState"]?.stringValue)
+
+        // Retry presents the same state without the principal → rejected.
+        let rejected = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"), body: mrtrCallBody(
+            tool: "askName",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["name": .string("x")])]),
+                "requestState": .string(state)
+            ]
+        ))
+        #expect(rejected["__error_code"]?.intValue == -32602)
+    }
+
+    @Test("prompts/get participates in MRTR round trips")
+    func promptRoundTrip() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+        let headers: HTTPFields = [
+            .accept: "application/json, text/event-stream", .contentType: "application/json",
+            .mcpProtocolVersion: "2026-07-28", .mcpMethod: "prompts/get", .mcpName: "greetPrompt"
+        ]
+
+        func promptBody(extra: JSONDictionary = [:]) throws -> Data {
+            var params: JSONDictionary = [
+                "name": .string("greetPrompt"), "arguments": .object([:]), "_meta": mrtrModernMeta
+            ]
+            for (key, value) in extra { params[key] = value }
+            return try HTTPTransportTestHelpers.encode(
+                JSONRPCMessage.request(id: 1, method: "prompts/get", params: .object(params))
+            )
+        }
+
+        let first = try await mrtrSend(adapter, headers: headers, body: promptBody())
+        #expect(first["resultType"]?.stringValue == "input_required")
+        let state = try #require(first["requestState"]?.stringValue)
+
+        let retry = try await mrtrSend(adapter, headers: headers, body: promptBody(extra: [
+            "inputResponses": .object(["input-0": mrtrAcceptResponse(["name": .string("Oliver")])]),
+            "requestState": .string(state)
+        ]))
+        let text = retry["messages"]?.arrayValue?.first?.dictionaryValue?["content"]?
+            .dictionaryValue?["text"]?.stringValue
+        #expect(text == "Greet Oliver")
+    }
+
+    @Test("Numeric arguments keep the request digest stable across rounds")
+    func numericDigestStability() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        func body(extra: JSONDictionary = [:]) throws -> Data {
+            var params: JSONDictionary = [
+                "name": .string("labelValue"),
+                "arguments": .object(["value": .double(3.14)]),
+                "_meta": mrtrModernMeta
+            ]
+            for (key, value) in extra { params[key] = value }
+            return try HTTPTransportTestHelpers.encode(
+                JSONRPCMessage.request(id: 1, method: "tools/call", params: .object(params))
+            )
+        }
+
+        let first = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "labelValue"), body: body())
+        #expect(first["resultType"]?.stringValue == "input_required")
+        let state = try #require(first["requestState"]?.stringValue)
+
+        // The retry re-encodes the same numeric argument; the digest must match.
+        let retry = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "labelValue"), body: body(extra: [
+            "inputResponses": .object(["input-0": mrtrAcceptResponse(["label": .string("pi")])]),
+            "requestState": .string(state)
+        ]))
+        let content = retry["content"]?.arrayValue?.first?.dictionaryValue
+        #expect(content?["text"]?.stringValue == "pi:3.14")
+    }
+
+    // MARK: - Capability gating & legacy
+
+    @Test("Without the elicitation capability the tool errors — never input_required")
+    func capabilityGated() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        let bareMeta: JSONValue = .object([
+            "io.modelcontextprotocol/protocolVersion": .string("2026-07-28")
+        ])
+        let result = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"),
+                                    body: mrtrCallBody(tool: "askName", meta: bareMeta))
+        #expect(result["resultType"]?.stringValue != "input_required")
+        #expect(result["isError"]?.boolValue == true)
+    }
+
+    @Test("Legacy sessions keep the live elicitation path (no input_required)")
+    func legacyUnaffected() async throws {
+        // The legacy live path needs a connected client to answer; here it must
+        // simply NOT produce input_required — it fails with the legacy error
+        // because no client answers on a bare in-memory exchange.
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+        let headers: HTTPFields = [
+            .accept: "application/json, text/event-stream", .contentType: "application/json"
+        ]
+        let initBody = try HTTPTransportTestHelpers.encode(HTTPTransportTestHelpers.initializeRequest())
+        let initExchange = await adapter.send(method: .post, path: "/mcp", headerFields: headers, body: initBody)
+        let sessionID = try #require(initExchange.headerFields[.mcpSessionID])
+        if case .sse(let stream) = initExchange.body { for await _ in stream {} }
+
+        var callHeaders = headers
+        callHeaders[.mcpSessionID] = sessionID
+        let body = try HTTPTransportTestHelpers.encode(JSONRPCMessage.request(
+            id: 2, method: "tools/call",
+            params: .object(["name": .string("askName"), "arguments": .object([:])])
+        ))
+        let result = try await mrtrSend(adapter, headers: callHeaders, body: body)
+        #expect(result["resultType"]?.stringValue != "input_required")
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/Connection/MRTRTestSupport.swift
+++ b/Tests/SwiftMCPTests/Connection/MRTRTestSupport.swift
@@ -1,0 +1,129 @@
+#if Server
+import Testing
+import Foundation
+import HTTPTypes
+@testable import SwiftMCP
+
+/// A server whose tools/prompts need client input — the MRTR fixtures.
+@MCPServer(name: "MRTRServer", version: "1.0")
+actor MRTRTestServer {
+    /// Greets the user after asking for their name.
+    /// - Returns: The greeting.
+    @MCPTool(description: "Greets after eliciting a name")
+    func askName() async throws -> String {
+        let response = try await RequestContext.current.elicit(
+            message: "Your name?",
+            schema: .object(JSONSchema.Object(properties: ["name": .string()], required: ["name"]))
+        )
+        let name = response.content?["name"]?.stringValue ?? "nobody"
+        return "Hello \(name)"
+    }
+
+    /// A prompt that needs the user's name first.
+    /// - Returns: The prompt messages.
+    @MCPPrompt(description: "Personalized greeting prompt")
+    func greetPrompt() async throws -> [PromptMessage] {
+        let response = try await RequestContext.current.elicit(
+            message: "Your name?",
+            schema: .object(JSONSchema.Object(properties: ["name": .string()], required: ["name"]))
+        )
+        let name = response.content?["name"]?.stringValue ?? "nobody"
+        return [PromptMessage(role: .user, content: .init(text: "Greet \(name)"))]
+    }
+
+    /// Scales a number after eliciting a label.
+    /// - Parameter value: The number to echo.
+    /// - Returns: Label and value.
+    @MCPTool(description: "Labels a value after eliciting")
+    func labelValue(value: Double) async throws -> String {
+        let response = try await RequestContext.current.elicit(
+            message: "Label?", schema: .object(JSONSchema.Object(properties: ["label": .string()], required: []))
+        )
+        let label = response.content?["label"]?.stringValue ?? "?"
+        return "\(label):\(value)"
+    }
+
+    /// Combines two sequential elicitations.
+    /// - Returns: Both answers.
+    @MCPTool(description: "Elicits twice")
+    func askTwo() async throws -> String {
+        let first = try await RequestContext.current.elicit(
+            message: "First?", schema: .object(JSONSchema.Object(properties: ["a": .string()], required: []))
+        )
+        let second = try await RequestContext.current.elicit(
+            message: "Second?", schema: .object(JSONSchema.Object(properties: ["b": .string()], required: []))
+        )
+        let firstAnswer = first.content?["a"]?.stringValue ?? "?"
+        let secondAnswer = second.content?["b"]?.stringValue ?? "?"
+        return "\(firstAnswer)+\(secondAnswer)"
+    }
+}
+
+// MARK: - Shared fixtures/helpers for both MRTR suites
+
+let mrtrModernMeta: JSONValue = .object([
+    "io.modelcontextprotocol/protocolVersion": .string("2026-07-28"),
+    "io.modelcontextprotocol/clientCapabilities": .object(["elicitation": .object([:])])
+])
+
+func mrtrCallBody(
+    tool: String,
+    extraParams: JSONDictionary = [:],
+    meta: JSONValue = mrtrModernMeta
+) throws -> Data {
+    var params: JSONDictionary = [
+        "name": .string(tool),
+        "arguments": .object([:]),
+        "_meta": meta
+    ]
+    for (key, value) in extraParams { params[key] = value }
+    return try HTTPTransportTestHelpers.encode(
+        JSONRPCMessage.request(id: 1, method: "tools/call", params: .object(params))
+    )
+}
+
+func mrtrCallHeaders(tool: String) -> HTTPFields {
+    [
+        .accept: "application/json, text/event-stream", .contentType: "application/json",
+        .mcpProtocolVersion: "2026-07-28", .mcpMethod: "tools/call", .mcpName: tool
+    ]
+}
+
+/// Sends a modern POST and returns the decoded JSON-RPC result dictionary.
+func mrtrSend(
+    _ adapter: InMemoryHTTPServerAdapter,
+    headers: HTTPFields,
+    body: Data
+) async throws -> JSONDictionary {
+    let exchange = await adapter.send(method: .post, path: "/mcp", headerFields: headers, body: body)
+    var payload = Data()
+    switch exchange.body {
+    case .sse(let stream):
+        for await chunk in stream { payload.append(chunk) }
+    case .buffered(let data):
+        payload = data ?? Data()
+    }
+    let text = String(bytes: payload, encoding: .utf8) ?? ""
+    // Extract the first SSE `data:` line (or take the buffered body verbatim).
+    let json: String
+    if let dataLine = text.split(separator: "\n").first(where: { $0.hasPrefix("data: ") }) {
+        json = String(dataLine.dropFirst("data: ".count))
+    } else {
+        json = text
+    }
+    let message = try HTTPTransportTestHelpers.decode(Data(json.utf8))
+    switch message {
+    case .response(let data):
+        return data.result?.dictionaryValue ?? [:]
+    case .errorResponse(let data):
+        return ["__error_code": .integer(data.error.code), "__error_message": .string(data.error.message)]
+    default:
+        Issue.record("unexpected message shape: \(message)")
+        return [:]
+    }
+}
+
+func mrtrAcceptResponse(_ fields: JSONDictionary) -> JSONValue {
+    .object(["action": .string("accept"), "content": .object(fields)])
+}
+#endif

--- a/Tests/SwiftMCPTests/Connection/MRTRTests.swift
+++ b/Tests/SwiftMCPTests/Connection/MRTRTests.swift
@@ -1,0 +1,87 @@
+#if Server
+import Testing
+import Foundation
+import HTTPTypes
+@testable import SwiftMCP
+
+@Suite("MRTR (input_required round trips)")
+struct MRTRTests {
+
+    // MARK: - Model
+
+    @Test("InputRequiredResult round-trips in the spec shape")
+    func modelRoundTrip() throws {
+        let result = InputRequiredResult(
+            inputRequests: ["input-0": InputRequest(method: "elicitation/create", params: .object([:]))],
+            requestState: "opaque"
+        )
+        let decoded = try JSONDecoder().decode(
+            InputRequiredResult.self, from: try JSONEncoder().encode(result)
+        )
+        #expect(decoded.resultType == "input_required")
+        #expect(decoded.inputRequests?["input-0"]?.method == "elicitation/create")
+        #expect(decoded.requestState == "opaque")
+    }
+
+    // MARK: - Round trips
+
+    @Test("Single elicit: input_required, then retry completes with the answer")
+    func singleRoundTrip() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        let first = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"),
+                                   body: mrtrCallBody(tool: "askName"))
+        #expect(first["resultType"]?.stringValue == "input_required")
+        let requests = try #require(first["inputRequests"]?.dictionaryValue)
+        let input0 = try #require(requests["input-0"]?.dictionaryValue)
+        #expect(input0["method"]?.stringValue == "elicitation/create")
+        let state = try #require(first["requestState"]?.stringValue)
+
+        let retry = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askName"), body: mrtrCallBody(
+            tool: "askName",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["name": .string("Oliver")])]),
+                "requestState": .string(state)
+            ]
+        ))
+        let content = retry["content"]?.arrayValue?.first?.dictionaryValue
+        #expect(content?["text"]?.stringValue == "Hello Oliver")
+    }
+
+    @Test("Two elicits: the accumulator carries round-1 answers through round 2")
+    func multiRoundTrip() async throws {
+        let transport = HTTPSSETransport(server: MRTRTestServer())
+        let adapter = InMemoryHTTPServerAdapter(engine: transport)
+
+        let round1 = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askTwo"),
+                                    body: mrtrCallBody(tool: "askTwo"))
+        #expect(round1["resultType"]?.stringValue == "input_required")
+        #expect(round1["inputRequests"]?.dictionaryValue?["input-0"] != nil)
+        let state1 = try #require(round1["requestState"]?.stringValue)
+
+        let round2 = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askTwo"), body: mrtrCallBody(
+            tool: "askTwo",
+            extraParams: [
+                "inputResponses": .object(["input-0": mrtrAcceptResponse(["a": .string("one")])]),
+                "requestState": .string(state1)
+            ]
+        ))
+        #expect(round2["resultType"]?.stringValue == "input_required")
+        #expect(round2["inputRequests"]?.dictionaryValue?["input-1"] != nil)
+        let state2 = try #require(round2["requestState"]?.stringValue)
+
+        // Round 3 carries only input-1's answer; input-0 rides in the signed state.
+        let final = try await mrtrSend(adapter, headers: mrtrCallHeaders(tool: "askTwo"), body: mrtrCallBody(
+            tool: "askTwo",
+            extraParams: [
+                "inputResponses": .object(["input-1": mrtrAcceptResponse(["b": .string("two")])]),
+                "requestState": .string(state2)
+            ]
+        ))
+        let content = final["content"]?.arrayValue?.first?.dictionaryValue
+        #expect(content?["text"]?.stringValue == "one+two")
+    }
+
+}
+#endif


### PR DESCRIPTION
**Phase 3 of #137 — the hardest change (§D):** the server side of Multi Round-Trip Requests (SEP-2322), the modern era's replacement for live server→client requests. Phases 0–2 are on `main`; legacy behavior stays byte-identical and `2026-07-28` remains out of `supported`.

## What it does

A modern `tools/call` / `resources/read` / `prompts/get` that needs client input now answers `{resultType: "input_required", inputRequests: {<id>: {method, params}}, requestState}` (wire shapes pinned against the draft spec + schema — retry carries **`params.inputResponses`** + **`params.requestState`**, new JSON-RPC id). **The author API is unchanged** — `context.elicit(...)`, `context.sample(...)`, `session.listRoots()` — only the runtime semantics switch on the negotiated profile:

- **Modern**: each call site takes a deterministic ordinal id (`input-0`, `input-1`, …). If the merged responses carry its answer → returned immediately; else an internal `InputRequiredSignal` aborts the handler and the dispatcher replies `input_required`. Capability-gated via the `_meta`-aware `effectiveClientCapabilities` (never emit a request type the client didn't declare). Handlers must keep their input-call sequence deterministic across re-executions (documented; skew fails loudly as `-32602`).
- **Legacy**: the live `Session.request` path, untouched.

## Multi-input via accumulation (the design key)

Each round's `requestState` **signs all responses gathered so far**; the retry merges `state.responses ∪ params.inputResponses` and re-executes — earlier call sites find their answers, only new ones signal. Fully stateless (no server store), and immune to the re-request ping-pong that a stateless multi-input flow otherwise hits.

## `requestState` hardening (spec: attacker-controlled input)

HMAC-SHA256 (`HMACRequestStateSigner`, ephemeral per-process key; `mrtrRequestStateSigner` protocol-extension hook for shared keys/AEAD — multi-instance deployments supply their own). Verified claims: **expiry** (5-min TTL), **principal** (bearer-token digest, else `"anonymous"`), **originating-request digest** (method + sorted-keys JSON of salient params; MRTR fields and `_meta` excluded). Signature/expiry/principal/digest failure → `-32602`. A present-but-undecodable `inputResponses` entry → `-32602` (malformed client input per the spec's error-handling section, not a tool error). NIO-free builds (no swift-crypto) degrade to unsigned single-round `input_required` — spec-legal (`inputRequests` alone).

## Testing (12 new)

Spec-shape model round-trip · single + **multi** round trips (accumulator observed across three rounds) · numeric-argument digest stability · tamper / cross-request digest / expiry / principal rejections · malformed inputResponse → `-32602` · capability gating · `prompts/get` round trip · modern `_meta` trumping a legacy session · legacy regression. **567 tests pass** (6× stress clean), NIO-free matrix builds (411), `swiftlint --strict` clean.

> Adversarially reviewed pre-commit (crypto/replay, control-flow/re-execution, era regression): the decode-error typing and two test gaps were fixed; also self-caught a tamper-test flake (base64url final-char padding bits). **Deliberately deferred as separate work** (pre-existing on `main`, wire-behavior changes deserving their own PRs): `-32603` classification of encoding errors in handlers, and the OpenAPI-route `RequestContext` gap.

## Deferred
Client-side MRTR (lands with client modern mode — `MCPServerProxy` has no server-initiated-request surface today, so nothing breaks); batching multiple `inputRequests` per round trip (spec-allowed enhancement); single-use state enforcement (spec: server-side concern for one-time redemptions; the signer hook enables it).

Part of #137. After this: Phase 4 (`subscriptions/listen`), 5 (utilities), 6 (result conformance), 7 (tasks/auth), then the `supported` flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)