### PR TITLE
Fix the session-expiry race that failed the release CI run

### DIFF
--- a/Tests/SwiftMCPTests/HTTPTransportOpenAPITests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportOpenAPITests.swift
@@ -65,21 +65,7 @@ struct HTTPTransportOpenAPITests {
         )
 
         let capture = HTTPTransportTestHelpers.openStreamingRequest(
-            try HTTPTransportTestHelpers.streamablePOSTRequest(
-                url: url,
-                message: .request(
-                    id: 9,
-                    method: "tools/call",
-                    params: [
-                        "name": .string("slowPing"),
-                        "arguments": .object([:]),
-                        "_meta": .object([
-                            "progressToken": .string("expiring-request")
-                        ])
-                    ]
-                ),
-                sessionID: sessionID
-            ),
+            try Self.slowPingRequest(url: url, sessionID: sessionID),
             urlSession: sharedSession
         )
 
@@ -113,6 +99,26 @@ struct HTTPTransportOpenAPITests {
         #expect((response as! HTTPURLResponse).statusCode == 404)
         #endif
     }
+
+    #if !canImport(FoundationNetworking)
+    private static func slowPingRequest(url: URL, sessionID: String) throws -> URLRequest {
+        try HTTPTransportTestHelpers.streamablePOSTRequest(
+            url: url,
+            message: .request(
+                id: 9,
+                method: "tools/call",
+                params: [
+                    "name": .string("slowPing"),
+                    "arguments": .object([:]),
+                    "_meta": .object([
+                        "progressToken": .string("expiring-request")
+                    ])
+                ]
+            ),
+            sessionID: sessionID
+        )
+    }
+    #endif
 
     @Test("OPTIONS returns CORS headers")
     func corsHeaders() async throws {

--- a/Tests/SwiftMCPTests/HTTPTransportOpenAPITests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportOpenAPITests.swift
@@ -48,12 +48,21 @@ struct HTTPTransportOpenAPITests {
         #else
         let (transport, baseURL) = try await HTTPTransportTestHelpers.startTransport(
             server: ResumableServer(),
-            retentionInterval: 0.2
+            retentionInterval: 1.0
         )
         defer { Task { try? await transport.stop() } }
 
         let url = baseURL.appendingPathComponent("mcp")
-        let (sessionID, _) = try await HTTPTransportTestHelpers.initializeSession(url: url)
+        // One warm URLSession for the whole test: the retention interval doubles
+        // as the idle-session TTL, so the gap between `initialize` completing and
+        // the tool POST arriving must stay well under it. A cold ephemeral
+        // URLSession can burn more than that just spinning up on a loaded CI
+        // runner; reusing the keep-alive connection keeps the gap at
+        // request-turnaround scale.
+        let sharedSession = URLSession(configuration: .ephemeral)
+        let (sessionID, _) = try await HTTPTransportTestHelpers.initializeSession(
+            url: url, urlSession: sharedSession
+        )
 
         let capture = HTTPTransportTestHelpers.openStreamingRequest(
             try HTTPTransportTestHelpers.streamablePOSTRequest(
@@ -70,7 +79,8 @@ struct HTTPTransportOpenAPITests {
                     ]
                 ),
                 sessionID: sessionID
-            )
+            ),
+            urlSession: sharedSession
         )
 
         // Wait for the response head separately from the first event so each
@@ -79,6 +89,11 @@ struct HTTPTransportOpenAPITests {
             capture.response.value != nil
         }
         try #require(connected, "SSE response head never arrived — the POST never reached dispatch")
+        let status = try #require(capture.response.value?.statusCode)
+        try #require(
+            status == 200,
+            "tool POST rejected with \(status) — the session expired before the request arrived"
+        )
 
         let sawProgress = await HTTPTransportTestHelpers.waitForCondition {
             HTTPTransportTestHelpers.notificationEvent(capture.events.value, method: "notifications/progress") != nil
@@ -87,13 +102,14 @@ struct HTTPTransportOpenAPITests {
         let lastEventID = try #require(capture.events.value.last?.id)
         capture.task.cancel()
 
-        try? await Task.sleep(nanoseconds: 700_000_000)
+        // Sleep comfortably past the retention interval. Oversleeping is safe:
+        // extra delay only makes the expiry below more certain.
+        try? await Task.sleep(nanoseconds: 3_000_000_000)
 
-        let session = URLSession(configuration: .ephemeral)
         let resumeRequest = HTTPTransportTestHelpers.generalSSERequest(
             url: url, sessionID: sessionID, lastEventID: lastEventID
         )
-        let (_, response) = try await session.data(for: resumeRequest)
+        let (_, response) = try await sharedSession.data(for: resumeRequest)
         #expect((response as! HTTPURLResponse).statusCode == 404)
         #endif
     }

--- a/Tests/SwiftMCPTests/HTTPTransportOpenAPITests.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportOpenAPITests.swift
@@ -73,6 +73,13 @@ struct HTTPTransportOpenAPITests {
             )
         )
 
+        // Wait for the response head separately from the first event so each
+        // phase gets its own budget and a failure names the phase that stalled.
+        let connected = await HTTPTransportTestHelpers.waitForCondition {
+            capture.response.value != nil
+        }
+        try #require(connected, "SSE response head never arrived — the POST never reached dispatch")
+
         let sawProgress = await HTTPTransportTestHelpers.waitForCondition {
             HTTPTransportTestHelpers.notificationEvent(capture.events.value, method: "notifications/progress") != nil
         }

--- a/Tests/SwiftMCPTests/HTTPTransportTestHelpers.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTestHelpers.swift
@@ -119,9 +119,11 @@ enum HTTPTransportTestHelpers {
         return request
     }
 
-    static func readFiniteSSEResponse(_ request: URLRequest) async throws -> (HTTPURLResponse, [SSEClientMessage]) {
-        let session = URLSession(configuration: .ephemeral)
-        let (bytes, response) = try await session.bytes(for: request)
+    static func readFiniteSSEResponse(
+        _ request: URLRequest,
+        urlSession: URLSession = URLSession(configuration: .ephemeral)
+    ) async throws -> (HTTPURLResponse, [SSEClientMessage]) {
+        let (bytes, response) = try await urlSession.bytes(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw TestError("Expected HTTPURLResponse")
         }
@@ -134,13 +136,15 @@ enum HTTPTransportTestHelpers {
         return (httpResponse, events)
     }
 
-    static func openStreamingRequest(_ request: URLRequest) -> HTTPTransportStreamCapture {
+    static func openStreamingRequest(
+        _ request: URLRequest,
+        urlSession: URLSession = URLSession(configuration: .ephemeral)
+    ) -> HTTPTransportStreamCapture {
         let responseBox = HTTPTransportBox<HTTPURLResponse?>(nil)
         let eventsBox = HTTPTransportBox<[SSEClientMessage]>([])
 
         let task = Task {
-            let session = URLSession(configuration: .ephemeral)
-            let (bytes, response) = try await session.bytes(for: request)
+            let (bytes, response) = try await urlSession.bytes(for: request)
             responseBox.value = response as? HTTPURLResponse
             for try await message in bytes.lines.sseMessages() {
                 eventsBox.modify { $0.append(message) }
@@ -177,9 +181,12 @@ enum HTTPTransportTestHelpers {
         return condition()
     }
 
-    static func initializeSession(url: URL) async throws -> (String, [SSEClientMessage]) {
+    static func initializeSession(
+        url: URL,
+        urlSession: URLSession = URLSession(configuration: .ephemeral)
+    ) async throws -> (String, [SSEClientMessage]) {
         let request = try streamablePOSTRequest(url: url, message: initializeRequest())
-        let (response, events) = try await readFiniteSSEResponse(request)
+        let (response, events) = try await readFiniteSSEResponse(request, urlSession: urlSession)
         guard let sessionID = response.value(forHTTPHeaderField: "Mcp-Session-Id") else {
             throw TestError("Expected Mcp-Session-Id header")
         }

--- a/Tests/SwiftMCPTests/HTTPTransportTestHelpers.swift
+++ b/Tests/SwiftMCPTests/HTTPTransportTestHelpers.swift
@@ -24,9 +24,26 @@ struct HTTPTransportStreamCapture {
 }
 
 /// Thread-safe box for capturing values from @Sendable closures.
+///
+/// The lock is load-bearing: the URLSession task appends events while
+/// `waitForCondition` polls from another thread, so unsynchronized access
+/// is a data race (and can hide appended events from the poller).
 final class HTTPTransportBox<T: Sendable>: @unchecked Sendable {
-    var value: T
-    init(_ value: T) { self.value = value }
+    private let lock = NSLock()
+    private var storage: T
+
+    init(_ value: T) { storage = value }
+
+    var value: T {
+        get { lock.lock(); defer { lock.unlock() }; return storage }
+        set { lock.lock(); defer { lock.unlock() }; storage = newValue }
+    }
+
+    func modify(_ body: (inout T) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        body(&storage)
+    }
 }
 
 enum HTTPTransportTestHelpers {
@@ -126,7 +143,7 @@ enum HTTPTransportTestHelpers {
             let (bytes, response) = try await session.bytes(for: request)
             responseBox.value = response as? HTTPURLResponse
             for try await message in bytes.lines.sseMessages() {
-                eventsBox.value.append(message)
+                eventsBox.modify { $0.append(message) }
             }
         }
 
@@ -140,10 +157,13 @@ enum HTTPTransportTestHelpers {
     /// event latency. It is sized generously because every caller is a positive
     /// wait racing real localhost networking (URLSession cold start + TCP connect
     /// + SSE delivery), which can far exceed a tight bound on a loaded CI runner —
-    /// a 2s deadline made `expiredRequestStreamResume` flake on macos-latest.
+    /// a 2s deadline made `expiredRequestStreamResume` flake on macos-latest,
+    /// and a 15s one lost to a ~13s whole-VM starvation stall on the same
+    /// runner image (the deadline is monotonic, so it keeps counting while
+    /// nothing — including the server under test — gets scheduled).
     /// Do NOT use this helper to assert a condition *stays* false.
     static func waitForCondition(
-        timeoutNanoseconds: UInt64 = 15_000_000_000,
+        timeoutNanoseconds: UInt64 = 30_000_000_000,
         pollNanoseconds: UInt64 = 50_000_000,
         _ condition: @escaping @Sendable () -> Bool
     ) async -> Bool {


### PR DESCRIPTION
`build-macos` failed twice in a row on the v1.10.2 release commit in `expiredRequestStreamResume` ("Resumable request streams expire after the retention interval"): zero SSE events, 15 s poll timeout, nothing in the server log. The second consecutive failure ruled out runner weather, and the root cause turned out to be a genuine race — in the test's design, not the shipped code.

## Root cause

`retentionInterval` feeds two clocks: the resumable-stream buffer **and** the idle-session TTL (`SessionManager.updateSessionExpiry` sets `expiresAt = lastActivity + retentionInterval` whenever a session has no active streams). The test configured 0.2 s to exercise stream expiry — which also meant the session died 200 ms after `initialize`'s finite stream closed.

The tool POST was then issued from a **cold ephemeral URLSession**; spinning one up plus a TCP connect routinely exceeds 200 ms on a loaded macos-latest runner. By the time the POST arrived, `resolveSessionHeader` → `hasSession` → `cleanupExpiredState` had destroyed the session, so the request resolved to `.unknown` and got the silent `text/plain` 404 ("Unknown session. Send initialize first.") — a response with zero SSE events and no log line. The old test only polled for progress events, so this surfaced as a mute 15 s timeout. Locally the gap is ~1 ms, which is why it never reproduced off CI.

**Diagnosis proven by experiment:** restoring 0.2 s and inserting a 400 ms sleep before the POST reproduces the CI failure deterministically — now caught by the new assertion in 0.5 s: `tool POST rejected with 404 — the session expired before the request arrived`.

## Fix (test-side)

- **One warm URLSession across `initialize` and the tool POST** — the gap becomes a request turnaround on a live keep-alive connection instead of a cold start.
- **Interval 0.2 s → 1.0 s, expiry sleep 0.7 s → 3.0 s.** Oversleeping is safe: extra delay only makes the expected expiry more certain; the assertions' failure direction is starvation-proof.
- **Assert the POST's status is 200** as soon as the response head arrives, so any residual race fails in milliseconds with a named cause instead of a silent timeout.

## Also in this PR (first commit)

- `HTTPTransportBox` gets a real lock — the URLSession task appended events while `waitForCondition` polled from another thread, an honest data race.
- The test waits in two named phases (response head, then first event), each with its own budget.
- `waitForCondition`'s default failure bound goes 15 s → 30 s (it returns the moment the condition holds, so healthy runs pay only actual latency).

Full suite locally: **636 tests in 109 suites pass**; the fixed test runs in ~3.3 s (dominated by the deliberate expiry sleep).

The v1.10.2 release itself is unaffected: the shipped server behaves exactly as configured; the race lived in the test's 200 ms TTL meeting real network latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)