### PR TITLE
Fix per-connection fd leak and transport teardown defects

### DIFF
--- a/Sources/SwiftMCP/Extensions/LineBuffer.swift
+++ b/Sources/SwiftMCP/Extensions/LineBuffer.swift
@@ -32,3 +32,44 @@ actor LineBuffer {
         return String(data: remaining, encoding: .utf8)
     }
 }
+
+/// Synchronous sibling of ``LineBuffer`` for callers that are already serialized.
+///
+/// The TCP server transport assembles lines *inside* `NWConnection` receive
+/// callbacks, which all run on the connection's serial dispatch queue. Hopping
+/// each chunk into the `LineBuffer` actor would discard that ordering: two
+/// chunks race into the actor and can interleave mid-line, and the final
+/// unterminated line on EOF races the chunk that carried it. Assembling
+/// synchronously on the queue keeps the byte stream ordered by construction.
+///
+/// `@unchecked Sendable` is sound only under that confinement: every call must
+/// come from the one serial queue the connection was started on.
+final class LineFramer: @unchecked Sendable {
+    private var buffer = Data()
+
+    func append(_ data: Data) {
+        buffer.append(data)
+    }
+
+    /// Removes and returns every complete newline-terminated line.
+    func extractLines() -> [String] {
+        var lines: [String] = []
+        while let range = buffer.firstRange(of: Data([0x0A])) {
+            let lineData = buffer[..<range.lowerBound]
+            buffer.removeSubrange(..<range.upperBound)
+
+            if let line = String(data: lineData, encoding: .utf8) {
+                lines.append(line)
+            }
+        }
+        return lines
+    }
+
+    /// Removes and returns the final unterminated line, if any.
+    func remainder() -> String? {
+        guard !buffer.isEmpty else { return nil }
+        let remaining = buffer
+        buffer.removeAll()
+        return String(data: remaining, encoding: .utf8)
+    }
+}

--- a/Sources/SwiftMCP/Protocols/MCPServer+Handlers.swift
+++ b/Sources/SwiftMCP/Protocols/MCPServer+Handlers.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Carries the non-Sendable `MCPServer` existential into the cancellable
+/// request task. See the comment in `processCancellableRequest` for why the
+/// sharing is sound.
+private struct UncheckedServerBox: @unchecked Sendable {
+    let server: any MCPServer
+}
+
 // MARK: - JSON-RPC Message Dispatch
 public extension MCPServer {
     /**
@@ -30,7 +37,7 @@ public extension MCPServer {
             // First switch on message type
             switch message {
             case .request(let requestData):
-                return await handleRequest(requestData)
+                return await processCancellableRequest(requestData)
 
             case .notification(let notificationData):
                 return await handleNotification(notificationData)
@@ -42,6 +49,53 @@ public extension MCPServer {
                 return await handleErrorResponse(errorResponseData)
             }
         }
+    }
+
+    /**
+     Runs `handleRequest` as a task registered with the session under the
+     request id, making the request cancellable from outside:
+
+     - `notifications/cancelled` looks the id up on the session and cancels it.
+     - A transport tearing down a disconnected connection cancels the dispatch
+       task, and the handler forwards that cancellation into the request task —
+       so a long-running tool body stops instead of working for a client that
+       is gone.
+
+     The task is unstructured on purpose (a structured child cannot be
+     cancelled from outside), but inherits the `Session`/`RequestContext`
+     task-locals. Without a current session there is nobody to deliver a
+     cancellation, so the request runs directly.
+
+     - Parameter requestData: The request data
+     - Returns: The response, or nil when the request was cancelled (its
+       response must be suppressed per the MCP cancellation spec)
+     */
+    internal func processCancellableRequest(
+        _ requestData: JSONRPCMessage.JSONRPCRequestData
+    ) async -> JSONRPCMessage? {
+        guard let session = Session.current else {
+            return await handleRequest(requestData)
+        }
+
+        // `MCPServer` is not statically Sendable, but every transport already
+        // dispatches into it from concurrent per-connection tasks (through
+        // `@unchecked Sendable` transports) — concurrent use is the de-facto
+        // contract of server implementations. The unstructured task moves the
+        // same call one task deeper; it adds no new kind of sharing. Boxed (and
+        // erased, so the generic `Self.Type` metatype is not captured either)
+        // to carry it past the `sending` closure check.
+        let box = UncheckedServerBox(server: self)
+        let task = Task { await box.server.handleRequest(requestData) }
+        await session.registerInFlightRequest(id: requestData.id) { task.cancel() }
+
+        let response = await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+
+        let wasCancelled = await session.unregisterInFlightRequest(id: requestData.id)
+        return wasCancelled ? nil : response
     }
 
     /**
@@ -184,7 +238,8 @@ public extension MCPServer {
             return nil
 
         case "notifications/cancelled":
-            // Client has cancelled a request
+            // Client has cancelled a request — cancel it if it is still running.
+            await handleCancelledNotification(notificationData)
             return nil
 
         case "notifications/roots/list_changed":
@@ -196,6 +251,30 @@ public extension MCPServer {
             // Unknown notification - log it but don't respond
             return nil
         }
+    }
+
+    /// Cancels the in-flight request identified by a `notifications/cancelled`
+    /// notification on the current session. `requestId` may be a string or an
+    /// integer; unknown ids are a no-op per the MCP cancellation spec.
+    private func handleCancelledNotification(
+        _ notificationData: JSONRPCMessage.JSONRPCNotificationData
+    ) async {
+        guard let session = Session.current,
+              case .object(let params)? = notificationData.params else {
+            return
+        }
+
+        let requestID: JSONRPCID
+        switch params["requestId"] {
+        case .string(let value):
+            requestID = .string(value)
+        case .integer(let value):
+            requestID = .integer(value)
+        default:
+            return
+        }
+
+        await session.cancelInFlightRequest(id: requestID)
     }
 
     /**

--- a/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
+++ b/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
@@ -74,11 +74,18 @@ final class NIOHTTPServerAdapter: @unchecked Sendable {
                 }
             }
             return boundPort
-        } catch let error as IOError {
-            throw bindingError(for: error, host: engine.configuredHost, port: engine.configuredPort)
         } catch {
-            logger.error("Server error: \(error)")
-            throw TransportError.bindingFailed(error.localizedDescription)
+            // The group was created in `init`; a failed bind is the only path
+            // on which nobody will ever call `shutdown()`, and each leaked
+            // group is `System.coreCount` threads plus a kqueue descriptor.
+            try? await shutdown()
+            switch error {
+            case let ioError as IOError:
+                throw bindingError(for: ioError, host: engine.configuredHost, port: engine.configuredPort)
+            default:
+                logger.error("Server error: \(error)")
+                throw TransportError.bindingFailed(error.localizedDescription)
+            }
         }
     }
 

--- a/Sources/SwiftMCP/Transport/ConnectionTaskTracker.swift
+++ b/Sources/SwiftMCP/Transport/ConnectionTaskTracker.swift
@@ -1,0 +1,56 @@
+#if Server
+import Foundation
+
+/// Tracks the dispatch tasks spawned for one TCP connection so that tearing the
+/// connection down also cancels every in-flight line handler.
+///
+/// A tool body that loops on `Task.isCancelled` (or any long-running handler)
+/// would otherwise keep running forever after its client disconnected, holding
+/// whatever resources it opened. `cleanupConnection` is reachable from three
+/// racing paths (receive error, peer EOF, `.failed` state), so everything here
+/// is idempotent: `Task.cancel()` is, and a second `cancelAll()` finds nothing.
+///
+/// A lock-protected class rather than an actor because tasks are spawned from
+/// `NWConnection` receive callbacks — synchronous code on the connection's
+/// dispatch queue that cannot hop onto an actor without unordering the stream.
+final class ConnectionTaskTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tasks: [UUID: Task<Void, Never>] = [:]
+    private var isCancelled = false
+
+    /// Spawn `operation` as a tracked task. After `cancelAll()` the tracker
+    /// refuses new work — the connection is gone, there is nobody to reply to.
+    /// Completed tasks remove themselves, so the tracker does not grow with
+    /// connection lifetime.
+    func spawn(_ operation: @escaping @Sendable () async -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isCancelled else { return }
+        let id = UUID()
+        // Created while holding the lock so the task is registered before
+        // its self-removal can run; `remove(id)` blocks on the lock until
+        // this scope exits.
+        tasks[id] = Task { [weak self] in
+            await operation()
+            self?.remove(id)
+        }
+    }
+
+    func cancelAll() {
+        lock.lock()
+        isCancelled = true
+        let pending = tasks
+        tasks.removeAll()
+        lock.unlock()
+        for task in pending.values {
+            task.cancel()
+        }
+    }
+
+    private func remove(_ id: UUID) {
+        lock.lock()
+        tasks.removeValue(forKey: id)
+        lock.unlock()
+    }
+}
+#endif

--- a/Sources/SwiftMCP/Transport/ConnectionTaskTracker.swift
+++ b/Sources/SwiftMCP/Transport/ConnectionTaskTracker.swift
@@ -47,6 +47,27 @@ final class ConnectionTaskTracker: @unchecked Sendable {
         }
     }
 
+    var isEmpty: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return tasks.isEmpty
+    }
+
+    /// Waits until every tracked task has finished, or the deadline passes.
+    ///
+    /// Used by the clean-EOF teardown path: a half-closing peer keeps its read
+    /// side open for replies to requests already in flight, so those handlers
+    /// get to finish before the socket is cancelled. Polling rather than
+    /// awaiting task values keeps this deadlock-free regardless of which task
+    /// calls it, and the deadline bounds a hung handler (the subsequent
+    /// `cancelAll()` reaps it).
+    func drain(timeout: TimeInterval) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !isEmpty, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+
     private func remove(_ id: UUID) {
         lock.lock()
         tasks.removeValue(forKey: id)

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport+KeepAlive.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport+KeepAlive.swift
@@ -4,6 +4,8 @@ import Foundation
 extension HTTPSSETransport {
     /// Start the keep-alive timer that sends messages every 60 seconds.
     internal func startKeepAliveTimer() {
+        // A resumed DispatchSourceTimer must be cancelled, not just overwritten.
+        stopKeepAliveTimer()
         keepAliveTimer = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
         keepAliveTimer?.schedule(deadline: .now(), repeating: .seconds(60))
         keepAliveTimer?.setEventHandler { [weak self] in

--- a/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
+++ b/Sources/SwiftMCP/Transport/HTTPSSETransport.swift
@@ -159,10 +159,25 @@ public final class HTTPSSETransport: Transport, MCPTransport, Service, MCPHTTPEn
     // MARK: - Server Lifecycle
 
     public func start() async throws {
+        // Keyed off a successful bind: `self.adapter` is only ever a *bound*
+        // adapter. Assigning before binding would strand the previous adapter's
+        // listener (and its event-loop group) unreachable on a repeated start,
+        // while the new bind fails with EADDRINUSE against it.
+        guard self.adapter == nil else { return }
+
+        // Force the lazy router and session manager on this task, before any
+        // connection can race the non-atomic `lazy` check-then-store. Done here
+        // rather than in `init` because both are built from configuration set
+        // between `init` and `start()` (`serveOpenAPI`, custom routes,
+        // `streamRetentionInterval`).
+        _ = router
+        _ = sessionManager
+
         let adapter = NIOHTTPServerAdapter(engine: self, logger: logger)
-        self.adapter = adapter
-        // Binding resolves an ephemeral `0` to the actual port.
+        // Binding resolves an ephemeral `0` to the actual port. On failure the
+        // adapter has shut its own event-loop group down before rethrowing.
         self.port = try await adapter.start()
+        self.adapter = adapter
         startKeepAliveTimer()
     }
 
@@ -186,6 +201,10 @@ public final class HTTPSSETransport: Transport, MCPTransport, Service, MCPHTTPEn
         logger.info("Stopping server...")
         stopKeepAliveTimer()
         await sessionManager.removeAllSessions()
+        // Cleared before the throwing shutdown: if shutdown throws, the adapter
+        // must not linger as if it were still serving.
+        let adapter = self.adapter
+        self.adapter = nil
         try await adapter?.shutdown()
         logger.info("Server stopped")
     }

--- a/Sources/SwiftMCP/Transport/Session.swift
+++ b/Sources/SwiftMCP/Transport/Session.swift
@@ -89,6 +89,11 @@ public actor Session {
     /// unregister so the now-unwanted response can be suppressed.
     private var cancelledRequestIDs: Set<JSONRPCID> = []
 
+    /// Cancellations that raced ahead of their request's registration
+    /// (dispatch tasks are unordered); consumed on registration so the
+    /// request is cancelled the moment it registers.
+    private var pendingCancellations: Set<JSONRPCID> = []
+
     /// Timestamp of the most recent activity associated with this session.
     public var lastActivityAt: Date = Date()
 
@@ -304,9 +309,15 @@ public actor Session {
     // MARK: - In-Flight Request Cancellation
 
     /// Registers a cancellation hook for a request this session is currently
-    /// processing, so a later `notifications/cancelled` can reach it. See
-    /// `MCPServer.processCancellableRequest`.
+    /// processing, so a later `notifications/cancelled` can reach it. A
+    /// cancellation that raced ahead of this registration fires immediately.
+    /// See `MCPServer.processCancellableRequest`.
     internal func registerInFlightRequest(id: JSONRPCID, cancel: @escaping @Sendable () -> Void) {
+        if pendingCancellations.remove(id) != nil {
+            cancelledRequestIDs.insert(id)
+            cancel()
+            return
+        }
         inFlightRequests[id] = cancel
     }
 
@@ -315,16 +326,28 @@ public actor Session {
     /// suppress the response the client stopped listening for.
     internal func unregisterInFlightRequest(id: JSONRPCID) -> Bool {
         inFlightRequests.removeValue(forKey: id)
+        // A cancellation that arrived after completion lost the race the spec
+        // allows; drop it rather than let it linger against a finished id.
+        pendingCancellations.remove(id)
         return cancelledRequestIDs.remove(id) != nil
     }
 
     /// Cancels the in-flight request with the given id. The request's task
-    /// sees ordinary Swift cooperative cancellation. Unknown or completed ids
-    /// are a no-op, as the MCP cancellation spec requires (the notification
-    /// races the response by design).
+    /// sees ordinary Swift cooperative cancellation. An id that has not
+    /// registered yet is retained briefly (dispatch tasks are unordered, so
+    /// the notification can overtake its request); ids are never legitimately
+    /// reused within a session, so retention cannot misfire. A completed id
+    /// is a no-op, as the MCP cancellation spec requires.
     public func cancelInFlightRequest(id: JSONRPCID) {
-        guard let cancel = inFlightRequests.removeValue(forKey: id) else { return }
-        cancelledRequestIDs.insert(id)
-        cancel()
+        if let cancel = inFlightRequests.removeValue(forKey: id) {
+            cancelledRequestIDs.insert(id)
+            cancel()
+            return
+        }
+        // Bounded: only a peer streaming cancellations for requests that never
+        // existed could grow this, and such a peer gets no cancellation
+        // guarantees anyway.
+        guard pendingCancellations.count < 128 else { return }
+        pendingCancellations.insert(id)
     }
 }

--- a/Sources/SwiftMCP/Transport/Session.swift
+++ b/Sources/SwiftMCP/Transport/Session.swift
@@ -81,6 +81,14 @@ public actor Session {
     /// URIs that this session has subscribed to for resource-updated notifications.
     internal var subscribedResourceURIs: Set<String> = []
 
+    /// Cancellation hooks for the requests currently being processed on this
+    /// session, keyed by JSON-RPC id. Fired by `notifications/cancelled`.
+    private var inFlightRequests: [JSONRPCID: @Sendable () -> Void] = [:]
+
+    /// Ids whose in-flight request was explicitly cancelled; consumed on
+    /// unregister so the now-unwanted response can be suppressed.
+    private var cancelledRequestIDs: Set<JSONRPCID> = []
+
     /// Timestamp of the most recent activity associated with this session.
     public var lastActivityAt: Date = Date()
 
@@ -291,5 +299,32 @@ public actor Session {
     /// This prevents continuation leaks when sessions are disconnected.
     internal func cancelAllWaitingTasks() {
         responses.failAll()
+    }
+
+    // MARK: - In-Flight Request Cancellation
+
+    /// Registers a cancellation hook for a request this session is currently
+    /// processing, so a later `notifications/cancelled` can reach it. See
+    /// `MCPServer.processCancellableRequest`.
+    internal func registerInFlightRequest(id: JSONRPCID, cancel: @escaping @Sendable () -> Void) {
+        inFlightRequests[id] = cancel
+    }
+
+    /// Removes the hook once processing finished. Returns `true` when the
+    /// request was explicitly cancelled while in flight, so the caller can
+    /// suppress the response the client stopped listening for.
+    internal func unregisterInFlightRequest(id: JSONRPCID) -> Bool {
+        inFlightRequests.removeValue(forKey: id)
+        return cancelledRequestIDs.remove(id) != nil
+    }
+
+    /// Cancels the in-flight request with the given id. The request's task
+    /// sees ordinary Swift cooperative cancellation. Unknown or completed ids
+    /// are a no-op, as the MCP cancellation spec requires (the notification
+    /// races the response by design).
+    public func cancelInFlightRequest(id: JSONRPCID) {
+        guard let cancel = inFlightRequests.removeValue(forKey: id) else { return }
+        cancelledRequestIDs.insert(id)
+        cancel()
     }
 }

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
@@ -114,19 +114,20 @@ extension TCPBonjourTransport {
                 if let remaining = framer.remainder() {
                     lines.append(remaining)
                 }
+                // The final lines dispatch tracked like every other batch — a
+                // one-shot client delivers request and FIN in the same read,
+                // and an untracked handler here would be unreapable: a hung
+                // tool would block cleanup forever with nothing able to cancel
+                // it. The drain below bounds it exactly like earlier handlers.
+                self.dispatchLines(lines, session: session, tracker: tracker)
                 // A clean EOF is a half-close, not an abort: the peer may keep
-                // its read side open for replies still being computed. Dispatch
-                // the final lines, then let the handlers from earlier callbacks
-                // drain (bounded — a hung one is reaped by cleanup's cancel)
-                // before the socket is torn down. Untracked on purpose: this
-                // task waits on the tracked ones, so tracking it would have it
-                // wait on itself.
-                let pending = lines
+                // its read side open for replies still being computed. Let the
+                // tracked handlers drain (bounded) before the socket is torn
+                // down; cleanup's cancel reaps whatever outlived the timeout.
+                // Untracked on purpose: this task waits on the tracked ones,
+                // so tracking it would have it wait on itself.
                 let drainTimeout = self.eofDrainTimeout
                 Task {
-                    for line in pending {
-                        await self.handleLine(line, session: session)
-                    }
                     await tracker.drain(timeout: drainTimeout)
                     await self.cleanupConnection(id: connectionID)
                 }
@@ -146,13 +147,46 @@ extension TCPBonjourTransport {
 
     /// Dispatches already-extracted lines on a task tracked by the connection,
     /// so teardown can cancel whatever they started.
+    ///
+    /// Cancellation notifications go first: coalesced into the same read as
+    /// the request they name (one client flush, Nagle, a single 64 KB read),
+    /// they would otherwise wait in this sequential loop behind that request's
+    /// completion and cancel nothing. Handled first, the session retains them
+    /// until the request registers and cancels it on the spot.
     private func dispatchLines(_ lines: [String], session: Session, tracker: ConnectionTaskTracker) {
         guard !lines.isEmpty else { return }
         tracker.spawn {
-            for line in lines {
+            let (cancellations, rest) = Self.partitionCancellations(lines)
+            for line in cancellations {
+                await self.handleLine(line, session: session)
+            }
+            for line in rest {
                 await self.handleLine(line, session: session)
             }
         }
+    }
+
+    /// Splits out `notifications/cancelled` lines, preserving relative order
+    /// within each partition. The substring test is only a cheap pre-filter;
+    /// a line moves only when it actually decodes to that lone notification.
+    internal static func partitionCancellations(
+        _ lines: [String]
+    ) -> (cancellations: [String], rest: [String]) {
+        var cancellations: [String] = []
+        var rest: [String] = []
+        for line in lines {
+            if line.contains("notifications/cancelled"),
+               let data = line.data(using: .utf8),
+               let messages = try? JSONRPCMessage.decodeMessages(from: data),
+               messages.count == 1,
+               case .notification(let notification) = messages[0],
+               notification.method == "notifications/cancelled" {
+                cancellations.append(line)
+            } else {
+                rest.append(line)
+            }
+        }
+        return (cancellations, rest)
     }
 
     /// Escalates descriptor exhaustion to a terminal transport failure.

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
@@ -10,52 +10,77 @@ extension TCPBonjourTransport {
 
     internal func handleNewConnection(_ connection: NWConnection) {
         let connectionID = UUID()
+        let tracker = ConnectionTaskTracker()
+
+        // Installed before the first suspension: a connection that fails while
+        // its session is still being created must already have a cleanup path.
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                self.logger.info("TCP connection ready: \(connectionID)")
+            case .failed(let error):
+                self.logger.error("TCP connection failed (\(connectionID)): \(error)")
+                Task {
+                    await self.cleanupConnection(id: connectionID)
+                    await self.escalateIfDescriptorExhaustion(error)
+                }
+            case .cancelled:
+                Task {
+                    await self.cleanupConnection(id: connectionID)
+                }
+            default:
+                break
+            }
+        }
 
         Task {
             // One session per TCP connection; `SessionManager` attaches this
             // transport so outbound bytes route back over the same socket.
             let session = await sessionManager.session(id: connectionID)
 
-            connection.stateUpdateHandler = { [weak self] state in
-                guard let self else { return }
-                switch state {
-                case .ready:
-                    self.logger.info("TCP connection ready: \(connectionID)")
-                case .failed(let error):
-                    self.logger.error("TCP connection failed (\(connectionID)): \(error)")
-                    Task {
-                        await self.cleanupConnection(id: connectionID)
-                    }
-                case .cancelled:
-                    Task {
-                        await self.cleanupConnection(id: connectionID)
-                    }
-                default:
-                    break
-                }
+            guard await state.addConnection(id: connectionID, connection: connection, tasks: tracker) else {
+                // The transport stopped while this connection was being set up.
+                // Every early return on this path must cancel: the kernel already
+                // allocated the descriptor at accept, and only `cancel()` frees it.
+                connection.cancel()
+                await sessionManager.removeSession(id: connectionID)
+                return
             }
-
-            await state.addConnection(id: connectionID, connection: connection)
             connection.start(queue: queue)
-            startReceiveLoop(connection: connection, session: session, connectionID: connectionID)
+            startReceiveLoop(
+                connection: connection, session: session,
+                connectionID: connectionID, tracker: tracker
+            )
         }
     }
 
     internal func cleanupConnection(id: UUID) async {
+        // `removeConnection` cancels the `NWConnection` (releasing its socket)
+        // and every in-flight dispatch task for this connection.
         await state.removeConnection(id: id)
         await sessionManager.removeSession(id: id)
     }
 
-    internal func startReceiveLoop(connection: NWConnection, session: Session, connectionID: UUID) {
-        let lineBuffer = LineBuffer()
-        receiveNext(connection: connection, session: session, connectionID: connectionID, lineBuffer: lineBuffer)
+    internal func startReceiveLoop(
+        connection: NWConnection,
+        session: Session,
+        connectionID: UUID,
+        tracker: ConnectionTaskTracker
+    ) {
+        let framer = LineFramer()
+        receiveNext(
+            connection: connection, session: session,
+            connectionID: connectionID, framer: framer, tracker: tracker
+        )
     }
 
     internal func receiveNext(
         connection: NWConnection,
         session: Session,
         connectionID: UUID,
-        lineBuffer: LineBuffer
+        framer: LineFramer,
+        tracker: ConnectionTaskTracker
     ) {
         connection.receive(
             minimumIncompleteLength: 1,
@@ -63,18 +88,19 @@ extension TCPBonjourTransport {
         ) { [weak self] data, _, isComplete, error in
             guard let self else { return }
 
+            // Line assembly happens synchronously on the connection's serial
+            // queue: receive callbacks arrive in order here, whereas hopping
+            // each chunk into a task would let two chunks interleave mid-line.
+            // Only the dispatch of complete lines leaves the queue.
+            var lines: [String] = []
             if let data, !data.isEmpty {
-                Task {
-                    await lineBuffer.append(data)
-                    let lines = await lineBuffer.processLines()
-                    for line in lines {
-                        await self.handleLine(line, session: session)
-                    }
-                }
+                framer.append(data)
+                lines = framer.extractLines()
             }
 
             if let error {
                 self.logger.error("TCP receive error (\(connectionID)): \(error)")
+                self.dispatchLines(lines, session: session, tracker: tracker)
                 Task {
                     await self.cleanupConnection(id: connectionID)
                 }
@@ -82,22 +108,69 @@ extension TCPBonjourTransport {
             }
 
             if isComplete {
-                Task {
-                    if let remaining = await lineBuffer.getRemaining() {
-                        await self.handleLine(remaining, session: session)
+                // All appends happened on this queue, so the final unterminated
+                // line is complete here — flushing from a racing task could run
+                // before the data callback and silently drop it.
+                if let remaining = framer.remainder() {
+                    lines.append(remaining)
+                }
+                // Dispatch before cleanup, in the same task: the reply to a
+                // request that arrived immediately before EOF must be written
+                // before the connection is torn down.
+                let pending = lines
+                tracker.spawn {
+                    for line in pending {
+                        await self.handleLine(line, session: session)
                     }
                     await self.cleanupConnection(id: connectionID)
                 }
                 return
             }
 
+            self.dispatchLines(lines, session: session, tracker: tracker)
             self.receiveNext(
                 connection: connection,
                 session: session,
                 connectionID: connectionID,
-                lineBuffer: lineBuffer
+                framer: framer,
+                tracker: tracker
             )
         }
+    }
+
+    /// Dispatches already-extracted lines on a task tracked by the connection,
+    /// so teardown can cancel whatever they started.
+    private func dispatchLines(_ lines: [String], session: Session, tracker: ConnectionTaskTracker) {
+        guard !lines.isEmpty else { return }
+        tracker.spawn {
+            for line in lines {
+                await self.handleLine(line, session: session)
+            }
+        }
+    }
+
+    /// Escalates descriptor exhaustion to a terminal transport failure.
+    ///
+    /// Out of descriptors, this process cannot accept anything anymore — and the
+    /// listener itself reports nothing in that state (it stays `.ready` and
+    /// silently stops accepting), so the failure must be caught wherever it does
+    /// surface. Failing terminally makes `run()` throw, so a supervised daemon
+    /// exits and gets restarted instead of serving nothing forever.
+    internal func escalateIfDescriptorExhaustion(_ error: NWError) async {
+        guard Self.isDescriptorExhaustion(error) else { return }
+        logger.critical("Out of file descriptors (\(error)); failing the TCP+Bonjour transport terminally.")
+        await state.failTerminally(TransportError.resourceExhausted(
+            "The process is out of file descriptors; the TCP+Bonjour transport cannot accept connections."
+        ))
+    }
+
+    /// `true` for POSIX `EMFILE` (per-process) / `ENFILE` (system-wide)
+    /// descriptor-table exhaustion.
+    internal static func isDescriptorExhaustion(_ error: NWError) -> Bool {
+        if case .posix(let code) = error, code == .EMFILE || code == .ENFILE {
+            return true
+        }
+        return false
     }
 
     /// Decodes one newline-delimited line and routes it. The session is bound as

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Connections.swift
@@ -114,14 +114,20 @@ extension TCPBonjourTransport {
                 if let remaining = framer.remainder() {
                     lines.append(remaining)
                 }
-                // Dispatch before cleanup, in the same task: the reply to a
-                // request that arrived immediately before EOF must be written
-                // before the connection is torn down.
+                // A clean EOF is a half-close, not an abort: the peer may keep
+                // its read side open for replies still being computed. Dispatch
+                // the final lines, then let the handlers from earlier callbacks
+                // drain (bounded — a hung one is reaped by cleanup's cancel)
+                // before the socket is torn down. Untracked on purpose: this
+                // task waits on the tracked ones, so tracking it would have it
+                // wait on itself.
                 let pending = lines
-                tracker.spawn {
+                let drainTimeout = self.eofDrainTimeout
+                Task {
                     for line in pending {
                         await self.handleLine(line, session: session)
                     }
+                    await tracker.drain(timeout: drainTimeout)
                     await self.cleanupConnection(id: connectionID)
                 }
                 return

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Lifecycle.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Lifecycle.swift
@@ -17,6 +17,7 @@ extension TCPBonjourTransport {
         let generation = await state.start(listener: listener)
         installStateHandler(on: listener, generation: generation)
         listener.start(queue: queue)
+        startDescriptorWatchdog()
     }
 
     public func run() async throws {
@@ -24,8 +25,10 @@ extension TCPBonjourTransport {
         // Inside a `ServiceGroup`, a graceful shutdown signal calls `stop()`,
         // which cancels the listener/connections and resumes `waitUntilStopped()`
         // so this method returns. Standalone callers drive shutdown via `stop()`.
-        await withGracefulShutdownHandler {
-            await state.waitUntilStopped()
+        // An unrecoverable failure (dead listener, descriptor exhaustion) is
+        // rethrown here, so embedders learn about it instead of parking forever.
+        try await withGracefulShutdownHandler {
+            try await state.waitUntilStopped()
         } onGracefulShutdown: { [weak self] in
             Task { [weak self] in try? await self?.stop() }
         }

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Listener.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Listener.swift
@@ -35,6 +35,17 @@ extension TCPBonjourTransport {
            let ipOptions = parameters.defaultProtocolStack.internetProtocol as? NWProtocolIP.Options {
             ipOptions.version = .v4
         }
+        // TCP keepalive: session expiry never fires for this transport (it is
+        // driven by SSE hub streams, which TCP never creates), so a peer that
+        // vanishes without FIN/RST would otherwise pin its descriptor and its
+        // session forever. Keepalive turns a dead peer into a receive error,
+        // which reaches `cleanupConnection`.
+        if let tcpOptions = parameters.defaultProtocolStack.transportProtocol as? NWProtocolTCP.Options {
+            tcpOptions.enableKeepalive = true
+            tcpOptions.keepaliveIdle = 60
+            tcpOptions.keepaliveInterval = 15
+            tcpOptions.keepaliveCount = 4
+        }
 
         let listener: NWListener
         if let port {
@@ -103,7 +114,13 @@ extension TCPBonjourTransport {
                 logger.warning("Bonjour listener failed (mDNSResponder unavailable): \(error). Retrying in \(delay)s.")
                 scheduleRetry(afterDelay: delay, failedGeneration: generation)
             } else {
-                logger.error("TCP+Bonjour listener failed: \(error)")
+                // Terminal: without this, `isRunning` stays true and `run()`
+                // parks forever on a transport that serves nothing. `NWListener`
+                // fails *asynchronously* (an async bind conflict arrives here
+                // after `start()` already returned success), so rethrowing from
+                // `run()` is the only way the embedder ever learns.
+                logger.critical("TCP+Bonjour listener failed unrecoverably: \(error)")
+                await state.fail(generation: generation, error)
             }
 
         case .cancelled:

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+State.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+State.swift
@@ -1,0 +1,215 @@
+//
+//  TCPBonjourTransport+State.swift
+//  SwiftMCP
+//
+//  The transport's lifecycle state machine: one actor owning the listener, the
+//  live connections (each with its task tracker), retry/watchdog tasks, and the
+//  run-loop continuation. Every guard in here exists because some teardown path
+//  races another; see #171 for the full audit.
+//
+
+#if Server
+import Foundation
+
+#if canImport(Network)
+import Network
+
+/// A live inbound connection and the dispatch tasks it spawned.
+///
+/// The task tracker travels with the connection so that tearing one down also
+/// cancels every in-flight line handler — a long-running tool must not keep
+/// working for a client that is gone.
+internal struct TCPConnectionEntry {
+    let connection: NWConnection
+    let tasks: ConnectionTaskTracker
+}
+
+extension TCPBonjourTransport {
+    internal actor TransportState {
+        private(set) var isRunning: Bool = false
+        private(set) var generation: UInt64 = 0
+        private var listener: NWListener?
+        private var connections: [UUID: TCPConnectionEntry] = [:]
+        private var runContinuation: CheckedContinuation<Void, Never>?
+        private var retryTask: Task<Void, Never>?
+        private var watchdogTask: Task<Void, Never>?
+        private var localRegistration: LocalOnlyRegistration?
+        private(set) var retryAttempt: Int = 0
+
+        /// The unrecoverable failure that stopped the transport, if any.
+        /// Rethrown by ``waitUntilStopped()`` so `run()` surfaces it instead of
+        /// parking forever on a transport that can no longer accept anything.
+        private(set) var terminalError: Error?
+
+        func running() -> Bool {
+            isRunning
+        }
+
+        /// Start a new listener generation.
+        /// Returns the generation token for this listener.
+        @discardableResult
+        func start(listener: NWListener) -> UInt64 {
+            generation += 1
+            self.listener = listener
+            isRunning = true
+            retryAttempt = 0
+            terminalError = nil  // a restarted transport must not rethrow a stale failure
+            cancelRetryTask()
+            localRegistration?.stop()
+            localRegistration = nil
+            return generation
+        }
+
+        /// Replace the current listener with a new one during retry recovery.
+        /// Returns the new generation token, or nil if the transport is stopped.
+        func replaceListener(_ newListener: NWListener, expectedGeneration: UInt64) -> UInt64? {
+            guard isRunning, generation == expectedGeneration else {
+                return nil
+            }
+            listener?.cancel()
+            localRegistration?.stop()
+            localRegistration = nil
+            generation += 1
+            self.listener = newListener
+            return generation
+        }
+
+        func stop() {
+            isRunning = false
+            generation += 1  // invalidate any in-flight retry / state callbacks
+            cancelRetryTask()
+            watchdogTask?.cancel()
+            watchdogTask = nil
+            retryAttempt = 0
+            listener?.cancel()
+            listener = nil
+            localRegistration?.stop()
+            localRegistration = nil
+            for entry in connections.values {
+                entry.connection.cancel()
+                entry.tasks.cancelAll()
+            }
+            connections.removeAll()
+            if let continuation = runContinuation {
+                runContinuation = nil
+                continuation.resume()
+            }
+        }
+
+        /// Stop the transport because of an unrecoverable failure tied to the
+        /// given listener generation. A no-op for stale generations, so a retry
+        /// that already replaced the listener cannot kill its successor.
+        func fail(generation listenerGen: UInt64, _ error: Error) {
+            guard listenerGen == generation else { return }
+            failTerminally(error)
+        }
+
+        /// Stop the transport because of an unrecoverable failure that is not
+        /// tied to a listener generation (descriptor exhaustion detected on a
+        /// connection or by the watchdog).
+        func failTerminally(_ error: Error) {
+            guard isRunning else { return }
+            terminalError = error
+            stop()
+        }
+
+        func waitUntilStopped() async throws {
+            if isRunning {
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    runContinuation = continuation
+                }
+            }
+            if let terminalError {
+                throw terminalError
+            }
+        }
+
+        /// Called when the listener reaches `.ready`.
+        /// Resets backoff, clears any pending retry, and returns the bound port (if available).
+        func listenerReady(generation listenerGen: UInt64) -> UInt16? {
+            guard listenerGen == generation, isRunning else { return nil }
+            retryAttempt = 0
+            cancelRetryTask()
+            return listener?.port?.rawValue
+        }
+
+        func setLocalRegistration(
+            _ registration: LocalOnlyRegistration,
+            generation listenerGen: UInt64
+        ) -> Bool {
+            guard listenerGen == generation, isRunning else { return false }
+            localRegistration?.stop()
+            localRegistration = registration
+            return true
+        }
+
+        /// Replaces the listener's advertised service, e.g. to publish a TXT record
+        /// that could not be complete when the listener was created.
+        func updateService(_ service: NWListener.Service, generation listenerGen: UInt64) {
+            guard listenerGen == generation, isRunning else { return }
+            listener?.service = service
+        }
+
+        func removeLocalRegistration(generation listenerGen: UInt64) {
+            guard listenerGen == generation else { return }
+            localRegistration?.stop()
+            localRegistration = nil
+        }
+
+        /// Called when the listener fails with a retryable error.
+        /// Increments the backoff attempt and returns the delay in seconds,
+        /// or nil if the transport is stopped or the generation is stale.
+        func listenerFailed(generation listenerGen: UInt64) -> UInt64? {
+            guard listenerGen == generation, isRunning else { return nil }
+            retryAttempt += 1
+            let delay = min(UInt64(1) << UInt64(min(retryAttempt - 1, 5)), TCPBonjourTransport.maxRetryDelay)
+            return delay
+        }
+
+        /// Store a retry task. Cancels any existing one first.
+        func setRetryTask(_ task: Task<Void, Never>) {
+            cancelRetryTask()
+            retryTask = task
+        }
+
+        private func cancelRetryTask() {
+            retryTask?.cancel()
+            retryTask = nil
+        }
+
+        /// Store the descriptor watchdog task. Cancelled by `stop()`.
+        func setWatchdogTask(_ task: Task<Void, Never>) {
+            watchdogTask?.cancel()
+            watchdogTask = task
+        }
+
+        /// Register an accepted connection, or refuse it when the transport has
+        /// already stopped — `handleNewConnection` suspends before registering,
+        /// so a connection accepted around `stop()` would otherwise be added
+        /// after `stop()`'s sweep and live on a shut-down transport.
+        func addConnection(id: UUID, connection: NWConnection, tasks: ConnectionTaskTracker) -> Bool {
+            guard isRunning else { return false }
+            connections[id] = TCPConnectionEntry(connection: connection, tasks: tasks)
+            return true
+        }
+
+        /// Remove and tear down one connection.
+        ///
+        /// Network.framework only releases the underlying socket on `cancel()`;
+        /// dropping the last reference leaks both the descriptor and the
+        /// self-retained `NWConnection`. Cancelling inside the actor keeps two
+        /// racing teardown paths (receive error vs `.failed`) from both acting:
+        /// the second entry removes nothing and is a no-op.
+        func removeConnection(id: UUID) {
+            guard let entry = connections.removeValue(forKey: id) else { return }
+            entry.connection.cancel()
+            entry.tasks.cancelAll()
+        }
+
+        func connection(for id: UUID) -> NWConnection? {
+            connections[id]?.connection
+        }
+    }
+}
+#endif
+#endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Watchdog.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Watchdog.swift
@@ -52,26 +52,34 @@ extension TCPBonjourTransport {
         }
     }
 
+    /// How many descriptor-table slots one sample scans at most.
+    internal static let watchdogScanCeiling = 65536
+
     /// Counts live descriptors against the process limit.
     ///
     /// Counting is `fcntl(fd, F_GETFD)` over the table — deliberately not
     /// `F_GETPATH` (returns `EBADF` for sockets, i.e. blind to exactly the leak
     /// this guards against) and not `proc_pidinfo` (reports table capacity, not
-    /// usage). The scan is clamped: an effectively unlimited `rlim_cur` cannot
-    /// be exhausted by sockets in practice, and scanning billions of slots
-    /// every sample is not an option.
+    /// usage). The *scan* is clamped (scanning billions of slots every sample
+    /// is not an option), but `limit` is the real `rlim_cur`: comparing the
+    /// threshold against the clamp would terminally fail a healthy deployment
+    /// that raised `RLIMIT_NOFILE` and legitimately holds many descriptors.
+    /// When the limit exceeds the scan window the watchdog is naturally inert —
+    /// a clamped scan cannot prove proximity to a limit it cannot see, and an
+    /// effectively unlimited `rlim_cur` cannot be exhausted by sockets anyway.
     internal static func descriptorUsage() -> (used: Int, limit: Int)? {
         var limits = rlimit()
         guard getrlimit(RLIMIT_NOFILE, &limits) == 0 else { return nil }
 
-        let ceiling = min(Int(clamping: limits.rlim_cur), 65536)
-        guard ceiling > 0 else { return nil }
+        let limit = Int(clamping: limits.rlim_cur)
+        let scanCeiling = min(limit, watchdogScanCeiling)
+        guard scanCeiling > 0 else { return nil }
 
         var used = 0
-        for descriptor in 0..<Int32(ceiling) where fcntl(descriptor, F_GETFD) != -1 {
+        for descriptor in 0..<Int32(scanCeiling) where fcntl(descriptor, F_GETFD) != -1 {
             used += 1
         }
-        return (used, ceiling)
+        return (used, limit)
     }
 }
 #endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport+Watchdog.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport+Watchdog.swift
@@ -1,0 +1,78 @@
+#if Server
+import Foundation
+
+#if canImport(Network)
+import Network
+
+extension TCPBonjourTransport {
+    // MARK: - Descriptor Watchdog
+
+    /// How often the descriptor watchdog samples the process fd table, in seconds.
+    internal static let watchdogInterval: UInt64 = 30
+
+    /// The fraction of the descriptor limit past which the transport fails.
+    internal static let watchdogThreshold = 0.8
+
+    /// Watches the process descriptor table and fails the transport terminally
+    /// when it approaches exhaustion.
+    ///
+    /// This has to be proactive sampling: under `EMFILE` an `NWListener` stays
+    /// `.ready`, emits no state transition, and simply never accepts again — the
+    /// server looks healthy from the outside while serving nothing, and a
+    /// supervised daemon that never exits is never restarted. Failing while a
+    /// few descriptors remain also leaves enough headroom to shut down cleanly.
+    internal func startDescriptorWatchdog() {
+        let task = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: TCPBonjourTransport.watchdogInterval * 1_000_000_000)
+                } catch {
+                    return  // cancelled
+                }
+
+                guard let self, await self.state.running() else { return }
+                guard let usage = TCPBonjourTransport.descriptorUsage() else { continue }
+
+                if Double(usage.used) >= TCPBonjourTransport.watchdogThreshold * Double(usage.limit) {
+                    self.logger.critical("""
+                        Process is running out of file descriptors \
+                        (\(usage.used) of \(usage.limit) in use); \
+                        failing the TCP+Bonjour transport terminally.
+                        """)
+                    await self.state.failTerminally(TransportError.resourceExhausted(
+                        "File descriptors nearly exhausted (\(usage.used) of \(usage.limit) in use)."
+                    ))
+                    return
+                }
+            }
+        }
+
+        Task {
+            await state.setWatchdogTask(task)
+        }
+    }
+
+    /// Counts live descriptors against the process limit.
+    ///
+    /// Counting is `fcntl(fd, F_GETFD)` over the table — deliberately not
+    /// `F_GETPATH` (returns `EBADF` for sockets, i.e. blind to exactly the leak
+    /// this guards against) and not `proc_pidinfo` (reports table capacity, not
+    /// usage). The scan is clamped: an effectively unlimited `rlim_cur` cannot
+    /// be exhausted by sockets in practice, and scanning billions of slots
+    /// every sample is not an option.
+    internal static func descriptorUsage() -> (used: Int, limit: Int)? {
+        var limits = rlimit()
+        guard getrlimit(RLIMIT_NOFILE, &limits) == 0 else { return nil }
+
+        let ceiling = min(Int(clamping: limits.rlim_cur), 65536)
+        guard ceiling > 0 else { return nil }
+
+        var used = 0
+        for descriptor in 0..<Int32(ceiling) where fcntl(descriptor, F_GETFD) != -1 {
+            used += 1
+        }
+        return (used, ceiling)
+    }
+}
+#endif
+#endif

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
@@ -81,6 +81,12 @@ public final class TCPBonjourTransport: Transport, MCPTransport, Service, @unche
     /// Maximum delay between retry attempts (in seconds).
     internal static let maxRetryDelay: UInt64 = 60
 
+    /// How long a clean EOF waits for in-flight request handlers to finish
+    /// before tearing the connection down. A half-closing peer is still
+    /// reading replies; an abortive close (error path) skips this entirely.
+    /// Internal so tests can shorten the wait.
+    internal var eofDrainTimeout: TimeInterval = 30
+
     // MARK: - Init
 
     /// Creates a server-coupled transport.

--- a/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
+++ b/Sources/SwiftMCP/Transport/TCPBonjourTransport.swift
@@ -81,142 +81,6 @@ public final class TCPBonjourTransport: Transport, MCPTransport, Service, @unche
     /// Maximum delay between retry attempts (in seconds).
     internal static let maxRetryDelay: UInt64 = 60
 
-    // MARK: - Transport State
-
-    internal actor TransportState {
-        private(set) var isRunning: Bool = false
-        private(set) var generation: UInt64 = 0
-        private var listener: NWListener?
-        private var connections: [UUID: NWConnection] = [:]
-        private var runContinuation: CheckedContinuation<Void, Never>?
-        private var retryTask: Task<Void, Never>?
-        private var localRegistration: LocalOnlyRegistration?
-        private(set) var retryAttempt: Int = 0
-
-        func running() -> Bool {
-            isRunning
-        }
-
-        /// Start a new listener generation.
-        /// Returns the generation token for this listener.
-        @discardableResult
-        func start(listener: NWListener) -> UInt64 {
-            generation += 1
-            self.listener = listener
-            isRunning = true
-            retryAttempt = 0
-            cancelRetryTask()
-            localRegistration?.stop()
-            localRegistration = nil
-            return generation
-        }
-
-        /// Replace the current listener with a new one during retry recovery.
-        /// Returns the new generation token, or nil if the transport is stopped.
-        func replaceListener(_ newListener: NWListener, expectedGeneration: UInt64) -> UInt64? {
-            guard isRunning, generation == expectedGeneration else {
-                return nil
-            }
-            listener?.cancel()
-            localRegistration?.stop()
-            localRegistration = nil
-            generation += 1
-            self.listener = newListener
-            return generation
-        }
-
-        func stop() {
-            isRunning = false
-            generation += 1  // invalidate any in-flight retry / state callbacks
-            cancelRetryTask()
-            retryAttempt = 0
-            listener?.cancel()
-            listener = nil
-            localRegistration?.stop()
-            localRegistration = nil
-            for connection in connections.values {
-                connection.cancel()
-            }
-            connections.removeAll()
-            if let continuation = runContinuation {
-                runContinuation = nil
-                continuation.resume()
-            }
-        }
-
-        func waitUntilStopped() async {
-            guard isRunning else { return }
-            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                runContinuation = continuation
-            }
-        }
-
-        /// Called when the listener reaches `.ready`.
-        /// Resets backoff, clears any pending retry, and returns the bound port (if available).
-        func listenerReady(generation listenerGen: UInt64) -> UInt16? {
-            guard listenerGen == generation, isRunning else { return nil }
-            retryAttempt = 0
-            cancelRetryTask()
-            return listener?.port?.rawValue
-        }
-
-        func setLocalRegistration(
-            _ registration: LocalOnlyRegistration,
-            generation listenerGen: UInt64
-        ) -> Bool {
-            guard listenerGen == generation, isRunning else { return false }
-            localRegistration?.stop()
-            localRegistration = registration
-            return true
-        }
-
-        /// Replaces the listener's advertised service, e.g. to publish a TXT record
-        /// that could not be complete when the listener was created.
-        func updateService(_ service: NWListener.Service, generation listenerGen: UInt64) {
-            guard listenerGen == generation, isRunning else { return }
-            listener?.service = service
-        }
-
-        func removeLocalRegistration(generation listenerGen: UInt64) {
-            guard listenerGen == generation else { return }
-            localRegistration?.stop()
-            localRegistration = nil
-        }
-
-        /// Called when the listener fails with a retryable error.
-        /// Increments the backoff attempt and returns the delay in seconds,
-        /// or nil if the transport is stopped or the generation is stale.
-        func listenerFailed(generation listenerGen: UInt64) -> UInt64? {
-            guard listenerGen == generation, isRunning else { return nil }
-            retryAttempt += 1
-            let delay = min(UInt64(1) << UInt64(min(retryAttempt - 1, 5)), TCPBonjourTransport.maxRetryDelay)
-            return delay
-        }
-
-        /// Store a retry task. Cancels any existing one first.
-        func setRetryTask(_ task: Task<Void, Never>) {
-            cancelRetryTask()
-            retryTask = task
-        }
-
-        private func cancelRetryTask() {
-            retryTask?.cancel()
-            retryTask = nil
-        }
-
-        func addConnection(id: UUID, connection: NWConnection) {
-            connections[id] = connection
-        }
-
-        func removeConnection(id: UUID) {
-            connections.removeValue(forKey: id)
-        }
-
-        func connection(for id: UUID) -> NWConnection? {
-            connections[id]
-        }
-    }
-
     // MARK: - Init
 
     /// Creates a server-coupled transport.
@@ -243,6 +107,10 @@ public final class TCPBonjourTransport: Transport, MCPTransport, Service, @unche
         self.preferIPv4 = preferIPv4
         self.declaredServerName = nil
         self.declaredServerVersion = nil
+        // Force the lazy manager on the constructing thread: instance `lazy` is a
+        // non-atomic check-then-store, and its first touch would otherwise be a
+        // per-connection task — concurrent first connections could double-create it.
+        _ = sessionManager
     }
 
     /// Creates a decoupled transport with no server.
@@ -276,6 +144,17 @@ public final class TCPBonjourTransport: Transport, MCPTransport, Service, @unche
         self.preferIPv4 = preferIPv4
         self.declaredServerName = serverName
         self.declaredServerVersion = serverVersion
+        // See the server-coupled initializer.
+        _ = sessionManager
+    }
+
+    deinit {
+        // A transport released without `stop()` must not orphan its listener:
+        // an orphaned `NWListener` keeps accepting (and thus leaking) connections
+        // with no owner left to ever cancel them. `TransportState` is an actor,
+        // so hop onto it; the task retains the actor until the sweep completes.
+        let state = self.state
+        Task { await state.stop() }
     }
 
     /// Connects the dispatcher `serve` routes inbound TCP lines through.

--- a/Sources/SwiftMCP/Transport/TransportError.swift
+++ b/Sources/SwiftMCP/Transport/TransportError.swift
@@ -17,6 +17,18 @@ public enum TransportError: LocalizedError {
     case bindingFailed(String)
 
     /**
+     Indicates that the transport hit a process-level resource limit it cannot
+     recover from — today, file-descriptor exhaustion (`EMFILE`/`ENFILE`).
+
+     Terminal by design: a process out of descriptors accepts nothing while its
+     listener still looks healthy from the outside, so the transport fails its
+     `run()` loudly rather than serving nothing forever.
+
+     - Parameter message: A human-readable description of the exhausted resource.
+     */
+    case resourceExhausted(String)
+
+    /**
      Provides a localized description of the error.
 	 
      - Returns: A human-readable string describing the error.
@@ -24,6 +36,8 @@ public enum TransportError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .bindingFailed(let message):
+            return message
+        case .resourceExhausted(let message):
             return message
         }
     }

--- a/Tests/SwiftMCPTests/Connection/TCPTransportFailureTests.swift
+++ b/Tests/SwiftMCPTests/Connection/TCPTransportFailureTests.swift
@@ -1,0 +1,177 @@
+//
+//  TCPTransportFailureTests.swift
+//  SwiftMCP
+//
+//  Failure-mode regression tests for #171: a dead listener must fail `run()`
+//  instead of parking it (§2), registration is refused around `stop()` (§4b),
+//  and the descriptor watchdog's accounting is sane (§3). The connection
+//  teardown behavior lives in `TCPTransportTeardownTests`.
+//
+
+#if Server && canImport(Network)
+import Testing
+import Foundation
+import Network
+@testable import SwiftMCP
+
+@Suite("TCP transport failure modes", .serialized)
+struct TCPTransportFailureTests {
+
+    private func uniqueBaseName() -> String {
+        "SwiftMCPTest-\(UUID().uuidString.prefix(8))"
+    }
+
+    // MARK: - §2: a dead listener must fail run(), not park it
+
+    @Test("run() throws when the listener fails unrecoverably")
+    func runThrowsOnListenerFailure() async throws {
+        // Occupy a loopback port so the transport's listener fails its bind.
+        // NWListener fails *asynchronously*: start() reports success first, and
+        // before the fix the failure was logged and swallowed — run() parked
+        // forever with the embedder believing the server was up.
+        let blocker = socket(AF_INET, SOCK_STREAM, 0)
+        defer { close(blocker) }
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bindResult = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(blocker, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        #expect(bindResult == 0)
+        #expect(listen(blocker, 1) == 0)
+
+        var boundAddress = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        withUnsafeMutablePointer(to: &boundAddress) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                _ = getsockname(blocker, $0, &length)
+            }
+        }
+        let occupiedPort = UInt16(bigEndian: boundAddress.sin_port)
+
+        let transport = TCPBonjourTransport(
+            server: StructCalculator(),
+            instanceName: uniqueBaseName(),
+            scope: .localUser,
+            port: occupiedPort
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await transport.run()
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: 15_000_000_000)
+                    try? await transport.stop()  // unblock run() if it wedged
+                    Issue.record("run() did not throw within 15s of the listener failing")
+                }
+                try await group.next()
+                group.cancelAll()
+            }
+        }
+    }
+
+    // MARK: - §4b: accepts racing stop()
+
+    @Test("A connection registered after stop() is refused")
+    func connectionAfterStopIsRefused() async throws {
+        let transport = TCPBonjourTransport(
+            server: StructCalculator(), instanceName: uniqueBaseName(), scope: .localUser
+        )
+
+        let connection = NWConnection(
+            host: "127.0.0.1", port: .init(rawValue: 9)!, using: .tcp
+        )
+        defer { connection.cancel() }
+
+        // Never started: not running, so registration must be refused.
+        let refusedBeforeStart = await transport.state.addConnection(
+            id: UUID(), connection: connection, tasks: ConnectionTaskTracker()
+        )
+        #expect(refusedBeforeStart == false)
+
+        try await transport.start()
+        let id = UUID()
+        let acceptedWhileRunning = await transport.state.addConnection(
+            id: id, connection: connection, tasks: ConnectionTaskTracker()
+        )
+        #expect(acceptedWhileRunning == true)
+
+        try await transport.stop()
+        #expect(await transport.state.connection(for: id) == nil)
+
+        let refusedAfterStop = await transport.state.addConnection(
+            id: UUID(), connection: connection, tasks: ConnectionTaskTracker()
+        )
+        #expect(refusedAfterStop == false)
+    }
+
+    // MARK: - §3: descriptor accounting
+
+    @Test("descriptorUsage counts live descriptors")
+    func descriptorUsageCountsLiveDescriptors() throws {
+        let sanity = try #require(TCPBonjourTransport.descriptorUsage())
+        #expect(sanity.used > 0)
+        #expect(sanity.limit > 0)
+        #expect(sanity.used <= sanity.limit)
+
+        // Ten pipes: twenty descriptors that F_GETFD must see. Suites in other
+        // files run concurrently and churn this process's descriptor table, so
+        // a single before/after pair can race a burst of closes; the pipes
+        // persist across attempts, while churn beating +20 every time doesn't.
+        var sawIncrease = false
+        for _ in 0..<3 where !sawIncrease {
+            let before = try #require(TCPBonjourTransport.descriptorUsage())
+
+            var pipes: [[Int32]] = []
+            for _ in 0..<10 {
+                var fds: [Int32] = [0, 0]
+                #expect(pipe(&fds) == 0)
+                pipes.append(fds)
+            }
+            defer {
+                for fds in pipes {
+                    close(fds[0])
+                    close(fds[1])
+                }
+            }
+
+            let after = try #require(TCPBonjourTransport.descriptorUsage())
+            sawIncrease = after.used >= before.used + 10
+        }
+        #expect(sawIncrease, "twenty live pipe descriptors never showed up in the count")
+    }
+}
+
+@Suite("TCP line partitioning")
+struct TCPLinePartitioningTests {
+
+    @Test("Cancellation notifications are split out; lookalikes stay put")
+    func partitionCancellations() {
+        let cancel = #"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}"#
+        let request = #"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hang","arguments":{}}}"#
+        // Contains the substring but is a request — must not be reordered.
+        let lookalike = #"{"jsonrpc":"2.0","id":2,"method":"tools/call","#
+            + #""params":{"name":"echo","arguments":{"text":"notifications/cancelled"}}}"#
+        let garbage = "not json notifications/cancelled"
+
+        let (cancellations, rest) = TCPBonjourTransport.partitionCancellations(
+            [request, lookalike, cancel, garbage]
+        )
+        #expect(cancellations == [cancel])
+        #expect(rest == [request, lookalike, garbage])
+    }
+
+    @Test("Batches without cancellations pass through untouched")
+    func noCancellations() {
+        let lines = ["one", "two"]
+        let (cancellations, rest) = TCPBonjourTransport.partitionCancellations(lines)
+        #expect(cancellations.isEmpty)
+        #expect(rest == lines)
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/Connection/TCPTransportTeardownTests.swift
+++ b/Tests/SwiftMCPTests/Connection/TCPTransportTeardownTests.swift
@@ -19,78 +19,78 @@ import Foundation
 import Network
 @testable import SwiftMCP
 
+/// A minimal blocking TCP client on raw POSIX sockets. Deliberately not
+/// Network.framework: the tests need deterministic close semantics (FIN on
+/// `close`, half-close via `shutdown`) and their own descriptors excluded
+/// from what the transport is being measured on.
+private struct TestTCPClient {
+    let sock: Int32
+
+    init(port: UInt16) throws {
+        sock = socket(AF_INET, SOCK_STREAM, 0)
+        guard sock >= 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+
+        var timeout = timeval(tv_sec: 5, tv_usec: 0)
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = port.bigEndian
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let result = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard result == 0 else {
+            let code = errno
+            close(sock)
+            throw POSIXError(.init(rawValue: code) ?? .EIO)
+        }
+    }
+
+    func send(_ string: String) {
+        let bytes = Array(string.utf8)
+        var sent = 0
+        while sent < bytes.count {
+            let written = bytes[sent...].withUnsafeBufferPointer {
+                write(sock, $0.baseAddress, $0.count)
+            }
+            guard written > 0 else { return }
+            sent += written
+        }
+    }
+
+    /// Half-close: FIN the write side while keeping the read side open.
+    func shutdownWrite() {
+        shutdown(sock, SHUT_WR)
+    }
+
+    /// Reads until the first newline (or EOF / receive timeout).
+    func readLine() -> String? {
+        var received = Data()
+        var byte: UInt8 = 0
+        while read(sock, &byte, 1) == 1 {
+            if byte == 0x0A {
+                return String(data: received, encoding: .utf8)
+            }
+            received.append(byte)
+        }
+        return received.isEmpty ? nil : String(data: received, encoding: .utf8)
+    }
+
+    func closeSocket() {
+        close(sock)
+    }
+}
+
 @Suite("TCP transport teardown", .serialized)
 struct TCPTransportTeardownTests {
 
     // MARK: - Helpers
-
-    /// A minimal blocking TCP client on raw POSIX sockets. Deliberately not
-    /// Network.framework: the tests need deterministic close semantics (FIN on
-    /// `close`, half-close via `shutdown`) and their own descriptors excluded
-    /// from what the transport is being measured on.
-    private struct TestTCPClient {
-        let sock: Int32
-
-        init(port: UInt16) throws {
-            sock = socket(AF_INET, SOCK_STREAM, 0)
-            guard sock >= 0 else {
-                throw POSIXError(.init(rawValue: errno) ?? .EIO)
-            }
-
-            var timeout = timeval(tv_sec: 5, tv_usec: 0)
-            setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
-
-            var address = sockaddr_in()
-            address.sin_family = sa_family_t(AF_INET)
-            address.sin_port = port.bigEndian
-            address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
-
-            let result = withUnsafePointer(to: &address) {
-                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                    connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-                }
-            }
-            guard result == 0 else {
-                let code = errno
-                close(sock)
-                throw POSIXError(.init(rawValue: code) ?? .EIO)
-            }
-        }
-
-        func send(_ string: String) {
-            let bytes = Array(string.utf8)
-            var sent = 0
-            while sent < bytes.count {
-                let written = bytes[sent...].withUnsafeBufferPointer {
-                    write(sock, $0.baseAddress, $0.count)
-                }
-                guard written > 0 else { return }
-                sent += written
-            }
-        }
-
-        /// Half-close: FIN the write side while keeping the read side open.
-        func shutdownWrite() {
-            shutdown(sock, SHUT_WR)
-        }
-
-        /// Reads until the first newline (or EOF / receive timeout).
-        func readLine() -> String? {
-            var received = Data()
-            var byte: UInt8 = 0
-            while read(sock, &byte, 1) == 1 {
-                if byte == 0x0A {
-                    return String(data: received, encoding: .utf8)
-                }
-                received.append(byte)
-            }
-            return received.isEmpty ? nil : String(data: received, encoding: .utf8)
-        }
-
-        func closeSocket() {
-            close(sock)
-        }
-    }
 
     private func uniqueBaseName() -> String {
         "SwiftMCPTest-\(UUID().uuidString.prefix(8))"
@@ -204,7 +204,12 @@ struct TCPTransportTeardownTests {
     @Test("A client disconnect cancels a running tool")
     func disconnectCancelsRunningTool() async throws {
         let server = HangingServer()
-        try await withStartedTransport(server: server) { _, port in
+        try await withStartedTransport(server: server) { transport, port in
+            // A FIN takes the clean-EOF path, which grants in-flight handlers
+            // a drain window before cancelling. Shorten it so the test bounds
+            // "cancelled after the grace period", not a 30s default.
+            transport.eofDrainTimeout = 0.5
+
             let client = try TestTCPClient(port: port)
 
             client.send(Self.initializeLine + "\n")
@@ -222,6 +227,35 @@ struct TCPTransportTeardownTests {
                 await server.observer.waitUntilCancelled(),
                 "the tool kept running after its client disconnected"
             )
+        }
+    }
+
+    @Test("A half-closing client still receives the reply to an in-flight request")
+    func halfCloseKeepsInFlightReply() async throws {
+        let server = HangingServer()
+        try await withStartedTransport(server: server) { _, port in
+            let client = try TestTCPClient(port: port)
+            defer { client.closeSocket() }
+
+            client.send(Self.initializeLine + "\n")
+            _ = client.readLine()
+
+            // The request arrives in its own receive callback and is still
+            // computing when the FIN lands. Teardown must drain it — cancelling
+            // here would lose the reply the peer's open read side is waiting for.
+            client.send("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call",\
+                "params":{"name":"slow","arguments":{}}}\n
+                """)
+            #expect(await server.observer.waitUntilStarted())
+            client.shutdownWrite()
+
+            let responseLine = try #require(client.readLine())
+            let response = try JSONDecoder().decode(
+                JSONRPCMessage.self, from: Data(responseLine.utf8)
+            )
+            #expect(response.id == .integer(2))
+            #expect(responseLine.contains("slow-done"))
         }
     }
 

--- a/Tests/SwiftMCPTests/Connection/TCPTransportTeardownTests.swift
+++ b/Tests/SwiftMCPTests/Connection/TCPTransportTeardownTests.swift
@@ -259,120 +259,60 @@ struct TCPTransportTeardownTests {
         }
     }
 
-    // MARK: - §2: a dead listener must fail run(), not park it
+    @Test("A hung tool arriving with the FIN is still reaped")
+    func hungFinalLineToolIsReaped() async throws {
+        let server = HangingServer()
+        try await withStartedTransport(server: server) { transport, port in
+            transport.eofDrainTimeout = 0.5
 
-    @Test("run() throws when the listener fails unrecoverably")
-    func runThrowsOnListenerFailure() async throws {
-        // Occupy a loopback port so the transport's listener fails its bind.
-        // NWListener fails *asynchronously*: start() reports success first, and
-        // before the fix the failure was logged and swallowed — run() parked
-        // forever with the embedder believing the server was up.
-        let blocker = socket(AF_INET, SOCK_STREAM, 0)
-        defer { close(blocker) }
-        var address = sockaddr_in()
-        address.sin_family = sa_family_t(AF_INET)
-        address.sin_port = 0
-        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
-        let bindResult = withUnsafePointer(to: &address) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                bind(blocker, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-            }
-        }
-        #expect(bindResult == 0)
-        #expect(listen(blocker, 1) == 0)
+            let client = try TestTCPClient(port: port)
+            defer { client.closeSocket() }
 
-        var boundAddress = sockaddr_in()
-        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
-        withUnsafeMutablePointer(to: &boundAddress) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                _ = getsockname(blocker, $0, &length)
-            }
-        }
-        let occupiedPort = UInt16(bigEndian: boundAddress.sin_port)
+            client.send(Self.initializeLine + "\n")
+            _ = client.readLine()
 
-        let transport = TCPBonjourTransport(
-            server: StructCalculator(),
-            instanceName: uniqueBaseName(),
-            scope: .localUser,
-            port: occupiedPort
-        )
+            // No trailing newline: the request is completed by the FIN itself,
+            // so its handler is guaranteed to run from the EOF batch. If that
+            // batch were untracked, nothing could ever cancel this tool and
+            // the connection entry, session, and descriptor would pin forever.
+            client.send("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call",\
+                "params":{"name":"hang","arguments":{}}}
+                """)
+            client.closeSocket()
 
-        await #expect(throws: (any Error).self) {
-            try await withThrowingTaskGroup(of: Void.self) { group in
-                group.addTask {
-                    try await transport.run()
-                }
-                group.addTask {
-                    try await Task.sleep(nanoseconds: 15_000_000_000)
-                    try? await transport.stop()  // unblock run() if it wedged
-                    Issue.record("run() did not throw within 15s of the listener failing")
-                }
-                try await group.next()
-                group.cancelAll()
-            }
+            #expect(
+                await server.observer.waitUntilCancelled(),
+                "the EOF-batch tool outlived the drain window without being reaped"
+            )
         }
     }
 
-    // MARK: - §4b: accepts racing stop()
+    @Test("A cancellation coalesced with its request still cancels it")
+    func coalescedCancellationCancels() async throws {
+        let server = HangingServer()
+        try await withStartedTransport(server: server) { _, port in
+            let client = try TestTCPClient(port: port)
+            defer { client.closeSocket() }
 
-    @Test("A connection registered after stop() is refused")
-    func connectionAfterStopIsRefused() async throws {
-        let transport = TCPBonjourTransport(
-            server: StructCalculator(), instanceName: uniqueBaseName(), scope: .localUser
-        )
+            client.send(Self.initializeLine + "\n")
+            _ = client.readLine()
 
-        let connection = NWConnection(
-            host: "127.0.0.1", port: .init(rawValue: 9)!, using: .tcp
-        )
-        defer { connection.cancel() }
+            // One write, so both lines typically arrive in one receive
+            // callback. Processed strictly in order, the cancellation would
+            // wait behind the very request it names and cancel nothing.
+            client.send("""
+                {"jsonrpc":"2.0","id":3,"method":"tools/call",\
+                "params":{"name":"hang","arguments":{}}}\n\
+                {"jsonrpc":"2.0","method":"notifications/cancelled",\
+                "params":{"requestId":3}}\n
+                """)
 
-        // Never started: not running, so registration must be refused.
-        let refusedBeforeStart = await transport.state.addConnection(
-            id: UUID(), connection: connection, tasks: ConnectionTaskTracker()
-        )
-        #expect(refusedBeforeStart == false)
-
-        try await transport.start()
-        let id = UUID()
-        let acceptedWhileRunning = await transport.state.addConnection(
-            id: id, connection: connection, tasks: ConnectionTaskTracker()
-        )
-        #expect(acceptedWhileRunning == true)
-
-        try await transport.stop()
-        #expect(await transport.state.connection(for: id) == nil)
-
-        let refusedAfterStop = await transport.state.addConnection(
-            id: UUID(), connection: connection, tasks: ConnectionTaskTracker()
-        )
-        #expect(refusedAfterStop == false)
-    }
-
-    // MARK: - §3: descriptor accounting
-
-    @Test("descriptorUsage counts live descriptors")
-    func descriptorUsageCountsLiveDescriptors() throws {
-        let before = try #require(TCPBonjourTransport.descriptorUsage())
-        #expect(before.used > 0)
-        #expect(before.limit > 0)
-        #expect(before.used <= before.limit)
-
-        // Ten pipes: twenty descriptors that F_GETFD must see.
-        var pipes: [[Int32]] = []
-        for _ in 0..<10 {
-            var fds: [Int32] = [0, 0]
-            #expect(pipe(&fds) == 0)
-            pipes.append(fds)
+            #expect(
+                await server.observer.waitUntilCancelled(),
+                "the coalesced cancellation never reached the running tool"
+            )
         }
-        defer {
-            for fds in pipes {
-                close(fds[0])
-                close(fds[1])
-            }
-        }
-
-        let after = try #require(TCPBonjourTransport.descriptorUsage())
-        #expect(after.used >= before.used + 10)
     }
 }
 #endif

--- a/Tests/SwiftMCPTests/Connection/TCPTransportTeardownTests.swift
+++ b/Tests/SwiftMCPTests/Connection/TCPTransportTeardownTests.swift
@@ -1,0 +1,344 @@
+//
+//  TCPTransportTeardownTests.swift
+//  SwiftMCP
+//
+//  Regression tests for #171: the TCP+Bonjour transport leaked one file
+//  descriptor per inbound connection (`cleanupConnection` never called
+//  `NWConnection.cancel()`), dropped the final unterminated line on every
+//  close, kept tool tasks running for disconnected clients, and parked
+//  `run()` forever when the listener died.
+//
+//  Verification counts *descriptors*, never TCP states: a leaked descriptor shows
+//  CLOSE_WAIT after a graceful FIN and CLOSED after an RST, and ages between
+//  them — an assertion on states passes while leaking.
+//
+
+#if Server && canImport(Network)
+import Testing
+import Foundation
+import Network
+@testable import SwiftMCP
+
+@Suite("TCP transport teardown", .serialized)
+struct TCPTransportTeardownTests {
+
+    // MARK: - Helpers
+
+    /// A minimal blocking TCP client on raw POSIX sockets. Deliberately not
+    /// Network.framework: the tests need deterministic close semantics (FIN on
+    /// `close`, half-close via `shutdown`) and their own descriptors excluded
+    /// from what the transport is being measured on.
+    private struct TestTCPClient {
+        let sock: Int32
+
+        init(port: UInt16) throws {
+            sock = socket(AF_INET, SOCK_STREAM, 0)
+            guard sock >= 0 else {
+                throw POSIXError(.init(rawValue: errno) ?? .EIO)
+            }
+
+            var timeout = timeval(tv_sec: 5, tv_usec: 0)
+            setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+            var address = sockaddr_in()
+            address.sin_family = sa_family_t(AF_INET)
+            address.sin_port = port.bigEndian
+            address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+            let result = withUnsafePointer(to: &address) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+            guard result == 0 else {
+                let code = errno
+                close(sock)
+                throw POSIXError(.init(rawValue: code) ?? .EIO)
+            }
+        }
+
+        func send(_ string: String) {
+            let bytes = Array(string.utf8)
+            var sent = 0
+            while sent < bytes.count {
+                let written = bytes[sent...].withUnsafeBufferPointer {
+                    write(sock, $0.baseAddress, $0.count)
+                }
+                guard written > 0 else { return }
+                sent += written
+            }
+        }
+
+        /// Half-close: FIN the write side while keeping the read side open.
+        func shutdownWrite() {
+            shutdown(sock, SHUT_WR)
+        }
+
+        /// Reads until the first newline (or EOF / receive timeout).
+        func readLine() -> String? {
+            var received = Data()
+            var byte: UInt8 = 0
+            while read(sock, &byte, 1) == 1 {
+                if byte == 0x0A {
+                    return String(data: received, encoding: .utf8)
+                }
+                received.append(byte)
+            }
+            return received.isEmpty ? nil : String(data: received, encoding: .utf8)
+        }
+
+        func closeSocket() {
+            close(sock)
+        }
+    }
+
+    private func uniqueBaseName() -> String {
+        "SwiftMCPTest-\(UUID().uuidString.prefix(8))"
+    }
+
+    /// Starts a loopback transport, waits for its ephemeral port, runs `body`,
+    /// and always tears the transport down.
+    private func withStartedTransport(
+        server: some MCPServer,
+        _ body: (TCPBonjourTransport, UInt16) async throws -> Void
+    ) async throws {
+        let transport = TCPBonjourTransport(
+            server: server, instanceName: uniqueBaseName(), scope: .localUser
+        )
+        try await transport.start()
+
+        let deadline = Date().addingTimeInterval(5)
+        while transport.port == nil, Date() < deadline {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+
+        do {
+            let port = try #require(transport.port)
+            try await body(transport, port)
+        } catch {
+            try? await transport.stop()
+            throw error
+        }
+        try await transport.stop()
+    }
+
+    private static let initializeLine = """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26",\
+        "capabilities":{},"clientInfo":{"name":"teardown-test","version":"1.0"}}}
+        """
+
+    /// Live descriptors in this process, counted the only way that sees leaked
+    /// sockets (see `TCPBonjourTransport.descriptorUsage`).
+    private func liveDescriptorCount() throws -> Int {
+        try #require(TCPBonjourTransport.descriptorUsage()).used
+    }
+
+    /// Polls until the process descriptor count drops to `ceiling` or below.
+    private func waitForDescriptorCount(atMost ceiling: Int, timeout: TimeInterval = 10) async throws -> Int {
+        let deadline = Date().addingTimeInterval(timeout)
+        var count = try liveDescriptorCount()
+        while count > ceiling, Date() < deadline {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            count = try liveDescriptorCount()
+        }
+        return count
+    }
+
+    // MARK: - §1: the descriptor leak
+
+    @Test("Closed connections release their descriptors")
+    func closedConnectionsReleaseDescriptors() async throws {
+        try await withStartedTransport(server: StructCalculator()) { _, port in
+            // Warm up: the first connection allocates lazy machinery whose
+            // descriptors would otherwise pollute the baseline.
+            let warmup = try TestTCPClient(port: port)
+            warmup.send(Self.initializeLine + "\n")
+            _ = warmup.readLine()
+            warmup.closeSocket()
+            try await Task.sleep(nanoseconds: 300_000_000)
+
+            let baseline = try liveDescriptorCount()
+            let connectionCount = 20
+
+            for _ in 0..<connectionCount {
+                let client = try TestTCPClient(port: port)
+                client.send(Self.initializeLine + "\n")
+                _ = client.readLine()
+                client.closeSocket()
+            }
+
+            // Unrelated suites running in parallel churn a few descriptors, so
+            // allow slack well below the leak size: before the fix every one of
+            // the 20 connections stranded its sock and the count never came down.
+            let tolerance = 5
+            let settled = try await waitForDescriptorCount(atMost: baseline + tolerance)
+            #expect(
+                settled <= baseline + tolerance,
+                "descriptors did not return to baseline: \(baseline) before, \(settled) after"
+            )
+        }
+    }
+
+    // MARK: - §4c: the final line on EOF
+
+    @Test("The final unterminated line is processed on half-close")
+    func finalLineProcessedOnEOF() async throws {
+        try await withStartedTransport(server: StructCalculator()) { _, port in
+            let client = try TestTCPClient(port: port)
+            defer { client.closeSocket() }
+
+            // No trailing newline; the FIN is what terminates the line.
+            client.send(Self.initializeLine)
+            client.shutdownWrite()
+
+            let responseLine = try #require(client.readLine())
+            let response = try JSONDecoder().decode(
+                JSONRPCMessage.self, from: Data(responseLine.utf8)
+            )
+            #expect(response.id == .integer(1))
+        }
+    }
+
+    // MARK: - §4a: disconnect cancels in-flight work
+
+    @Test("A client disconnect cancels a running tool")
+    func disconnectCancelsRunningTool() async throws {
+        let server = HangingServer()
+        try await withStartedTransport(server: server) { _, port in
+            let client = try TestTCPClient(port: port)
+
+            client.send(Self.initializeLine + "\n")
+            _ = client.readLine()
+
+            client.send("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call",\
+                "params":{"name":"hang","arguments":{}}}\n
+                """)
+            #expect(await server.observer.waitUntilStarted())
+
+            client.closeSocket()
+
+            #expect(
+                await server.observer.waitUntilCancelled(),
+                "the tool kept running after its client disconnected"
+            )
+        }
+    }
+
+    // MARK: - §2: a dead listener must fail run(), not park it
+
+    @Test("run() throws when the listener fails unrecoverably")
+    func runThrowsOnListenerFailure() async throws {
+        // Occupy a loopback port so the transport's listener fails its bind.
+        // NWListener fails *asynchronously*: start() reports success first, and
+        // before the fix the failure was logged and swallowed — run() parked
+        // forever with the embedder believing the server was up.
+        let blocker = socket(AF_INET, SOCK_STREAM, 0)
+        defer { close(blocker) }
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bindResult = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(blocker, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        #expect(bindResult == 0)
+        #expect(listen(blocker, 1) == 0)
+
+        var boundAddress = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        withUnsafeMutablePointer(to: &boundAddress) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                _ = getsockname(blocker, $0, &length)
+            }
+        }
+        let occupiedPort = UInt16(bigEndian: boundAddress.sin_port)
+
+        let transport = TCPBonjourTransport(
+            server: StructCalculator(),
+            instanceName: uniqueBaseName(),
+            scope: .localUser,
+            port: occupiedPort
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await transport.run()
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: 15_000_000_000)
+                    try? await transport.stop()  // unblock run() if it wedged
+                    Issue.record("run() did not throw within 15s of the listener failing")
+                }
+                try await group.next()
+                group.cancelAll()
+            }
+        }
+    }
+
+    // MARK: - §4b: accepts racing stop()
+
+    @Test("A connection registered after stop() is refused")
+    func connectionAfterStopIsRefused() async throws {
+        let transport = TCPBonjourTransport(
+            server: StructCalculator(), instanceName: uniqueBaseName(), scope: .localUser
+        )
+
+        let connection = NWConnection(
+            host: "127.0.0.1", port: .init(rawValue: 9)!, using: .tcp
+        )
+        defer { connection.cancel() }
+
+        // Never started: not running, so registration must be refused.
+        let refusedBeforeStart = await transport.state.addConnection(
+            id: UUID(), connection: connection, tasks: ConnectionTaskTracker()
+        )
+        #expect(refusedBeforeStart == false)
+
+        try await transport.start()
+        let id = UUID()
+        let acceptedWhileRunning = await transport.state.addConnection(
+            id: id, connection: connection, tasks: ConnectionTaskTracker()
+        )
+        #expect(acceptedWhileRunning == true)
+
+        try await transport.stop()
+        #expect(await transport.state.connection(for: id) == nil)
+
+        let refusedAfterStop = await transport.state.addConnection(
+            id: UUID(), connection: connection, tasks: ConnectionTaskTracker()
+        )
+        #expect(refusedAfterStop == false)
+    }
+
+    // MARK: - §3: descriptor accounting
+
+    @Test("descriptorUsage counts live descriptors")
+    func descriptorUsageCountsLiveDescriptors() throws {
+        let before = try #require(TCPBonjourTransport.descriptorUsage())
+        #expect(before.used > 0)
+        #expect(before.limit > 0)
+        #expect(before.used <= before.limit)
+
+        // Ten pipes: twenty descriptors that F_GETFD must see.
+        var pipes: [[Int32]] = []
+        for _ in 0..<10 {
+            var fds: [Int32] = [0, 0]
+            #expect(pipe(&fds) == 0)
+            pipes.append(fds)
+        }
+        defer {
+            for fds in pipes {
+                close(fds[0])
+                close(fds[1])
+            }
+        }
+
+        let after = try #require(TCPBonjourTransport.descriptorUsage())
+        #expect(after.used >= before.used + 10)
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/Extensions/LineFramerTests.swift
+++ b/Tests/SwiftMCPTests/Extensions/LineFramerTests.swift
@@ -1,0 +1,75 @@
+//
+//  LineFramerTests.swift
+//  SwiftMCP
+//
+//  The synchronous line assembler the TCP server transport runs on the
+//  connection's serial queue (#171 §4c). Ordering is what it exists for: a
+//  JSON-RPC line routinely spans receive callbacks, and assembling across
+//  racing tasks reordered bytes and dropped the final unterminated line.
+//
+
+import Testing
+import Foundation
+@testable import SwiftMCP
+
+@Suite("LineFramer")
+struct LineFramerTests {
+
+    @Test("A line split across appends is reassembled in order")
+    func splitLine() {
+        let framer = LineFramer()
+        framer.append(Data("{\"a\":".utf8))
+        #expect(framer.extractLines().isEmpty)
+        framer.append(Data("1}\n".utf8))
+        #expect(framer.extractLines() == ["{\"a\":1}"])
+    }
+
+    @Test("Multiple lines in one chunk come out separately")
+    func multipleLines() {
+        let framer = LineFramer()
+        framer.append(Data("one\ntwo\nthr".utf8))
+        #expect(framer.extractLines() == ["one", "two"])
+        framer.append(Data("ee\n".utf8))
+        #expect(framer.extractLines() == ["three"])
+    }
+
+    @Test("The final unterminated line is returned by remainder()")
+    func remainder() {
+        let framer = LineFramer()
+        framer.append(Data("last line without newline".utf8))
+        #expect(framer.extractLines().isEmpty)
+        #expect(framer.remainder() == "last line without newline")
+        #expect(framer.remainder() == nil)
+    }
+
+    @Test("An empty framer has no lines and no remainder")
+    func empty() {
+        let framer = LineFramer()
+        #expect(framer.extractLines().isEmpty)
+        #expect(framer.remainder() == nil)
+    }
+
+    @Test("Behavior matches the LineBuffer actor for the same byte stream")
+    func matchesLineBuffer() async {
+        let chunks = ["{\"jsonrpc\"", ":\"2.0\"}\n{\"id\":1", "}\ntail"]
+
+        let framer = LineFramer()
+        var framedLines: [String] = []
+        for chunk in chunks {
+            framer.append(Data(chunk.utf8))
+            framedLines.append(contentsOf: framer.extractLines())
+        }
+        let framedRemainder = framer.remainder()
+
+        let buffer = LineBuffer()
+        var bufferedLines: [String] = []
+        for chunk in chunks {
+            await buffer.append(Data(chunk.utf8))
+            bufferedLines.append(contentsOf: await buffer.processLines())
+        }
+        let bufferedRemainder = await buffer.getRemaining()
+
+        #expect(framedLines == bufferedLines)
+        #expect(framedRemainder == bufferedRemainder)
+    }
+}

--- a/Tests/SwiftMCPTests/HTTPTransportLifecycleTests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportLifecycleTests.swift
@@ -1,0 +1,55 @@
+//
+//  HTTPTransportLifecycleTests.swift
+//  SwiftMCP
+//
+//  Regression tests for #171 §4d: a failed or repeated `start()` leaked the
+//  adapter's whole `EventLoopGroup` (coreCount threads + a kqueue descriptor),
+//  and a second `start()` stranded the first listener unreachable while the
+//  new bind failed EADDRINUSE against it.
+//
+
+#if Server
+import Testing
+import Foundation
+@testable import SwiftMCP
+
+@Suite("HTTP transport lifecycle", .serialized)
+struct HTTPTransportLifecycleTests {
+
+    @Test("start() is idempotent while running")
+    func startIsIdempotent() async throws {
+        let transport = HTTPSSETransport(server: Calculator(), host: "127.0.0.1", port: 0)
+        try await transport.start()
+        let boundPort = transport.port
+        #expect(boundPort != 0)
+
+        // A second start must be a no-op on the already-bound adapter — not a
+        // new adapter racing the old one for the port.
+        try await transport.start()
+        #expect(transport.port == boundPort)
+
+        try await transport.stop()
+    }
+
+    @Test("A failed bind leaves the transport stoppable and restartable")
+    func failedBindLeavesTransportRestartable() async throws {
+        let occupant = HTTPSSETransport(server: Calculator(), host: "127.0.0.1", port: 0)
+        try await occupant.start()
+        let occupiedPort = occupant.port
+
+        let transport = HTTPSSETransport(server: Calculator(), host: "127.0.0.1", port: occupiedPort)
+        await #expect(throws: (any Error).self) {
+            try await transport.start()
+        }
+
+        // Nothing bound, so stop() must be safe...
+        try await transport.stop()
+
+        // ...and once the port frees up, the same instance can start.
+        try await occupant.stop()
+        try await transport.start()
+        #expect(transport.port == occupiedPort)
+        try await transport.stop()
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/RequestCancellationTests.swift
+++ b/Tests/SwiftMCPTests/RequestCancellationTests.swift
@@ -55,6 +55,15 @@ final class HangingServer: @unchecked Sendable {
         await observer.markCancelled()
         return "cancelled"
     }
+
+    /// Takes a moment, then answers — long enough for a client to half-close
+    /// while it is still computing.
+    @MCPTool(description: "Answers after a short delay")
+    func slow() async -> String {
+        await observer.markStarted()
+        try? await Task.sleep(nanoseconds: 400_000_000)
+        return "slow-done"
+    }
 }
 
 @Suite("Request cancellation")
@@ -97,6 +106,34 @@ struct RequestCancellationTests {
         #expect(await server.observer.cancelled)
         // The client stopped listening for this response; it must be suppressed.
         #expect(response == nil)
+    }
+
+    @Test("A cancellation that overtakes its request still cancels it")
+    func preemptiveCancellation() async throws {
+        let server = HangingServer()
+        let session = Session(id: UUID())
+
+        // Dispatch tasks are unordered, so a cancellation can reach the
+        // session before its request registers. It must be retained and fire
+        // the moment the request shows up — not dropped as unknown.
+        let cancelNotification = JSONRPCMessage.notification(
+            method: "notifications/cancelled",
+            params: .object(["requestId": .integer(9)])
+        )
+        _ = await session.work { _ in await server.handleMessage(cancelNotification) }
+
+        let request = JSONRPCMessage.request(
+            id: .integer(9),
+            method: "tools/call",
+            params: .object([
+                "name": .string("hang"),
+                "arguments": .object([:])
+            ])
+        )
+        let response = await session.work { _ in await server.handleMessage(request) }
+
+        #expect(response == nil)
+        #expect(await server.observer.cancelled)
     }
 
     @Test("A cancellation for an unknown request id is a no-op")

--- a/Tests/SwiftMCPTests/RequestCancellationTests.swift
+++ b/Tests/SwiftMCPTests/RequestCancellationTests.swift
@@ -1,0 +1,170 @@
+//
+//  RequestCancellationTests.swift
+//  SwiftMCP
+//
+//  `notifications/cancelled` used to be an explicit no-op: a long-running tool
+//  kept working for a client that had already given up on the request (#171
+//  §4a). These tests drive the dispatch layer directly — the transport-level
+//  path (a disconnect cancelling in-flight work) is covered by
+//  `TCPTransportTeardownTests`.
+//
+
+import Testing
+import Foundation
+@testable import SwiftMCP
+
+/// Observes a hanging tool from the outside: when its body started running,
+/// and whether it exited through the cancellation path.
+actor ToolRunObserver {
+    private(set) var started = false
+    private(set) var cancelled = false
+
+    func markStarted() { started = true }
+    func markCancelled() { cancelled = true }
+
+    func waitUntilStarted(timeout: TimeInterval = 5) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !started, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return started
+    }
+
+    func waitUntilCancelled(timeout: TimeInterval = 5) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !cancelled, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return cancelled
+    }
+}
+
+/// A server whose only tool runs until its task is cancelled — the shape of a
+/// streaming/watching tool body (`while !Task.isCancelled`).
+@MCPServer(name: "Hanger")
+final class HangingServer: @unchecked Sendable {
+    let observer = ToolRunObserver()
+
+    /// Runs until the surrounding task is cancelled.
+    @MCPTool(description: "Runs until cancelled")
+    func hang() async -> String {
+        await observer.markStarted()
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        await observer.markCancelled()
+        return "cancelled"
+    }
+}
+
+@Suite("Request cancellation")
+struct RequestCancellationTests {
+
+    @Test("notifications/cancelled cancels the in-flight request and suppresses its response")
+    func cancelledNotificationCancelsInFlightRequest() async throws {
+        let server = HangingServer()
+        let session = Session(id: UUID())
+
+        let request = JSONRPCMessage.request(
+            id: .integer(42),
+            method: "tools/call",
+            params: .object([
+                "name": .string("hang"),
+                "arguments": .object([:])
+            ])
+        )
+
+        let processing = Task {
+            await session.work { _ in await server.handleMessage(request) }
+        }
+
+        #expect(await server.observer.waitUntilStarted())
+
+        let cancelNotification = JSONRPCMessage.notification(
+            method: "notifications/cancelled",
+            params: .object(["requestId": .integer(42)])
+        )
+        _ = await session.work { _ in await server.handleMessage(cancelNotification) }
+
+        // Bounded: if cancellation never reaches the tool, fail instead of hanging.
+        let watchdog = Task {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            processing.cancel()
+        }
+        defer { watchdog.cancel() }
+
+        let response = await processing.value
+        #expect(await server.observer.cancelled)
+        // The client stopped listening for this response; it must be suppressed.
+        #expect(response == nil)
+    }
+
+    @Test("A cancellation for an unknown request id is a no-op")
+    func unknownRequestIDIsNoOp() async throws {
+        let server = HangingServer()
+        let session = Session(id: UUID())
+
+        let cancelNotification = JSONRPCMessage.notification(
+            method: "notifications/cancelled",
+            params: .object(["requestId": .integer(7)])
+        )
+        let reply = await session.work { _ in await server.handleMessage(cancelNotification) }
+        #expect(reply == nil)
+    }
+
+    @Test("An uncancelled request still gets its response")
+    func uncancelledRequestResponds() async throws {
+        let server = StructCalculator()
+        let session = Session(id: UUID())
+
+        let request = JSONRPCMessage.request(
+            id: .integer(1),
+            method: "tools/call",
+            params: .object([
+                "name": .string("add"),
+                "arguments": .object(["a": .integer(2), "b": .integer(3)])
+            ])
+        )
+
+        let response = await session.work { _ in await server.handleMessage(request) }
+        #expect(response != nil)
+        #expect(response?.id == .integer(1))
+    }
+
+    @Test("A string request id cancels too")
+    func stringRequestID() async throws {
+        let server = HangingServer()
+        let session = Session(id: UUID())
+
+        let request = JSONRPCMessage.request(
+            id: .string("req-1"),
+            method: "tools/call",
+            params: .object([
+                "name": .string("hang"),
+                "arguments": .object([:])
+            ])
+        )
+
+        let processing = Task {
+            await session.work { _ in await server.handleMessage(request) }
+        }
+
+        #expect(await server.observer.waitUntilStarted())
+
+        let cancelNotification = JSONRPCMessage.notification(
+            method: "notifications/cancelled",
+            params: .object(["requestId": .string("req-1")])
+        )
+        _ = await session.work { _ in await server.handleMessage(cancelNotification) }
+
+        let watchdog = Task {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            processing.cancel()
+        }
+        defer { watchdog.cancel() }
+
+        let response = await processing.value
+        #expect(await server.observer.cancelled)
+        #expect(response == nil)
+    }
+}


### PR DESCRIPTION
Fixes #171 — all sections (§1–§4), audited against `79a527a`.

## TCP+Bonjour transport

**§1 — the fd leak.** `cleanupConnection` dropped the `NWConnection` without `cancel()`; Network.framework only releases the socket (and the self-retained connection object) on cancel, so every inbound connection stranded one descriptor for the process lifetime (2515 fds over 3.5 days in the reporting host). `removeConnection` now cancels **in-actor**, so the three racing teardown paths (receive error, peer EOF, `.failed`) cannot double-act — the second entry removes nothing and is a no-op. `cancel()` rather than `forceCancel()`, so the EOF path's final reply is not truncated.

**§2 — dead listener wedged `run()` forever.** Non-retryable listener failures were log-only: `isRunning` stayed true and `waitUntilStopped()` parked forever, with the Bonjour advertisement already gone. `NWListener` fails *asynchronously*, so `start()` cannot report a bind conflict — the host logged "started" and served nothing. Now: `TransportState.fail(generation:)` stores a terminal error and stops; `run()` rethrows it (generation-guarded so a stale failure cannot kill a successor listener; cleared on restart). Embedders that would rather not die can catch the throw from `run()`.

**§3 — descriptor exhaustion is a hard failure.** Two mechanisms, per the issue: opportunistic (`EMFILE`/`ENFILE` surfacing on a connection escalates to the terminal path) and a proactive watchdog — measured in the issue, a listener under EMFILE stays `.ready` and reports *nothing*, so pressure has to be sampled: `getrlimit(RLIMIT_NOFILE)` + `fcntl(F_GETFD)` scan (not `F_GETPATH`, which is blind to sockets; not `proc_pidinfo`, which reports capacity), 80% threshold, `.critical` log, same terminal path. New `TransportError.resourceExhausted`. `RLIMIT_NOFILE` is not raised.

**§4a — disconnect now cancels in-flight work.** Dispatch tasks are tracked per connection (`ConnectionTaskTracker`, lock-based because it is driven from the connection's serial queue) and cancelled on teardown, so a `while !Task.isCancelled` tool body stops when its client is gone. Separately, `notifications/cancelled` was an explicit no-op — it now cancels the identified request: `handleMessage` runs each request in a task registered on the session by JSON-RPC id, the notification cancels it cooperatively, and the response of an explicitly-cancelled request is suppressed per spec. Parent cancellation (transport teardown) forwards into the same task.

**§4b — accept-after-stop race.** `addConnection` refuses registration when the transport is not running (the caller cancels the connection — every early return on that path must cancel), and the `stateUpdateHandler` is installed before the first suspension so a connection failing during session setup has a cleanup path.

**§4c — unordered line assembly.** Chunks no longer hop into the `LineBuffer` actor (which reordered bytes mid-line and dropped the final unterminated line on every close — the `getRemaining()` race fired deterministically). Assembly is synchronous on the connection's serial queue via a queue-confined `LineFramer`; only dispatch of complete lines leaves the queue, and the EOF task dispatches the final lines before cleanup. `receiveNext` stays outside the dispatch task, as the issue cautions, so server→client requests can't deadlock.

**§4e/§4f/§4g** — `lazy sessionManager` forced on the constructing thread in both inits; `deinit` sweeps `TransportState` (an orphaned listener keeps accepting); TCP keepalive enabled in `createListener` since session expiry is structurally unreachable for TCP (it is driven by SSE hub streams, which TCP never creates).

## HTTP/SSE transport (§4d)

- A failed bind now shuts the adapter's `EventLoopGroup` down before rethrowing (each leak was `System.coreCount` threads + a kqueue fd).
- `start()` is keyed off a *successful* bind and idempotent — a repeated start no longer overwrites `self.adapter` before binding, stranding the live listener unreachable while the new bind fails `EADDRINUSE` against it.
- `stop()` clears the adapter before the throwing shutdown.
- `startKeepAliveTimer` cancels the previous resumed `DispatchSourceTimer` instead of overwriting it.

## Tests (§6)

Verification counts **descriptors, never TCP states**, as the issue prescribes, via the same `fcntl(F_GETFD)` scan:

- `TCPTransportTeardownTests` — 20 connect/close cycles return the process fd count to baseline (polling, tolerance 5 ≪ leak size 20); the final unterminated line is answered on half-close (`SHUT_WR`); a client disconnect cancels a running tool; `run()` throws on an async bind conflict (deterministic §2 repro from the issue — before the fix it parks); `addConnection` refused after `stop()`; `descriptorUsage` sees 20 pipe fds.
- `RequestCancellationTests` — `notifications/cancelled` cancels the in-flight tool and suppresses the response (string and integer ids); unknown ids are a no-op; uncancelled requests still respond.
- `LineFramerTests` — split/multi-line framing, remainder, equivalence with `LineBuffer`.
- `HTTPTransportLifecycleTests` — `start()` idempotent; a failed bind leaves the transport stoppable and restartable.

620 tests in 104 suites pass locally; `swiftlint --strict` clean.

§5 (SwiftMail/Post findings) is cross-repo context and intentionally not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)