### PR TITLE
Drop ServiceLifecycle product dependency from the demo executables

### DIFF
--- a/Demos/SwiftMCPDemo/Commands/HTTPSSECommand.swift
+++ b/Demos/SwiftMCPDemo/Commands/HTTPSSECommand.swift
@@ -3,7 +3,6 @@ import Foundation
 import ArgumentParser
 import SwiftMCP
 import Logging
-import ServiceLifecycle
 
 /**
  A command that starts an HTTP server with Server-Sent Events (SSE) support for SwiftMCP.
@@ -134,24 +133,18 @@ final class HTTPSSECommand: AsyncParsableCommand {
         try configureAuthentication(on: transport)
         transport.serveOpenAPI = openapi
 
-        // Each transport is a `Service`. The `ServiceGroup` starts them, traps
-        // SIGINT/SIGTERM, and drives an ordered graceful shutdown (with a
-        // timeout) — replacing the bespoke signal handler.
-        var services: [ServiceGroupConfiguration.ServiceConfiguration] = [
-            .init(service: transport, successTerminationBehavior: .gracefullyShutdownGroup)
-        ]
+        // `serve(over:)` owns the run loop, traps SIGINT/SIGTERM, and drives an
+        // ordered graceful shutdown of every transport — no hand-built
+        // `ServiceGroup`.
+        var transports: [any MCPTransport] = [transport]
         if let tcpTransport = makeTCPTransportIfNeeded(server: calculator) {
-            services.append(.init(service: tcpTransport, successTerminationBehavior: .gracefullyShutdownGroup))
+            transports.append(tcpTransport)
         }
 
-        let group = ServiceGroup(
-            configuration: .init(
-                services: services,
-                gracefulShutdownSignals: [.sigterm, .sigint],
-                logger: Logging.Logger(label: "com.cocoanetics.SwiftMCP.ServiceGroup")
-            )
+        try await calculator.serve(
+            over: transports,
+            logger: Logging.Logger(label: "com.cocoanetics.SwiftMCP.Serve")
         )
-        try await group.run()
     }
 
     private func configureAuthentication(on transport: HTTPSSETransport) throws {
@@ -210,7 +203,7 @@ final class HTTPSSECommand: AsyncParsableCommand {
     }
 
     /// Builds the optional TCP+Bonjour transport. It is returned unstarted —
-    /// the `ServiceGroup` starts it by calling `run()`.
+    /// `serve(over:)` starts it by calling `run()`.
     private func makeTCPTransportIfNeeded(server: DemoServer) -> TCPBonjourTransport? {
         guard tcp else { return nil }
         print("MCP Server \(server.serverName) will also expose a TCP+Bonjour transport")

--- a/Demos/SwiftMCPIntentsDemo/Commands/HTTPSSECommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/HTTPSSECommand.swift
@@ -3,7 +3,6 @@ import Foundation
 import ArgumentParser
 import SwiftMCP
 import Logging
-import ServiceLifecycle
 
 /**
  A command that starts an HTTP server with Server-Sent Events (SSE) support for SwiftMCP.
@@ -83,24 +82,18 @@ final class HTTPSSECommand: AsyncParsableCommand {
         try configureAuthentication(on: transport)
         transport.serveOpenAPI = openapi
 
-        // Each transport is a `Service`. The `ServiceGroup` starts them, traps
-        // SIGINT/SIGTERM, and drives an ordered graceful shutdown (with a
-        // timeout) — replacing the bespoke signal handler.
-        var services: [ServiceGroupConfiguration.ServiceConfiguration] = [
-            .init(service: transport, successTerminationBehavior: .gracefullyShutdownGroup)
-        ]
+        // `serve(over:)` owns the run loop, traps SIGINT/SIGTERM, and drives an
+        // ordered graceful shutdown of every transport — no hand-built
+        // `ServiceGroup`.
+        var transports: [any MCPTransport] = [transport]
         if let tcpTransport = makeTCPTransportIfNeeded(server: server) {
-            services.append(.init(service: tcpTransport, successTerminationBehavior: .gracefullyShutdownGroup))
+            transports.append(tcpTransport)
         }
 
-        let group = ServiceGroup(
-            configuration: .init(
-                services: services,
-                gracefulShutdownSignals: [.sigterm, .sigint],
-                logger: Logging.Logger(label: "com.cocoanetics.SwiftMCP.ServiceGroup")
-            )
+        try await server.serve(
+            over: transports,
+            logger: Logging.Logger(label: "com.cocoanetics.SwiftMCP.Serve")
         )
-        try await group.run()
     }
 
     private func configureAuthentication(on transport: HTTPSSETransport) throws {
@@ -159,7 +152,7 @@ final class HTTPSSECommand: AsyncParsableCommand {
     }
 
     /// Builds the optional TCP+Bonjour transport. It is returned unstarted —
-    /// the `ServiceGroup` starts it by calling `run()`.
+    /// `serve(over:)` starts it by calling `run()`.
     private func makeTCPTransportIfNeeded(server: any MCPServer) -> TCPBonjourTransport? {
         guard tcp else { return nil }
         print("MCP Server \(server.serverName) will also expose a TCP+Bonjour transport")

--- a/Demos/SwiftMCPIntentsDemo/Commands/StdioCommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/StdioCommand.swift
@@ -4,7 +4,6 @@ import ArgumentParser
 import SwiftMCP
 import Logging
 import NIOCore
-import ServiceLifecycle
 
 /**
  A command that processes JSON-RPC requests from standard input and writes responses to standard output.
@@ -46,21 +45,13 @@ struct StdioCommand: AsyncParsableCommand {
 
         do {
             logToStderr("MCP Server \(server.serverName) (\(server.serverVersion)) started with Stdio transport")
-            let transport = StdioTransport(server: server)
 
-            // A `ServiceGroup` owns the run loop and traps SIGINT/SIGTERM,
-            // driving a graceful shutdown of the transport. The lifecycle logs
-            // go to stderr so they never corrupt the stdout JSON-RPC stream.
-            let group = ServiceGroup(
-                configuration: .init(
-                    services: [
-                        .init(service: transport, successTerminationBehavior: .gracefullyShutdownGroup)
-                    ],
-                    gracefulShutdownSignals: [.sigterm, .sigint],
-                    logger: Self.lifecycleLogger
-                )
-            )
-            try await group.run()
+            // `serve(over:)` owns the run loop, traps SIGINT/SIGTERM, and drives
+            // an ordered graceful shutdown — no hand-built `ServiceGroup`. The
+            // server-less `StdioTransport()` reads stdin and routes each payload
+            // through the dispatcher `serve` connects; the lifecycle logger writes
+            // to stderr so it never corrupts the stdout JSON-RPC stream.
+            try await server.serve(over: [StdioTransport()], logger: Self.lifecycleLogger)
         } catch let error as TransportError {
             let errorMessage = """
                 Transport Error: \(error.localizedDescription)

--- a/Demos/SwiftMCPIntentsDemo/Commands/TCPBonjourCommand.swift
+++ b/Demos/SwiftMCPIntentsDemo/Commands/TCPBonjourCommand.swift
@@ -3,7 +3,6 @@ import Foundation
 import ArgumentParser
 import SwiftMCP
 import Logging
-import ServiceLifecycle
 
 /**
  A command that exposes the AppIntents demo server over TCP with Bonjour discovery.
@@ -47,27 +46,21 @@ struct TCPBonjourCommand: AsyncParsableCommand {
             logToStderr("MCP Server \(server.serverName) (\(server.serverVersion)) started with TCP+Bonjour transport")
 
             let bindPort = port == 0 ? nil : port
+            // A server-less transport handed to `serve(over:)`: the framework
+            // owns the run loop, SIGINT/SIGTERM trapping, and ordered graceful
+            // shutdown — the consumer no longer hand-wires a `ServiceGroup`.
             let transport = TCPBonjourTransport(
-                server: server,
-                serviceName: name,
+                serviceName: name ?? server.serverName,
                 serviceDomain: domain,
                 port: bindPort,
                 acceptLocalOnly: true,
                 preferIPv4: ipv4Only
             )
 
-            // A `ServiceGroup` owns the run loop and traps SIGINT/SIGTERM to
-            // drive a graceful shutdown of the transport.
-            let group = ServiceGroup(
-                configuration: .init(
-                    services: [
-                        .init(service: transport, successTerminationBehavior: .gracefullyShutdownGroup)
-                    ],
-                    gracefulShutdownSignals: [.sigterm, .sigint],
-                    logger: Logging.Logger(label: "com.cocoanetics.SwiftMCP.ServiceGroup")
-                )
+            try await server.serve(
+                over: [transport],
+                logger: Logging.Logger(label: "com.cocoanetics.SwiftMCP.Serve")
             )
-            try await group.run()
         } catch let error as TransportError {
             let errorMessage = """
                 Transport Error: \(error.localizedDescription)

--- a/Demos/SwiftMCPIntentsDemo/IntentsDemoServerFactory.swift
+++ b/Demos/SwiftMCPIntentsDemo/IntentsDemoServerFactory.swift
@@ -2,7 +2,9 @@ import Foundation
 import SwiftMCP
 
 enum IntentsDemoServerFactory {
-    static func makeServer() -> MCPServer? {
+    // `& Sendable` so the commands can hand the server to
+    // `MCPServer.serve(over:)`, which requires `Self: Sendable`.
+    static func makeServer() -> (any MCPServer & Sendable)? {
 #if canImport(AppIntents)
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return IntentsDemoServer()

--- a/Package.swift
+++ b/Package.swift
@@ -220,12 +220,22 @@ let package = Package(
 				.product(name: "UnixSignals", package: "swift-service-lifecycle", condition: .when(traits: ["Server"]))
 			]
 		),
+		// The demo executables deliberately declare no swift-service-lifecycle
+		// product of their own: they run their transports via
+		// `MCPServer.serve(over:)`, which owns the `ServiceGroup`. Each
+		// swift-service-lifecycle product is therefore declared by exactly one
+		// target (the core). Duplicating the trait-conditional `ServiceLifecycle`
+		// product across the demo targets was also the most frequent trigger of
+		// Xcode 26.2's warm-state validation race ("product 'ServiceLifecycle'
+		// required by … 'SwiftMCPIntentsDemo' not found in package
+		// 'swift-service-lifecycle'") — note the race itself is an Xcode/SwiftPM
+		// defect that can still hit any trait-conditional product dependency
+		// (e.g. NIOCore above), so this only narrows the surface.
 		.executableTarget(
 			name: "SwiftMCPDemo",
 			dependencies: [
 				"SwiftMCP",
-				.product(name: "ArgumentParser", package: "swift-argument-parser"),
-				.product(name: "ServiceLifecycle", package: "swift-service-lifecycle", condition: .when(traits: ["Server"]))
+				.product(name: "ArgumentParser", package: "swift-argument-parser")
 			],
 			path: "Demos/SwiftMCPDemo"
 		),
@@ -233,8 +243,7 @@ let package = Package(
 			name: "SwiftMCPIntentsDemo",
 			dependencies: [
 				"SwiftMCP",
-				.product(name: "ArgumentParser", package: "swift-argument-parser"),
-				.product(name: "ServiceLifecycle", package: "swift-service-lifecycle", condition: .when(traits: ["Server"]))
+				.product(name: "ArgumentParser", package: "swift-argument-parser")
 			],
 			path: "Demos/SwiftMCPIntentsDemo"
 		),


### PR DESCRIPTION
The demos never needed a direct swift-service-lifecycle dependency since `MCPServer.serve(over:)` landed: it owns the `ServiceGroup`. This migrates the remaining hand-wired ServiceGroups to `serve(over:)` and drops the demos' ServiceLifecycle product dependency, so each swift-service-lifecycle product is declared by exactly one target (the SwiftMCP core):

* SwiftMCPDemo `httpsse`: `serve(over:)` with the HTTP+SSE transport plus the optional TCP transport (`stdio` and `tcp` had already migrated)
* SwiftMCPIntentsDemo `stdio`/`httpsse`/`tcp`: same migration; `IntentsDemoServerFactory` now returns `(any MCPServer & Sendable)?` so the commands can call `serve(over:)`

Server-ful transports keep working under `serve(over:)`: each transport prefers the dispatcher `serve` connects (same server, same gates), and the HTTP transport still uses its server reference for OpenAPI introspection.

Verification: `swift build --build-tests` green (full build incl. both demos and the test bundle); a consumer (MissionControlMobile) compiles against the branch.

Scope note: this narrows the most frequent trigger of the Xcode 26.2 warm-state validation race (refs #164) but does not fix it — over warm state the validation can then trip on other trait-conditional products (e.g. NIOCore). Use "Refs", NOT "Fixes" — the issue must stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
