### PR TITLE
Suppress handler responses for aborted request bodies (server-killing double response)

### DIFF
--- a/Sources/SwiftMCP/Transport/Adapters/InboundBodyBuffer.swift
+++ b/Sources/SwiftMCP/Transport/Adapters/InboundBodyBuffer.swift
@@ -24,6 +24,7 @@ final class InboundBodyBuffer: @unchecked Sendable {
         var chunks: [Data] = []
         var bufferedBytes = 0
         var finished = false
+        var aborted = false
         var readsPaused = false
         var waiter: CheckedContinuation<Data?, Never>?
     }
@@ -55,6 +56,18 @@ final class InboundBodyBuffer: @unchecked Sendable {
     /// Bytes currently buffered (for tests and diagnostics).
     var bufferedByteCount: Int {
         lock.withLock { state.bufferedBytes }
+    }
+
+    /// Whether the body was aborted (oversize rejection, dead connection).
+    ///
+    /// When `true`, the channel-read layer owns the connection's fate — it
+    /// has already answered (413) or the peer is gone. The dispatched route
+    /// handler must not write a response of its own: a second response for
+    /// the same request trips NIO's HTTP pipeline handler `fatalError`
+    /// ("Unexpectedly received a response in state idle") and kills the
+    /// process.
+    var wasAborted: Bool {
+        lock.withLock { state.aborted }
     }
 
     // MARK: - Producer side (event loop)
@@ -100,6 +113,7 @@ final class InboundBodyBuffer: @unchecked Sendable {
             if discardBuffered {
                 state.chunks.removeAll()
                 state.bufferedBytes = 0
+                state.aborted = true
             }
             state.finished = true
             if let waiter = state.waiter {

--- a/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
+++ b/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
@@ -208,7 +208,7 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
             )
             requestState = .streaming(head: head, body: body, bytesWritten: 0)
             requestGeneration &+= 1
-            dispatchRoute(context: context, head: head, bodyStream: body.stream)
+            dispatchRoute(context: context, head: head, body: body)
 
         // BODY — append chunk to the buffer
         case (.body(let buffer), .streaming(let head, let body, let bytesWritten)):
@@ -247,12 +247,17 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
 
     // MARK: - Dispatch
 
-    private func dispatchRoute(context: ChannelHandlerContext, head: HTTPRequest, bodyStream: AsyncStream<Data>) {
+    private func dispatchRoute(context: ChannelHandlerContext, head: HTTPRequest, body: InboundBodyBuffer) {
         let channel = context.channel
         let engine = self.engine
         let generation = requestGeneration
         Task {
-            let response = await engine.handle(head: head, bodyStream: bodyStream)
+            let response = await engine.handle(head: head, bodyStream: body.stream)
+            // An aborted body means the channel-read layer owns the
+            // connection: it already answered (413 oversize) or the peer is
+            // gone. Writing a second response for the same request trips
+            // NIO's pipeline handler `fatalError` and kills the process.
+            guard !body.wasAborted else { return }
             await self.writeEngineResponse(response, to: channel, engine: engine)
             // A handler that responded without consuming its body to the end
             // leaves the connection unresynchronizable (and, with reads

--- a/Tests/SwiftMCPTests/OversizedStreamedBodyTests.swift
+++ b/Tests/SwiftMCPTests/OversizedStreamedBodyTests.swift
@@ -1,0 +1,64 @@
+#if Server
+import Foundation
+import Testing
+
+@testable import SwiftMCP
+
+@Suite("Oversized streamed request bodies")
+struct OversizedStreamedBodyTests {
+
+    /// A chunked upload that exceeds `maxMessageSize` mid-stream is rejected
+    /// with 413 — and, crucially, the already-dispatched route handler must
+    /// not write a second response for the same request. That double
+    /// response trips NIO's HTTP pipeline handler `fatalError`
+    /// ("Unexpectedly received a response in state idle") and killed the
+    /// whole server process before the `wasAborted` suppression existed.
+    @Test("Server survives a chunked body exceeding the limit mid-stream")
+    func serverSurvivesOversizedChunkedBody() async throws {
+        #if canImport(FoundationNetworking)
+        return
+        #else
+        let (transport, baseURL) = try await HTTPTransportTestHelpers.startTransport()
+        defer { Task { try? await transport.stop() } }
+
+        let mcpURL = baseURL.appendingPathComponent("mcp")
+
+        // Stream 2 MiB against a 1 MiB limit with no Content-Length, so the
+        // precheck cannot reject it and the oversize trips mid-body while
+        // the dispatched handler is already consuming the stream.
+        transport.maxMessageSize = 1 << 20
+
+        var request = URLRequest(url: mcpURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+        request.httpBodyStream = InputStream(data: Data(repeating: 0x20, count: 2 << 20))
+
+        let session = URLSession(configuration: .ephemeral)
+        do {
+            let (_, response) = try await session.data(for: request)
+            let httpResponse = try #require(response as? HTTPURLResponse)
+            #expect(httpResponse.statusCode == 413)
+        } catch {
+            // Also acceptable: the server closes the connection while the
+            // client still has body to send, surfacing as a transport error.
+        }
+
+        // The server must still be alive and serving. Before the fix this
+        // request never got an answer — the process had already died on the
+        // pipeline fatalError.
+        transport.maxMessageSize = 4 * 1024 * 1024
+        var sanity = URLRequest(url: mcpURL)
+        sanity.httpMethod = "POST"
+        sanity.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        sanity.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+        sanity.httpBody = try JSONEncoder().encode(
+            HTTPTransportTestHelpers.initializeRequest(id: 1))
+
+        let (_, aliveResponse) = try await session.data(for: sanity)
+        let aliveHTTP = try #require(aliveResponse as? HTTPURLResponse)
+        #expect(aliveHTTP.statusCode == 200)
+        #endif
+    }
+}
+#endif


### PR DESCRIPTION
Found by live abuse-testing the daemon embedding #174: three chunked POSTs exceeding `maxMessageSize` killed the server with NIO's `HTTPServerPipelineHandler.swift:573: Fatal error: Unexpectedly received a response in state idle`.

**Root cause — a double response for one request:** on mid-stream oversize, `channelRead` writes the 413 and closes, but the already-dispatched route handler also produces a response for the same request. The pipeline handler's request/response accounting fatalErrors on the second head. The race predates the inbound buffer rework — the old path `finish()`ed the stream and the engine still responded; `abort()` discarding buffered chunks just made the engine's (suppressed-parse) response fast enough to hit the live channel deterministically.

**Impact in the wild:** any client POSTing a body over the limit without an honest Content-Length could kill the entire server — e.g. a legacy base64 `uploadImage` call for an image whose encoding exceeds the MCP message limit. This matches the "login, then boom" reports in Aigent#507.

**Fix:** `InboundBodyBuffer.abort()` marks the body; the dispatch task checks `wasAborted` after the engine returns and drops its response — the channel-read layer already answered (413) or the peer is gone.

**Test:** streams a chunked 2 MiB body against a 1 MiB limit (no Content-Length, so the precheck can't catch it), expects 413/connection-error, then proves the server still answers a normal initialize. Full suite: 635 tests in 109 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)