### PR TITLE
Apply backpressure in the NIO streaming response writer

### DIFF
--- a/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
+++ b/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
@@ -257,8 +257,19 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
             }
 
             for await chunk in stream {
-                channel.write(HTTPResponsePart.body(channel.allocator.buffer(data: chunk)), promise: nil)
-                channel.flush()
+                // Await each write. Fire-and-forget writes let a fast producer
+                // queue an entire large body in the channel's outbound buffer
+                // while a slow client drains it — memory grows by the full
+                // response size — and writes to a closed channel fail silently,
+                // so the loop would keep pulling the rest of the stream into a
+                // dead connection. A failed write stops the pull, which is what
+                // carries backpressure (and client aborts) to the producer.
+                let buffer = channel.allocator.buffer(data: chunk)
+                do {
+                    try await channel.writeAndFlush(HTTPResponsePart.body(buffer)).get()
+                } catch {
+                    return
+                }
             }
 
             channel.writeAndFlush(HTTPResponsePart.end(nil), promise: nil)


### PR DESCRIPTION
Streaming route responses (`for await chunk in stream`) wrote with `promise: nil`:

1. **No backpressure** — the loop pulls the body stream as fast as NIO queues writes; a slow client viewing a large file makes the server buffer the whole body in memory (observed: ~3 GB RSS oscillation in an Aigent daemon soak streaming a 368 MB TIFF to a 2 MB/s client).
2. **Silent dead-channel writes** — after a client abort, writes fail silently and the loop still drains the entire remaining stream into the closed channel.

Awaiting each `writeAndFlush` bounds outbound buffering to one chunk and makes a failed write stop consumption, which is exactly what propagates backpressure and aborts upstream to pull-based producers.

All 626 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)