### PR TITLE
Bound streaming body memory in both directions of the NIO HTTP adapter

### DIFF
--- a/Sources/SwiftMCP/Transport/Adapters/InboundBodyBuffer.swift
+++ b/Sources/SwiftMCP/Transport/Adapters/InboundBodyBuffer.swift
@@ -1,0 +1,144 @@
+#if Server
+import Foundation
+import NIOConcurrencyHelpers
+
+/// Hands inbound HTTP body chunks from the event loop to a Swift-concurrency
+/// consumer with bounded buffering.
+///
+/// The channel handler ``append(_:)``s chunks synchronously on the event
+/// loop; the route handler consumes ``stream``. When buffered bytes exceed
+/// ``highWatermark`` the buffer pauses channel reads, and resumes them once
+/// the consumer drains below ``lowWatermark`` — TCP flow control then pushes
+/// back on the sender instead of the whole request body queueing in memory.
+///
+/// ``finish()`` ends the stream after the final chunk. ``abort()`` ends it
+/// immediately and discards anything buffered — used when the connection
+/// dies, so a consumer can never park forever on a dead upload.
+final class InboundBodyBuffer: @unchecked Sendable {
+    /// Pause channel reads once this many bytes are buffered.
+    static let highWatermark = 1 << 20
+    /// Resume channel reads once the buffer drains below this many bytes.
+    static let lowWatermark = 256 << 10
+
+    private struct State {
+        var chunks: [Data] = []
+        var bufferedBytes = 0
+        var finished = false
+        var readsPaused = false
+        var waiter: CheckedContinuation<Data?, Never>?
+    }
+
+    private let lock = NIOLock()
+    private var state = State()
+    private let pauseReads: @Sendable () -> Void
+    private let resumeReads: @Sendable () -> Void
+
+    /// Creates a buffer with injectable read control.
+    ///
+    /// - Parameters:
+    ///   - pauseReads: Invoked (off-lock) when the high watermark is crossed.
+    ///   - resumeReads: Invoked (off-lock) when the buffer drains below the
+    ///     low watermark after having been paused.
+    init(
+        pauseReads: @escaping @Sendable () -> Void,
+        resumeReads: @escaping @Sendable () -> Void
+    ) {
+        self.pauseReads = pauseReads
+        self.resumeReads = resumeReads
+    }
+
+    /// The consumer-facing stream. Single consumer.
+    var stream: AsyncStream<Data> {
+        AsyncStream(unfolding: { await self.next() })
+    }
+
+    /// Bytes currently buffered (for tests and diagnostics).
+    var bufferedByteCount: Int {
+        lock.withLock { state.bufferedBytes }
+    }
+
+    // MARK: - Producer side (event loop)
+
+    /// Enqueues a chunk, handing it straight to a parked consumer when one
+    /// is waiting.
+    func append(_ data: Data) {
+        var waiterToResume: CheckedContinuation<Data?, Never>?
+        var crossedHighWatermark = false
+        lock.withLock {
+            guard !state.finished else { return }
+            if let waiter = state.waiter {
+                state.waiter = nil
+                waiterToResume = waiter
+            } else {
+                state.chunks.append(data)
+                state.bufferedBytes += data.count
+                if !state.readsPaused, state.bufferedBytes > Self.highWatermark {
+                    state.readsPaused = true
+                    crossedHighWatermark = true
+                }
+            }
+        }
+        waiterToResume?.resume(returning: data)
+        if crossedHighWatermark {
+            pauseReads()
+        }
+    }
+
+    /// Ends the stream after everything already buffered has been consumed.
+    func finish() {
+        end(discardBuffered: false)
+    }
+
+    /// Ends the stream immediately, discarding buffered chunks.
+    func abort() {
+        end(discardBuffered: true)
+    }
+
+    private func end(discardBuffered: Bool) {
+        var waiterToResume: CheckedContinuation<Data?, Never>?
+        lock.withLock {
+            if discardBuffered {
+                state.chunks.removeAll()
+                state.bufferedBytes = 0
+            }
+            state.finished = true
+            if let waiter = state.waiter {
+                state.waiter = nil
+                waiterToResume = waiter
+            }
+        }
+        waiterToResume?.resume(returning: nil)
+    }
+
+    // MARK: - Consumer side
+
+    private func next() async -> Data? {
+        var shouldResumeReads = false
+        let value: Data? = await withCheckedContinuation { continuation in
+            var immediate: Data??
+            lock.withLock {
+                if !state.chunks.isEmpty {
+                    let chunk = state.chunks.removeFirst()
+                    state.bufferedBytes -= chunk.count
+                    if state.readsPaused, state.bufferedBytes < Self.lowWatermark {
+                        state.readsPaused = false
+                        shouldResumeReads = true
+                    }
+                    immediate = .some(chunk)
+                } else if state.finished {
+                    immediate = .some(nil)
+                } else {
+                    state.waiter = continuation
+                }
+            }
+            if let immediate {
+                continuation.resume(returning: immediate)
+            }
+        }
+        if shouldResumeReads {
+            resumeReads()
+        }
+        return value
+    }
+}
+#endif

--- a/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
+++ b/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
@@ -135,6 +135,10 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias OutboundOut = HTTPResponsePart
 
     private var requestState: RequestState = .idle
+    /// Increments per request head; lets the post-response check recognize
+    /// whether a `.streaming` state still belongs to *its* request or to a
+    /// pipelined successor.
+    private var requestGeneration = 0
     private let engine: any MCPHTTPEngine
     private let logger: Logger
 
@@ -144,11 +148,23 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     func channelInactive(context: ChannelHandlerContext) {
+        abortInFlightRequestBody()
         context.fireChannelInactive()
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
+        abortInFlightRequestBody()
         context.close(promise: nil)
+    }
+
+    /// Ends a mid-request body stream when the connection dies. Without this,
+    /// a handler consuming an upload would wait for the next chunk forever —
+    /// leaking the handler task and everything it holds open.
+    private func abortInFlightRequestBody() {
+        if case .streaming(_, let body, _) = requestState {
+            body.abort()
+        }
+        requestState = .idle
     }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
@@ -175,30 +191,45 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
                 return
             }
 
-            let (stream, continuation) = AsyncStream<Data>.makeStream()
-            requestState = .streaming(head: head, continuation: continuation, bytesWritten: 0)
-            dispatchRoute(context: context, head: head, bodyStream: stream)
+            // Watermarked handoff: pausing reads when the consumer lags lets
+            // TCP flow control push back on the sender, instead of a fast
+            // upload with a slow downstream (e.g. Drive) queueing the entire
+            // body in memory.
+            let channel = context.channel
+            let body = InboundBodyBuffer(
+                pauseReads: {
+                    channel.setOption(ChannelOptions.autoRead, value: false).whenComplete { _ in }
+                },
+                resumeReads: {
+                    channel.setOption(ChannelOptions.autoRead, value: true).whenComplete { _ in
+                        channel.read()
+                    }
+                }
+            )
+            requestState = .streaming(head: head, body: body, bytesWritten: 0)
+            requestGeneration &+= 1
+            dispatchRoute(context: context, head: head, bodyStream: body.stream)
 
-        // BODY — yield chunk into the stream
-        case (.body(let buffer), .streaming(let head, let continuation, let bytesWritten)):
+        // BODY — append chunk to the buffer
+        case (.body(let buffer), .streaming(let head, let body, let bytesWritten)):
             let sizeLimit = engine.maxBodySize(for: head)
             let newTotal = bytesWritten + buffer.readableBytes
             guard newTotal <= sizeLimit else {
                 logger.warning("Rejecting request: body size \(newTotal) > max \(sizeLimit)")
-                continuation.finish()
+                body.abort()
                 rejectOversizedRequest(context: context, limit: sizeLimit)
                 requestState = .rejected
                 return
             }
             if let bytes = buffer.getBytes(at: buffer.readerIndex, length: buffer.readableBytes) {
-                continuation.yield(Data(bytes))
+                body.append(Data(bytes))
             }
-            requestState = .streaming(head: head, continuation: continuation, bytesWritten: newTotal)
+            requestState = .streaming(head: head, body: body, bytesWritten: newTotal)
 
         // END — finish the stream
-        case (.end, .streaming(_, let continuation, _)):
+        case (.end, .streaming(_, let body, _)):
             defer { requestState = .idle }
-            continuation.finish()
+            body.finish()
 
         // Rejection / unexpected states
         case (.body, .rejected), (.end, .rejected):
@@ -219,9 +250,21 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
     private func dispatchRoute(context: ChannelHandlerContext, head: HTTPRequest, bodyStream: AsyncStream<Data>) {
         let channel = context.channel
         let engine = self.engine
+        let generation = requestGeneration
         Task {
             let response = await engine.handle(head: head, bodyStream: bodyStream)
             await self.writeEngineResponse(response, to: channel, engine: engine)
+            // A handler that responded without consuming its body to the end
+            // leaves the connection unresynchronizable (and, with reads
+            // paused at the watermark, wedged). Close it — but only when the
+            // streaming state still belongs to this request, not a pipelined
+            // successor.
+            channel.eventLoop.execute {
+                if case .streaming = self.requestState, self.requestGeneration == generation {
+                    self.abortInFlightRequestBody()
+                    channel.close(promise: nil)
+                }
+            }
         }
     }
 

--- a/Sources/SwiftMCP/Transport/RequestState.swift
+++ b/Sources/SwiftMCP/Transport/RequestState.swift
@@ -4,13 +4,14 @@ import HTTPTypes
 
 /// Represents the state of an HTTP request being processed.
 ///
-/// The state machine always streams body chunks via an `AsyncStream<Data>` continuation.
-/// The dispatch layer decides whether to collect the stream into `Data` (for buffered
-/// handlers) or forward it directly (for streaming handlers).
+/// The state machine always streams body chunks through an
+/// ``InboundBodyBuffer``, which bounds buffering with read watermarks. The
+/// dispatch layer decides whether to collect the stream into `Data` (for
+/// buffered handlers) or forward it directly (for streaming handlers).
 enum RequestState {
     case idle
-    /// Body chunks are being yielded into the continuation.
-    case streaming(head: HTTPRequest, continuation: AsyncStream<Data>.Continuation, bytesWritten: Int)
+    /// Body chunks are being appended to the buffer.
+    case streaming(head: HTTPRequest, body: InboundBodyBuffer, bytesWritten: Int)
     case rejected
 }
 #endif

--- a/Sources/SwiftMCP/Transport/Routing/ChunkedFileReader.swift
+++ b/Sources/SwiftMCP/Transport/Routing/ChunkedFileReader.swift
@@ -1,0 +1,54 @@
+#if Server
+//
+//  ChunkedFileReader.swift
+//  SwiftMCP
+//
+
+import Foundation
+
+/// Reads a file chunk-by-chunk on consumer demand for pull-based streaming.
+///
+/// The file is opened lazily on first demand and closed at end-of-file, on
+/// read failure, and on deallocation — an abandoned stream (client abort)
+/// never leaks the descriptor.
+actor ChunkedFileReader {
+	private let url: URL
+	private let chunkSize: Int
+	private var handle: FileHandle?
+	private var finished = false
+
+	init(url: URL, chunkSize: Int) {
+		self.url = url
+		self.chunkSize = max(chunkSize, 1)
+	}
+
+	deinit {
+		try? handle?.close()
+	}
+
+	/// Returns the next chunk, or `nil` at end-of-file or when the file
+	/// cannot be opened.
+	func next() -> Data? {
+		if finished {
+			return nil
+		}
+
+		if handle == nil {
+			guard let opened = try? FileHandle(forReadingFrom: url) else {
+				finished = true
+				return nil
+			}
+			handle = opened
+		}
+
+		let chunk = handle?.readData(ofLength: chunkSize) ?? Data()
+		if chunk.isEmpty {
+			finished = true
+			try? handle?.close()
+			handle = nil
+			return nil
+		}
+		return chunk
+	}
+}
+#endif

--- a/Sources/SwiftMCP/Transport/Routing/HTTPRouteResponse+Stream.swift
+++ b/Sources/SwiftMCP/Transport/Routing/HTTPRouteResponse+Stream.swift
@@ -14,28 +14,18 @@ import HTTPTypes
 extension HTTPRouteResponse where Body == AsyncStream<Data> {
 
 	/// Stream a file from disk in chunks.
+	///
+	/// The stream is pull-based: each chunk is read only when the consumer
+	/// demands the next element. An eager producer would queue the entire
+	/// file into the stream whenever the client drains slower than disk
+	/// reads — body-sized memory growth that consumer-side backpressure
+	/// cannot prevent.
 	public static func file(_ url: URL, contentType: String, chunkSize: Int = 65536) -> Self {
-		let (stream, continuation) = AsyncStream<Data>.makeStream()
-
-		// Read the file in a background task
-		Task {
-			defer { continuation.finish() }
-			guard let handle = try? FileHandle(forReadingFrom: url) else {
-				return
-			}
-			defer { try? handle.close() }
-
-			while true {
-				let chunk = handle.readData(ofLength: chunkSize)
-				if chunk.isEmpty { break }
-				continuation.yield(chunk)
-			}
-		}
-
+		let reader = ChunkedFileReader(url: url, chunkSize: chunkSize)
 		return HTTPRouteResponse(
 			status: .ok,
 			headerFields: [.contentType: contentType],
-			body: stream
+			body: AsyncStream(unfolding: { await reader.next() })
 		)
 	}
 

--- a/Tests/SwiftMCPTests/FileResponseStreamingTests.swift
+++ b/Tests/SwiftMCPTests/FileResponseStreamingTests.swift
@@ -1,0 +1,60 @@
+#if Server
+import Foundation
+import Testing
+
+@testable import SwiftMCP
+
+@Suite("File response streaming")
+struct FileResponseStreamingTests {
+
+    private func makeTempFile(bytes: Int) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftmcp-file-response-\(UUID().uuidString).bin")
+        var data = Data(capacity: bytes)
+        var seed: UInt8 = 0
+        for _ in 0..<bytes {
+            data.append(seed)
+            seed &+= 1
+        }
+        try data.write(to: url)
+        return url
+    }
+
+    @Test("Streamed content matches the file byte-for-byte")
+    func contentIntegrity() async throws {
+        let url = try makeTempFile(bytes: 300_000)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let response = HTTPRouteResponse<AsyncStream<Data>>.file(
+            url, contentType: "application/octet-stream", chunkSize: 4096)
+
+        var received = Data()
+        for await chunk in response.body {
+            // Chunks must respect the requested size — the pull-based reader
+            // never hands out more than one chunk per demand.
+            #expect(chunk.count <= 4096)
+            received.append(chunk)
+        }
+        #expect(received == (try Data(contentsOf: url)))
+    }
+
+    @Test("The file is opened lazily, on first demand")
+    func lazyOpen() async throws {
+        let url = try makeTempFile(bytes: 1024)
+
+        let response = HTTPRouteResponse<AsyncStream<Data>>.file(
+            url, contentType: "application/octet-stream")
+
+        // Delete the file before any consumption. An eager producer would
+        // already have opened (and begun reading) it; the pull-based reader
+        // must come up empty instead of serving a half-read body.
+        try FileManager.default.removeItem(at: url)
+
+        var received = Data()
+        for await chunk in response.body {
+            received.append(chunk)
+        }
+        #expect(received.isEmpty)
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/InboundBodyBufferTests.swift
+++ b/Tests/SwiftMCPTests/InboundBodyBufferTests.swift
@@ -1,0 +1,142 @@
+#if Server
+import Foundation
+import Testing
+
+@testable import SwiftMCP
+
+@Suite("Inbound body buffer")
+struct InboundBodyBufferTests {
+
+    private final class WatermarkRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _pauses = 0
+        private var _resumes = 0
+
+        var pauses: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _pauses
+        }
+        var resumes: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _resumes
+        }
+        func pause() {
+            lock.lock()
+            _pauses += 1
+            lock.unlock()
+        }
+        func resume() {
+            lock.lock()
+            _resumes += 1
+            lock.unlock()
+        }
+    }
+
+    private func makeBuffer(recorder: WatermarkRecorder) -> InboundBodyBuffer {
+        InboundBodyBuffer(
+            pauseReads: { recorder.pause() },
+            resumeReads: { recorder.resume() }
+        )
+    }
+
+    @Test("Chunks flow through in order and the stream ends on finish")
+    func chunksFlowInOrder() async {
+        let buffer = makeBuffer(recorder: WatermarkRecorder())
+        let chunks = [Data([1, 2]), Data([3]), Data([4, 5, 6])]
+        for chunk in chunks {
+            buffer.append(chunk)
+        }
+        buffer.finish()
+
+        var received: [Data] = []
+        for await chunk in buffer.stream {
+            received.append(chunk)
+        }
+        #expect(received == chunks)
+    }
+
+    @Test("A parked consumer is resumed by the next append")
+    func parkedConsumerResumes() async {
+        let buffer = makeBuffer(recorder: WatermarkRecorder())
+
+        let consumer = Task { () -> Data? in
+            var iterator = buffer.stream.makeAsyncIterator()
+            return await iterator.next()
+        }
+        // Give the consumer a moment to park on the empty buffer.
+        try? await Task.sleep(for: .milliseconds(50))
+        buffer.append(Data([9]))
+
+        let received = await consumer.value
+        #expect(received == Data([9]))
+    }
+
+    @Test("Exceeding the high watermark pauses reads; draining resumes them")
+    func watermarksPauseAndResumeReads() async {
+        let recorder = WatermarkRecorder()
+        let buffer = makeBuffer(recorder: recorder)
+
+        // Fill past the high watermark without a consumer.
+        let chunk = Data(repeating: 0, count: 256 << 10)
+        for _ in 0..<5 {  // 5 × 256 KiB = 1.25 MiB > 1 MiB high watermark
+            buffer.append(chunk)
+        }
+        #expect(recorder.pauses == 1)
+        #expect(recorder.resumes == 0)
+
+        // Drain below the low watermark (256 KiB): after consuming all five
+        // chunks the buffer is empty, which is below any watermark.
+        var iterator = buffer.stream.makeAsyncIterator()
+        for _ in 0..<5 {
+            _ = await iterator.next()
+        }
+        #expect(recorder.resumes == 1)
+        // No repeated pause/resume churn for a single crossing.
+        #expect(recorder.pauses == 1)
+    }
+
+    @Test("Abort ends the stream immediately for a parked consumer")
+    func abortUnparksConsumer() async {
+        let buffer = makeBuffer(recorder: WatermarkRecorder())
+
+        let consumer = Task { () -> Data? in
+            var iterator = buffer.stream.makeAsyncIterator()
+            return await iterator.next()
+        }
+        try? await Task.sleep(for: .milliseconds(50))
+        buffer.abort()
+
+        let received = await consumer.value
+        #expect(received == nil)
+    }
+
+    @Test("Abort discards buffered chunks")
+    func abortDiscardsBuffered() async {
+        let buffer = makeBuffer(recorder: WatermarkRecorder())
+        buffer.append(Data([1]))
+        buffer.append(Data([2]))
+        buffer.abort()
+
+        var iterator = buffer.stream.makeAsyncIterator()
+        let received = await iterator.next()
+        #expect(received == nil)
+        #expect(buffer.bufferedByteCount == 0)
+    }
+
+    @Test("Appends after finish are ignored")
+    func appendAfterFinishIgnored() async {
+        let buffer = makeBuffer(recorder: WatermarkRecorder())
+        buffer.append(Data([1]))
+        buffer.finish()
+        buffer.append(Data([2]))
+
+        var received: [Data] = []
+        for await chunk in buffer.stream {
+            received.append(chunk)
+        }
+        #expect(received == [Data([1])])
+    }
+}
+#endif


### PR DESCRIPTION
Follow-up to #173, addressing the [Codex P1 review finding](https://github.com/Cocoanetics/SwiftMCP/pull/173#pullrequestreview-comment) and two adjacent defects discovered while fixing it.

## What was wrong

1. **`HTTPRouteResponse.file` producer was unbounded** (the review finding): a background task synchronously read the entire file into the `AsyncStream`. The awaited writes from #173 throttle only the consumer — the queued data merely moved from NIO's outbound buffer into the stream. Now pull-based: `ChunkedFileReader` opens lazily on first demand, hands out one chunk per demand, and closes on EOF and abandonment.

2. **Inbound request bodies were equally unbounded**: `channelRead` yielded chunks into an unbounded stream with no read management. A client uploading faster than the route handler consumes (a server relaying to a slower upstream) queued up to the entire body in memory. Chunks now flow through `InboundBodyBuffer` with watermarks — channel reads pause above 1 MiB buffered and resume below 256 KiB, so TCP flow control throttles the sender.

3. **A connection dying mid-body never finished the stream** — the consuming handler awaited the next chunk forever, leaking its task and whatever it held open. `channelInactive`/`errorCaught` now abort the in-flight body.

4. **Unconsumed bodies could wedge keep-alive**: a handler responding without draining its body leaves the connection unresynchronizable (and with paused reads, stalled). Such connections are closed after the response, generation-guarded so a pipelined successor request is never hit by mistake.

## Tests

8 new tests (`InboundBodyBufferTests`, `FileResponseStreamingTests`): ordering, parked-consumer resume, watermark pause/resume counts, abort-unparks-consumer, abort-discards-buffer, append-after-finish, file content integrity, lazy open. Full suite: **634 tests in 108 suites pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)