### PR TITLE
Reclaim never-bound SSE streams and stop dropping broadcasts silently

### DIFF
--- a/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
+++ b/Sources/SwiftMCP/Transport/Adapters/NIOHTTPServerAdapter.swift
@@ -257,7 +257,15 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
             // connection: it already answered (413 oversize) or the peer is
             // gone. Writing a second response for the same request trips
             // NIO's pipeline handler `fatalError` and kills the process.
-            guard !body.wasAborted else { return }
+            guard !body.wasAborted else {
+                // The discarded response may carry an SSE stream the engine
+                // already opened (and, for a general stream, promoted to the
+                // session's primary). Nothing will ever drain or bind it, so
+                // hand it back for reconciliation instead of leaking a
+                // routable-looking stream that black-holes routed sends.
+                await Self.reconcileDiscardedResponse(response, engine: engine)
+                return
+            }
             await self.writeEngineResponse(response, to: channel, engine: engine)
             // A handler that responded without consuming its body to the end
             // leaves the connection unresynchronizable (and, with reads
@@ -270,6 +278,21 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
                     channel.close(promise: nil)
                 }
             }
+        }
+    }
+
+    /// Reconcile the engine's SSE state for a response that is being discarded
+    /// unwritten. Registering the (already dead) connection makes the engine's
+    /// liveness guard reject it and start the stream's retention clock, so the
+    /// stream — and any primary-general claim it holds — expires normally
+    /// instead of surviving as an undrained, never-expiring black hole.
+    private static func reconcileDiscardedResponse(
+        _ response: EngineResponse,
+        engine: any MCPHTTPEngine
+    ) async {
+        guard case .sse(_, let registration) = response.body, let registration else { return }
+        if let token = await engine.registerConnection(DeadSSEConnection(), for: registration) {
+            await engine.connectionDisconnected(token)
         }
     }
 
@@ -316,6 +339,19 @@ final class NIOHTTPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
                 do {
                     try await channel.writeAndFlush(HTTPResponsePart.body(buffer)).get()
                 } catch {
+                    // A failed write means this response can no longer reach
+                    // the client — but not necessarily that the socket died
+                    // (a pipeline or encoder state error fails the write and
+                    // leaves the connection open). Close it so the client
+                    // reconnects and `closeFuture` reconciles the engine's
+                    // stream state; returning without closing leaves an
+                    // ESTABLISHED connection whose stream nobody drains, and
+                    // every later send "succeeds" into that void. Gated on
+                    // liveness: a write that failed because the channel (or
+                    // its event loop) is already going down needs no close.
+                    if channel.isActive {
+                        channel.close(promise: nil)
+                    }
                     return
                 }
             }
@@ -343,5 +379,13 @@ final class NIOSSEConnection: SSEConnection {
     init(channel: Channel) { self.channel = channel }
     var isConnected: Bool { channel.isActive }
     func terminate() { channel.close(promise: nil) }
+}
+
+/// A never-connected ``SSEConnection``, used to reconcile SSE streams whose
+/// response was discarded before any connection could bind.
+final class DeadSSEConnection: SSEConnection {
+    init() {}
+    var isConnected: Bool { false }
+    func terminate() {}
 }
 #endif

--- a/Sources/SwiftMCP/Transport/SessionManager+Broadcasting.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+Broadcasting.swift
@@ -53,16 +53,52 @@ extension SessionManager {
     }
 
     /// Send a resource-updated notification to all sessions subscribed to the given URI.
+    ///
+    /// Routing failures are counted and logged (once per session per outage): a
+    /// subscribed session with no routable general stream used to drop the
+    /// notification without a trace, leaving a healthy-looking session that
+    /// never receives another push (the zombie-session incident).
     func broadcastResourceUpdated(uri: URL) async {
         await cleanupExpiredState()
         let uriString = uri.absoluteString
         for session in sessions.values {
-            let subscribed = await session.isSubscribedToResource(uri: uriString)
-            if subscribed {
-                await session.work { session in
-                    try? await session.sendResourceUpdated(uri: uri)
-                }
+            guard await session.isSubscribedToResource(uri: uriString) else { continue }
+
+            let notification = JSONRPCMessage.notification(
+                method: "notifications/resources/updated",
+                params: ["uri": .string(uriString)]
+            )
+            let routed = await routeJSONRPC(notification, sessionID: session.id)
+            recordResourceUpdatedOutcome(routed: routed, sessionID: session.id, uri: uriString)
+        }
+    }
+
+    /// Encode and route a JSON-RPC message to the session's primary general
+    /// stream, reporting whether any stream accepted it.
+    @discardableResult
+    internal func routeJSONRPC(_ message: JSONRPCMessage, sessionID: UUID) async -> Bool {
+        guard let data = try? JSONRPCMessage.makeEncoder().encode(message),
+              let text = String(data: data, encoding: .utf8) else {
+            return false
+        }
+        return await routeSSEMessage(SSEMessage(data: text), sessionID: sessionID, preferredStreamID: nil)
+    }
+
+    /// Track per-session delivery of resource-updated broadcasts, logging the
+    /// transitions (first drop, later recovery) rather than every occurrence.
+    private func recordResourceUpdatedOutcome(routed: Bool, sessionID: UUID, uri: String) {
+        if routed {
+            if sessionsWithUndeliverableBroadcast.remove(sessionID) != nil {
+                logger.info("resource-updated delivery recovered for session \(sessionID)")
             }
+            return
+        }
+
+        undeliverableBroadcastCount += 1
+        if sessionsWithUndeliverableBroadcast.insert(sessionID).inserted {
+            let details = "resource-updated for \(uri) dropped: session \(sessionID) is subscribed"
+                + " but has no routable general SSE stream; dropping until one (re)connects"
+            logger.warning("\(details)")
         }
     }
 
@@ -85,6 +121,7 @@ extension SessionManager {
         }
 
         guard let primaryStreamID = primaryGeneralStreamIDs[sessionID] else {
+            logger.debug("No primary general stream for session \(sessionID); SSE message not routed")
             return false
         }
 

--- a/Sources/SwiftMCP/Transport/SessionManager+Broadcasting.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+Broadcasting.swift
@@ -54,40 +54,52 @@ extension SessionManager {
 
     /// Send a resource-updated notification to all sessions subscribed to the given URI.
     ///
-    /// Routing failures are counted and logged (once per session per outage): a
-    /// subscribed session with no routable general stream used to drop the
-    /// notification without a trace, leaving a healthy-looking session that
-    /// never receives another push (the zombie-session incident).
+    /// Delivery failures are counted and logged (once per session per outage): a
+    /// subscribed session the notification cannot reach used to drop it without
+    /// a trace, leaving a healthy-looking session that never receives another
+    /// push (the zombie-session incident).
     func broadcastResourceUpdated(uri: URL) async {
         await cleanupExpiredState()
         let uriString = uri.absoluteString
         for session in sessions.values {
             guard await session.isSubscribedToResource(uri: uriString) else { continue }
-
-            let notification = JSONRPCMessage.notification(
-                method: "notifications/resources/updated",
-                params: ["uri": .string(uriString)]
-            )
-            let routed = await routeJSONRPC(notification, sessionID: session.id)
-            recordResourceUpdatedOutcome(routed: routed, sessionID: session.id, uri: uriString)
+            let delivered = await deliverResourceUpdated(uri: uri, to: session)
+            recordResourceUpdatedOutcome(delivered: delivered, sessionID: session.id, uri: uriString)
         }
     }
 
-    /// Encode and route a JSON-RPC message to the session's primary general
-    /// stream, reporting whether any stream accepted it.
-    @discardableResult
-    internal func routeJSONRPC(_ message: JSONRPCMessage, sessionID: UUID) async -> Bool {
-        guard let data = try? JSONRPCMessage.makeEncoder().encode(message),
-              let text = String(data: data, encoding: .utf8) else {
+    /// Deliver through the session's own transport, reporting whether it went
+    /// out. Every transport keeps its own delivery mechanism — SSE routing for
+    /// ``HTTPSSETransport``, the connection write for ``TCPBonjourTransport``
+    /// (which shares this manager and has no SSE streams at all) — and each
+    /// throws when the client is unreachable. That throw is the delivery
+    /// signal; it was previously swallowed by `try?`.
+    private func deliverResourceUpdated(uri: URL, to session: Session) async -> Bool {
+        // A `nil` weak transport makes `transport?.send` a silent no-op rather
+        // than a throw, so it has to be checked separately.
+        guard await session.transport != nil else {
             return false
         }
-        return await routeSSEMessage(SSEMessage(data: text), sessionID: sessionID, preferredStreamID: nil)
+
+        do {
+            try await session.work { try await $0.sendResourceUpdated(uri: uri) }
+            return true
+        } catch {
+            return false
+        }
     }
 
     /// Track per-session delivery of resource-updated broadcasts, logging the
     /// transitions (first drop, later recovery) rather than every occurrence.
-    private func recordResourceUpdatedOutcome(routed: Bool, sessionID: UUID, uri: String) {
-        if routed {
+    private func recordResourceUpdatedOutcome(delivered: Bool, sessionID: UUID, uri: String) {
+        // The session can be destroyed while the delivery above is suspended.
+        // `destroySession` already dropped its marker, so recording here would
+        // both re-add a stale id and count a session that no longer exists.
+        guard sessions[sessionID] != nil else {
+            return
+        }
+
+        if delivered {
             if sessionsWithUndeliverableBroadcast.remove(sessionID) != nil {
                 logger.info("resource-updated delivery recovered for session \(sessionID)")
             }
@@ -97,7 +109,7 @@ extension SessionManager {
         undeliverableBroadcastCount += 1
         if sessionsWithUndeliverableBroadcast.insert(sessionID).inserted {
             let details = "resource-updated for \(uri) dropped: session \(sessionID) is subscribed"
-                + " but has no routable general SSE stream; dropping until one (re)connects"
+                + " but is unreachable; dropping until its transport can deliver again"
             logger.warning("\(details)")
         }
     }

--- a/Sources/SwiftMCP/Transport/SessionManager+Sessions.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+Sessions.swift
@@ -109,6 +109,7 @@ extension SessionManager {
 
         primaryGeneralStreamIDs.removeValue(forKey: sessionID)
         sessionStreams.removeValue(forKey: sessionID)
+        sessionsWithUndeliverableBroadcast.remove(sessionID)
     }
 
     internal func updateSessionExpiry(for sessionID: UUID) async {
@@ -142,6 +143,21 @@ extension SessionManager {
             await removeStream(id: streamID)
         }
 
+        // Reclaim streams that were opened (or resumed) but whose connection
+        // never bound: the hub starts its retention clock only on disconnect or
+        // finish, so these have no expiry at all and would otherwise survive
+        // forever — and a general one keeps holding the session's primary slot,
+        // silently black-holing every routed send for that session (the
+        // zombie-session incident). One retention interval is ample time for an
+        // adapter to bind the connection it was handed.
+        let abandonedStreamIDs = streamMeta.compactMap { streamID, _ in
+            isAbandoned(streamID: streamID, now: now) ? streamID : nil
+        }
+        for streamID in abandonedStreamIDs where isAbandoned(streamID: streamID, now: now) {
+            logger.warning("Reclaiming SSE stream \(streamID) whose connection never bound")
+            await removeStream(id: streamID)
+        }
+
         let expiredSessionIDs = sessions.compactMap { sessionID, _ in
             sessionID
         }
@@ -151,6 +167,20 @@ extension SessionManager {
                 await destroySession(id: sessionID)
             }
         }
+    }
+
+    /// Whether a stream has been waiting for a connection for longer than one
+    /// retention interval: not attached, no retention deadline running, and its
+    /// attach grace window has passed. Re-evaluated right before removal, since
+    /// a bind can interleave with the cleanup loop's suspension points.
+    private func isAbandoned(streamID: UUID, now: Date) -> Bool {
+        guard let meta = streamMeta[streamID],
+              let info = hub.info(streamID: streamID),
+              info.expiresAt == nil,
+              !hub.attachedStreamIDs().contains(streamID) else {
+            return false
+        }
+        return now.timeIntervalSince(meta.attachGraceStart) > retentionInterval
     }
 }
 #endif

--- a/Sources/SwiftMCP/Transport/SessionManager+Streams.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager+Streams.swift
@@ -74,6 +74,11 @@ extension SessionManager {
             await session.touchActivity()
         }
 
+        // The resume cleared the hub's retention deadline while the new
+        // connection has not bound yet — restart the attach grace window so the
+        // abandoned-stream reclaim doesn't misfire on (or miss) this stream.
+        streamMeta[eventID.streamID] = StreamMeta(sessionID: meta.sessionID, kind: meta.kind)
+
         // The hub finishes + retains a stream that was already completed; mirror
         // the session-side reconciliation the original did via markStreamDisconnected.
         if let info = hub.info(streamID: eventID.streamID), info.isCompleted {
@@ -95,6 +100,22 @@ extension SessionManager {
 
         let sink = SSEConnectionSink(connection: connection)
         guard let connectionToken = hub.attach(sink: sink, streamID: streamID) else {
+            return nil
+        }
+
+        // A connection that is already dead (or a stream whose outbound
+        // continuation is gone) can never drain this stream. Keeping the sink
+        // bound would park the stream in a live-looking state that no cleanup
+        // reclaims and that keeps winning the primary-general slot. Detach it
+        // and start the retention clock instead, so the stream stays resumable
+        // and expires normally.
+        guard hub.isActive(streamID: streamID) else {
+            logger.warning("Rejecting SSE registration for stream \(streamID): connection not live")
+            hub.markDisconnected(streamID: streamID, connectionToken: connectionToken)
+            if meta.kind.isGeneral {
+                selectPrimaryGeneralStream(for: meta.sessionID, keepRetainedCurrent: true)
+            }
+            await updateSessionExpiry(for: meta.sessionID)
             return nil
         }
 

--- a/Sources/SwiftMCP/Transport/SessionManager.swift
+++ b/Sources/SwiftMCP/Transport/SessionManager.swift
@@ -1,5 +1,6 @@
 #if Server
 import Foundation
+import Logging
 
 actor SessionManager {
     /// The per-stream MCP metadata the generic ``SSEStreamHub`` does not track:
@@ -7,6 +8,18 @@ actor SessionManager {
     struct StreamMeta {
         let sessionID: UUID
         let kind: SSEStreamKind
+        /// When the stream last started waiting for a live connection to bind —
+        /// stamped at open and refreshed on resume. The hub only starts its
+        /// retention clock on disconnect/finish, so a stream whose connection
+        /// never binds has no expiry at all; `cleanupExpiredState` reclaims it
+        /// once this is a full retention interval in the past.
+        let attachGraceStart: Date
+
+        init(sessionID: UUID, kind: SSEStreamKind, attachGraceStart: Date = Date()) {
+            self.sessionID = sessionID
+            self.kind = kind
+            self.attachGraceStart = attachGraceStart
+        }
     }
 
     enum StreamResumeError: Error {
@@ -16,9 +29,19 @@ actor SessionManager {
         case resumePointUnavailable
     }
 
+    internal let logger = Logger(label: "com.cocoanetics.SwiftMCP.SessionManager")
+
     internal var sessions: [UUID: Session] = [:]
     internal weak var transport: (any Transport)?
     internal let retentionInterval: TimeInterval
+
+    /// Sessions whose most recent resource-updated broadcast could not be
+    /// routed, so the outage is logged once instead of once per broadcast.
+    internal var sessionsWithUndeliverableBroadcast: Set<UUID> = []
+
+    /// Total resource-updated notifications dropped because a subscribed
+    /// session had no routable general stream. Diagnostic counter.
+    internal var undeliverableBroadcastCount = 0
 
     /// The transport-agnostic SSE registry — replay buffer, resume-after-disconnect,
     /// and retention — shared with LSP/ACP via JSONFoundation. It is *synchronous*

--- a/Tests/SwiftMCPTests/BroadcastRealProxyTests.swift
+++ b/Tests/SwiftMCPTests/BroadcastRealProxyTests.swift
@@ -1,0 +1,142 @@
+#if Server
+// Reproduces the MissionControl zombie with SwiftMCP's own client: the real
+// MCPServerProxy abandons each POST's SSE stream as soon as its response event
+// arrives, which raw-URLSession tests don't replicate. Mirrors the Mac app's
+// maintain() loop: connect (initialize + notifications/initialized + general
+// GET task), sequential subscribes, then rely on pushes — while broadcast
+// churn and agent-like POST traffic hammer the same server, as the production
+// daemon does from the moment it boots.
+
+import Foundation
+import Testing
+import SwiftCross
+@testable import SwiftMCP
+
+/// Records resource-updated notifications delivered to the proxy.
+final class PushRecorder: MCPServerProxyResourceNotificationHandling, @unchecked Sendable {
+    private let received = HTTPTransportBox<[URL]>([])
+
+    func mcpServerProxy(_ proxy: MCPServerProxy, resourceUpdatedAt uri: URL) async {
+        received.modify { $0.append(uri) }
+    }
+
+    var count: Int {
+        received.value.count
+    }
+}
+
+@Suite("Broadcast delivery to real proxy", .serialized)
+struct BroadcastRealProxyTests {
+
+    static let subscribedURIs: [String] = (0..<10).map { "push://resource/\($0)" }
+
+    @Test(.timeLimit(.minutes(10)))
+    func proxyConnectingAtBootReceivesBroadcasts() async throws {
+        for iteration in 0..<4 {
+            let (transport, baseURL) = try await HTTPTransportTestHelpers.startTransport(
+                server: PushFixtureServer()
+            )
+            try await runIteration(transport: transport, baseURL: baseURL, iteration: iteration)
+        }
+    }
+
+    private func runIteration(transport: HTTPSSETransport, baseURL: URL, iteration: Int) async throws {
+        let mcpURL = baseURL.appendingPathComponent("mcp")
+
+        // Broadcast churn from the instant the server is up, like the daemon's
+        // monitor sweeps and log rebroadcasts.
+        let broadcasting = Task {
+            var round = 0
+            while !Task.isCancelled {
+                let uri = URL(string: Self.subscribedURIs[round % Self.subscribedURIs.count])!
+                await transport.broadcastResourceUpdated(uri: uri)
+                await transport.broadcastLog(LogMessage(level: .info, data: ["round": .integer(round)]))
+                round += 1
+                try? await Task.sleep(nanoseconds: 2_000_000)
+            }
+        }
+
+        // Agent-like background POST traffic on its own session, as the daemon
+        // sees from CLI/agent clients while the app connects.
+        let agentSession = URLSession(configuration: .ephemeral)
+        let agentTraffic = try await startAgentTraffic(mcpURL: mcpURL, urlSession: agentSession)
+
+        let recorder = PushRecorder()
+        let proxy = MCPServerProxy(config: .sse(config: MCPServerSseConfig(url: mcpURL)))
+        await proxy.setResourceNotificationHandler(recorder)
+
+        // Quiesce all background work before stopping the transport, so no send
+        // races the adapter shutdown, then release CFNetwork's descriptors.
+        func quiesce() async {
+            broadcasting.cancel()
+            agentTraffic.cancel()
+            _ = await broadcasting.result
+            _ = await agentTraffic.result
+            await proxy.disconnect()
+            agentSession.invalidateAndCancel()
+        }
+
+        do {
+            try await connectAndAssertPushArrives(
+                proxy: proxy, recorder: recorder, transport: transport, iteration: iteration
+            )
+        } catch {
+            await quiesce()
+            try? await transport.stop()
+            throw error
+        }
+
+        await quiesce()
+        try await transport.stop()
+    }
+
+    /// Ping the server in a tight loop from a separate session until cancelled.
+    private func startAgentTraffic(mcpURL: URL, urlSession: URLSession) async throws -> Task<Void, Never> {
+        let (sessionID, _) = try await HTTPTransportTestHelpers.initializeSession(
+            url: mcpURL, urlSession: urlSession
+        )
+        return Task {
+            var requestID = 1000
+            while !Task.isCancelled {
+                let ping = JSONRPCMessage.request(id: requestID, method: "ping")
+                if let request = try? HTTPTransportTestHelpers.streamablePOSTRequest(
+                    url: mcpURL, message: ping, sessionID: sessionID
+                ) {
+                    _ = try? await HTTPTransportTestHelpers.readFiniteSSEResponse(
+                        request, urlSession: urlSession
+                    )
+                }
+                requestID += 1
+            }
+        }
+    }
+
+    private func connectAndAssertPushArrives(
+        proxy: MCPServerProxy,
+        recorder: PushRecorder,
+        transport: HTTPSSETransport,
+        iteration: Int
+    ) async throws {
+        try await proxy.connect(clientName: "MissionControl", clientVersion: "0.1.0")
+        for uri in Self.subscribedURIs {
+            try await proxy.subscribeResource(uri: URL(string: uri)!)
+        }
+
+        // The broadcaster fires every 2ms; a healthy session sees a push
+        // near-instantly. 10s is a failure bound, not a wait.
+        let received = await HTTPTransportTestHelpers.waitForCondition(
+            timeoutNanoseconds: 10_000_000_000
+        ) {
+            recorder.count > 0
+        }
+
+        guard !received else { return }
+
+        let sessionID = await proxy.sessionID ?? "nil"
+        let diagnostics = await BroadcastResourceUpdatedTests.dumpRoutingState(
+            transport: transport, sessionID: sessionID
+        )
+        Issue.record("ZOMBIE reproduced at iteration \(iteration): \(diagnostics)")
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/BroadcastResourceUpdatedTests.swift
+++ b/Tests/SwiftMCPTests/BroadcastResourceUpdatedTests.swift
@@ -1,0 +1,159 @@
+#if Server
+// Reproduces the MissionControl "zombie session" defect: a client that connects
+// immediately at server start, subscribes, and holds a general GET stream must
+// receive `notifications/resources/updated` broadcasts. See the production
+// incident of 2026-08-12 (session healthy for POSTs and keepalives, but no
+// pushes for 10+ hours).
+
+import Foundation
+import Testing
+import SwiftCross
+@testable import SwiftMCP
+
+@MCPServer(name: "PushFixtureServer")
+final class PushFixtureServer {
+    /// A subscribable resource, so `exposesResources` is true and
+    /// `resources/subscribe` is accepted.
+    @MCPResource("push://status")
+    func status() -> String {
+        return "ok"
+    }
+}
+
+@Suite("Broadcast resource-updated delivery", .serialized)
+struct BroadcastResourceUpdatedTests {
+
+    static let subscribedURIs: [String] = (0..<10).map { "push://resource/\($0)" }
+
+    /// Mirrors the production client: initialize, then fire the general GET
+    /// stream and the subscribe POSTs concurrently, then broadcast and assert
+    /// the notification arrives on the general stream.
+    @Test func clientConnectingAtBootReceivesBroadcasts() async throws {
+        for iteration in 0..<3 {
+            let (transport, baseURL) = try await HTTPTransportTestHelpers.startTransport(
+                server: PushFixtureServer()
+            )
+
+            do {
+                try await runBootWindowScenario(
+                    transport: transport,
+                    baseURL: baseURL,
+                    iteration: iteration
+                )
+            } catch {
+                try? await transport.stop()
+                throw error
+            }
+
+            try await transport.stop()
+        }
+    }
+
+    private func runBootWindowScenario(
+        transport: HTTPSSETransport,
+        baseURL: URL,
+        iteration: Int
+    ) async throws {
+        let mcpURL = baseURL.appendingPathComponent("mcp")
+        let urlSession = URLSession(configuration: .ephemeral)
+
+        // 1. initialize — the first request the server ever sees.
+        let (sessionID, initEvents) = try await HTTPTransportTestHelpers.initializeSession(
+            url: mcpURL, urlSession: urlSession
+        )
+        #expect(HTTPTransportTestHelpers.responseEvent(initEvents, id: 1) != nil)
+
+        // 2. General GET stream and the 10 subscribe POSTs race, as the real
+        //    client does (connect() starts the GET task and returns; the app
+        //    then subscribes immediately).
+        let streamRequest = HTTPTransportTestHelpers.generalSSERequest(
+            url: mcpURL, sessionID: sessionID
+        )
+        let capture = HTTPTransportTestHelpers.openStreamingRequest(
+            streamRequest, urlSession: urlSession
+        )
+
+        try await subscribeAll(mcpURL: mcpURL, sessionID: sessionID, urlSession: urlSession, iteration: iteration)
+
+        // 3. The general stream must be up before broadcasting: wait for its
+        //    priming event (a data event carrying the resume anchor).
+        let streamLive = await HTTPTransportTestHelpers.waitForCondition {
+            capture.response.value?.statusCode == 200 && !capture.events.value.isEmpty
+        }
+        #expect(streamLive, "general stream never became live (iteration \(iteration))")
+
+        // 4. Broadcast to one of the subscribed URIs.
+        let updatedURI = URL(string: Self.subscribedURIs[iteration % Self.subscribedURIs.count])!
+        await transport.broadcastResourceUpdated(uri: updatedURI)
+
+        // 5. The push must arrive on the general stream.
+        let received = await HTTPTransportTestHelpers.waitForCondition(timeoutNanoseconds: 10_000_000_000) {
+            HTTPTransportTestHelpers.notificationEvent(
+                capture.events.value, method: "notifications/resources/updated"
+            ) != nil
+        }
+
+        if !received {
+            let diagnostics = await Self.dumpRoutingState(transport: transport, sessionID: sessionID)
+            Issue.record(
+                "notifications/resources/updated never arrived (iteration \(iteration)); \(diagnostics)"
+            )
+        }
+
+        capture.task.cancel()
+        urlSession.invalidateAndCancel()
+    }
+
+    /// Subscribe to every URI concurrently, as the real client's requests race
+    /// the general GET during connect.
+    private func subscribeAll(
+        mcpURL: URL,
+        sessionID: String,
+        urlSession: URLSession,
+        iteration: Int
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for (index, uri) in Self.subscribedURIs.enumerated() {
+                group.addTask {
+                    let subscribe = JSONRPCMessage.request(
+                        id: 100 + index,
+                        method: "resources/subscribe",
+                        params: ["uri": .string(uri)]
+                    )
+                    let request = try HTTPTransportTestHelpers.streamablePOSTRequest(
+                        url: mcpURL, message: subscribe, sessionID: sessionID
+                    )
+                    let (response, events) = try await HTTPTransportTestHelpers.readFiniteSSEResponse(
+                        request, urlSession: urlSession
+                    )
+                    #expect(response.statusCode == 200)
+                    guard HTTPTransportTestHelpers.responseEvent(events, id: 100 + index) != nil else {
+                        throw TestError("subscribe \(uri) did not return a result (iteration \(iteration))")
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    /// Snapshot the session-manager routing state for a failed iteration.
+    static func dumpRoutingState(transport: HTTPSSETransport, sessionID: String) async -> String {
+        guard let sessionUUID = UUID(uuidString: sessionID) else {
+            return "malformed session id"
+        }
+        let manager = transport.sessionManager
+        let hasSession = await manager.hasSession(id: sessionUUID)
+        let primary = await manager.primaryGeneralStreamID(for: sessionUUID)
+        let active = await manager.hasActivePrimaryGeneralConnection(for: sessionUUID)
+        var subscribed: Set<String> = []
+        if let session = await manager.existingSession(id: sessionUUID) {
+            for uri in subscribedURIs {
+                guard await session.isSubscribedToResource(uri: uri) else { continue }
+                subscribed.insert(uri)
+            }
+        }
+        return "hasSession=\(hasSession) primaryStream=\(String(describing: primary)) "
+            + "primaryActive=\(active) subscriptionsRecorded=\(subscribed.count)/\(subscribedURIs.count)"
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/BroadcastZombieRegressionTests.swift
+++ b/Tests/SwiftMCPTests/BroadcastZombieRegressionTests.swift
@@ -15,12 +15,68 @@
 // interval would otherwise multiply that churn.
 
 import Foundation
+import Logging
 import Testing
 import SwiftCross
 @testable import SwiftMCP
 
+/// A non-SSE ``Transport``, standing in for ``TCPBonjourTransport`` (which
+/// shares ``SessionManager`` but has no SSE streams): it records what the
+/// session sends, and can be made unreachable to exercise the failure path.
+final class NonSSERecordingTransport: Transport, @unchecked Sendable {
+    let logger = Logger(label: "com.cocoanetics.SwiftMCP.RecordingTransport")
+    private let sent = HTTPTransportBox<[String]>([])
+    private let reachable = HTTPTransportBox<Bool>(true)
+
+    var sentMessages: [String] { sent.value }
+    func setReachable(_ value: Bool) { reachable.value = value }
+
+    func start() async throws {}
+    func run() async throws {}
+    func stop() async throws {}
+
+    func send(_ data: Data) async throws {
+        guard reachable.value else {
+            throw TransportError.bindingFailed("Client unreachable")
+        }
+        sent.modify { $0.append(String(data: data, encoding: .utf8) ?? "") }
+    }
+}
+
 @Suite("Zombie-session regression", .serialized)
 struct BroadcastZombieRegressionTests {
+
+    /// `SessionManager` is shared with the TCP transport, whose sessions never
+    /// create SSE streams. Broadcasts must therefore go out through each
+    /// session's own transport, not through SSE stream routing — routing
+    /// directly would silently drop every TCP client's notifications.
+    @Test func nonSSETransportsStillReceiveResourceUpdated() async throws {
+        // Both references must be held: `Session.transport` and
+        // `SessionManager.transport` are weak.
+        let transport = NonSSERecordingTransport()
+        let manager = SessionManager(transport: transport)
+
+        let session = await manager.session(id: UUID())
+        await session.subscribeResource(uri: "push://tcp")
+
+        await manager.broadcastResourceUpdated(uri: URL(string: "push://tcp")!)
+        #expect(transport.sentMessages.count == 1)
+        #expect(transport.sentMessages.first?.contains("notifications/resources/updated") == true)
+        #expect(transport.sentMessages.first?.contains("push://tcp") == true)
+        #expect(await manager.undeliverableBroadcastCount == 0)
+
+        // An unreachable client is a counted drop, not a silent one.
+        transport.setReachable(false)
+        await manager.broadcastResourceUpdated(uri: URL(string: "push://tcp")!)
+        #expect(transport.sentMessages.count == 1)
+        #expect(await manager.undeliverableBroadcastCount == 1)
+
+        // …and delivery recovers once the client is reachable again.
+        transport.setReachable(true)
+        await manager.broadcastResourceUpdated(uri: URL(string: "push://tcp")!)
+        #expect(transport.sentMessages.count == 2)
+        #expect(await manager.undeliverableBroadcastCount == 1)
+    }
 
     @Test(.timeLimit(.minutes(3)))
     func zombieStreamStatesAreReclaimedCountedAndRejected() async throws {

--- a/Tests/SwiftMCPTests/BroadcastZombieRegressionTests.swift
+++ b/Tests/SwiftMCPTests/BroadcastZombieRegressionTests.swift
@@ -1,0 +1,205 @@
+#if Server
+// Regression tests for the zombie-session defect (MissionControl incident,
+// 2026-08-12): an SSE stream that is opened but never drained/bound could hold
+// a session's primary-general slot forever, silently black-holing every
+// broadcast while POSTs and the (other) live stream stayed healthy.
+//
+// The phases forge the black-hole states directly through SessionManager and
+// assert that (1) undeliverable resource-updated broadcasts are counted
+// instead of dropped silently, (2) registration rejects dead connections and
+// starts the retention clock, and (3) the janitor reclaims never-bound streams
+// after one retention interval so routing heals onto the live stream.
+//
+// One shared transport on purpose: each start/stop spins up (and tears down) a
+// full event-loop group, and phases that need to outwait the retention
+// interval would otherwise multiply that churn.
+
+import Foundation
+import Testing
+import SwiftCross
+@testable import SwiftMCP
+
+@Suite("Zombie-session regression", .serialized)
+struct BroadcastZombieRegressionTests {
+
+    @Test(.timeLimit(.minutes(3)))
+    func zombieStreamStatesAreReclaimedCountedAndRejected() async throws {
+        let (transport, baseURL) = try await HTTPTransportTestHelpers.startTransport(
+            server: PushFixtureServer(), retentionInterval: 1.0
+        )
+        let mcpURL = baseURL.appendingPathComponent("mcp")
+        let urlSession = URLSession(configuration: .ephemeral)
+
+        try await assertUndeliverableBroadcastIsCounted(
+            transport: transport, mcpURL: mcpURL, urlSession: urlSession
+        )
+        try await assertDeadConnectionRegistrationIsRejected(
+            transport: transport, mcpURL: mcpURL, urlSession: urlSession
+        )
+        try await assertNeverBoundStreamIsReclaimedAndRoutingHeals(
+            transport: transport, mcpURL: mcpURL, urlSession: urlSession
+        )
+
+        urlSession.invalidateAndCancel()
+        try await transport.stop()
+    }
+
+    // MARK: - Phases
+
+    /// A subscribed session with no routable general stream must be counted
+    /// (and logged) instead of dropping the notification without a trace.
+    private func assertUndeliverableBroadcastIsCounted(
+        transport: HTTPSSETransport,
+        mcpURL: URL,
+        urlSession: URLSession
+    ) async throws {
+        let uri = "push://counting"
+        let (sessionID, _) = try await initializeAndSubscribe(
+            uri: uri, mcpURL: mcpURL, urlSession: urlSession
+        )
+
+        // No general stream was ever opened for this session.
+        await transport.broadcastResourceUpdated(uri: URL(string: uri)!)
+        await transport.broadcastResourceUpdated(uri: URL(string: uri)!)
+
+        let manager = transport.sessionManager
+        #expect(await manager.undeliverableBroadcastCount == 2)
+
+        // Once a general stream connects, delivery must recover and the
+        // counter must stop growing.
+        let capture = try await openLiveGeneralStream(
+            sessionID: sessionID, mcpURL: mcpURL, urlSession: urlSession
+        )
+        await transport.broadcastResourceUpdated(uri: URL(string: uri)!)
+        #expect(await manager.undeliverableBroadcastCount == 2)
+        let received = await HTTPTransportTestHelpers.waitForCondition {
+            HTTPTransportTestHelpers.notificationEvent(
+                capture.events.value, method: "notifications/resources/updated"
+            ) != nil
+        }
+        #expect(received)
+
+        capture.task.cancel()
+    }
+
+    /// Registering a connection that is already dead must fail and start the
+    /// retention clock, instead of parking the stream in a live-looking state
+    /// no cleanup ever reclaims.
+    private func assertDeadConnectionRegistrationIsRejected(
+        transport: HTTPSSETransport,
+        mcpURL: URL,
+        urlSession: URLSession
+    ) async throws {
+        let (sessionID, _) = try await HTTPTransportTestHelpers.initializeSession(
+            url: mcpURL, urlSession: urlSession
+        )
+        let sessionUUID = try #require(UUID(uuidString: sessionID))
+        let manager = transport.sessionManager
+
+        let (_, info) = await manager.createStream(sessionID: sessionUUID, kind: .general)
+        let token = await manager.register(
+            connection: DeadSSEConnection(),
+            sessionID: sessionUUID,
+            streamID: info.streamID
+        )
+        #expect(token == nil, "a dead connection must not be registered")
+
+        // The rejection started the retention clock: the stream must be gone
+        // after one retention interval.
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        let streams = await manager.activeStreamIDs()
+        #expect(!streams.contains(info.streamID))
+        #expect(await manager.primaryGeneralStreamID(for: sessionUUID) != info.streamID)
+    }
+
+    /// A general stream that is opened but never drained or bound (e.g. its
+    /// response was discarded, or the drain never started) steals the
+    /// primary-general slot. The janitor must reclaim it after one retention
+    /// interval so broadcasts heal back onto the live stream — before the fix
+    /// this state survived forever.
+    private func assertNeverBoundStreamIsReclaimedAndRoutingHeals(
+        transport: HTTPSSETransport,
+        mcpURL: URL,
+        urlSession: URLSession
+    ) async throws {
+        let uri = "push://healing"
+        let (sessionID, sessionUUID) = try await initializeAndSubscribe(
+            uri: uri, mcpURL: mcpURL, urlSession: urlSession
+        )
+        let capture = try await openLiveGeneralStream(
+            sessionID: sessionID, mcpURL: mcpURL, urlSession: urlSession
+        )
+        let manager = transport.sessionManager
+        let liveStreamID = try #require(await manager.primaryGeneralStreamID(for: sessionUUID))
+
+        // Forge the black hole: an SSE stream the route layer opened (claiming
+        // the primary slot) whose response never gets drained or bound —
+        // exactly what handleSSE produces when the adapter discards the
+        // response or the drain dies before binding.
+        let (_, abandonedInfo) = await manager.createStream(sessionID: sessionUUID, kind: .general)
+        #expect(await manager.primaryGeneralStreamID(for: sessionUUID) == abandonedInfo.streamID)
+
+        // While the abandoned stream holds the slot, broadcasts vanish into its
+        // unconsumed buffer: the live stream must not receive this one.
+        await transport.broadcastResourceUpdated(uri: URL(string: uri)!)
+
+        // Past one retention interval the janitor reclaims the stream and the
+        // primary slot falls back to the live, bound stream; the next broadcast
+        // must arrive. (The reclaim runs inside the broadcast's own cleanup.)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        await transport.broadcastResourceUpdated(uri: URL(string: uri)!)
+
+        #expect(await manager.primaryGeneralStreamID(for: sessionUUID) == liveStreamID)
+        let received = await HTTPTransportTestHelpers.waitForCondition {
+            HTTPTransportTestHelpers.notificationEvent(
+                capture.events.value, method: "notifications/resources/updated"
+            ) != nil
+        }
+        #expect(received, "broadcast did not arrive after the abandoned stream was reclaimed")
+
+        capture.task.cancel()
+    }
+
+    // MARK: - Helpers
+
+    private func initializeAndSubscribe(
+        uri: String,
+        mcpURL: URL,
+        urlSession: URLSession
+    ) async throws -> (sessionID: String, sessionUUID: UUID) {
+        let (sessionID, _) = try await HTTPTransportTestHelpers.initializeSession(
+            url: mcpURL, urlSession: urlSession
+        )
+
+        let subscribe = JSONRPCMessage.request(
+            id: 100,
+            method: "resources/subscribe",
+            params: ["uri": .string(uri)]
+        )
+        let request = try HTTPTransportTestHelpers.streamablePOSTRequest(
+            url: mcpURL, message: subscribe, sessionID: sessionID
+        )
+        let (response, events) = try await HTTPTransportTestHelpers.readFiniteSSEResponse(
+            request, urlSession: urlSession
+        )
+        #expect(response.statusCode == 200)
+        #expect(HTTPTransportTestHelpers.responseEvent(events, id: 100) != nil)
+
+        return (sessionID, try #require(UUID(uuidString: sessionID)))
+    }
+
+    private func openLiveGeneralStream(
+        sessionID: String,
+        mcpURL: URL,
+        urlSession: URLSession
+    ) async throws -> HTTPTransportStreamCapture {
+        let streamRequest = HTTPTransportTestHelpers.generalSSERequest(url: mcpURL, sessionID: sessionID)
+        let capture = HTTPTransportTestHelpers.openStreamingRequest(streamRequest, urlSession: urlSession)
+        let live = await HTTPTransportTestHelpers.waitForCondition {
+            capture.response.value?.statusCode == 200 && !capture.events.value.isEmpty
+        }
+        #expect(live, "general stream never became live")
+        return capture
+    }
+}
+#endif

--- a/Tests/SwiftMCPTests/Connection/TCPTransportFailureTests.swift
+++ b/Tests/SwiftMCPTests/Connection/TCPTransportFailureTests.swift
@@ -119,16 +119,19 @@ struct TCPTransportFailureTests {
         #expect(sanity.limit > 0)
         #expect(sanity.used <= sanity.limit)
 
-        // Ten pipes: twenty descriptors that F_GETFD must see. Suites in other
-        // files run concurrently and churn this process's descriptor table, so
-        // a single before/after pair can race a burst of closes; the pipes
-        // persist across attempts, while churn beating +20 every time doesn't.
+        // Fifty pipes: a hundred descriptors that F_GETFD must see. Suites in
+        // other files run concurrently and churn this process's descriptor
+        // table, so a single before/after pair can race a burst of closes — a
+        // single HTTP transport teardown releases dozens of descriptors (its
+        // event-loop kqueues, channels, sockets) at once. The signal must
+        // outweigh any such burst; the pipes persist across attempts, while
+        // churn beating +100 every time doesn't.
         var sawIncrease = false
         for _ in 0..<3 where !sawIncrease {
             let before = try #require(TCPBonjourTransport.descriptorUsage())
 
             var pipes: [[Int32]] = []
-            for _ in 0..<10 {
+            for _ in 0..<50 {
                 var fds: [Int32] = [0, 0]
                 #expect(pipe(&fds) == 0)
                 pipes.append(fds)
@@ -141,9 +144,9 @@ struct TCPTransportFailureTests {
             }
 
             let after = try #require(TCPBonjourTransport.descriptorUsage())
-            sawIncrease = after.used >= before.used + 10
+            sawIncrease = after.used >= before.used + 50
         }
-        #expect(sawIncrease, "twenty live pipe descriptors never showed up in the count")
+        #expect(sawIncrease, "a hundred live pipe descriptors never showed up in the count")
     }
 }
 


### PR DESCRIPTION
Fixes #180.

A session whose primary-general slot is held by an SSE stream that nobody will ever drain receives no routed server→client messages — resource-updated pushes, log broadcasts, keep-alive pings — while POSTs and any *other* live stream stay healthy. In production this froze the MissionControl Agents pane for 10+ hours (see the issue for the full forensics). Every hole below is a way such a stream could exist forever, and none of them produced a single log line.

## Changes

**Reclaim streams whose connection never binds** — the hub starts its retention clock only on disconnect/finish, so a stream that was opened (or resumed) but never bound had `expiresAt == nil` for life. `StreamMeta` now records when the stream began waiting for its connection, and `cleanupExpiredState` removes it once that grace window exceeds one retention interval. Removing it re-runs primary-general selection, so routing heals onto the session's live stream.

**Close the channel when a drain write fails** — the NIO SSE drain loop used to `return` on a failed write, which leaves an ESTABLISHED connection whose stream nobody drains when the failure was pipeline-level rather than socket-level (every later send "succeeds" into the void; server pings hang in the correlator — the `E5AE1949` print storm). Closing the channel makes the client reconnect and lets `closeFuture` reconcile the engine's state.

**Reconcile discarded SSE responses** — when `dispatchRoute` drops a response because the request body aborted, the engine has already opened the stream (and possibly promoted it to primary). The adapter now registers the dead connection so the engine's new liveness guard starts the retention clock instead of leaking the stream.

**Reject dead connections at registration** — `SessionManager.register` verifies the stream is actually active after attach; a connection that is already dead is detached again with retention running, instead of parking the stream in a live-looking state no cleanup reclaims.

**Diagnosability** — `broadcastResourceUpdated` routes through a result-reporting path: drops are counted in `undeliverableBroadcastCount` and logged once per session per outage (with a recovery line when delivery resumes), `routeSSEMessage` debug-logs a missing primary stream, and `SessionManager` finally has a logger.

## Tests

- `BroadcastZombieRegressionTests` forges the black-hole states directly: never-bound stream reclaimed + routing heals (fails on main: the abandoned stream holds the slot forever), dead-connection registration rejected, undeliverable broadcasts counted and recovery observed.
- `BroadcastResourceUpdatedTests` mirrors the production connect sequence — a client connecting immediately at server start, subscribing to 10 URIs while the general GET races the POSTs, asserting broadcasts arrive.
- `BroadcastRealProxyTests` runs the same scenario through the real `MCPServerProxy` (which abandons each POST's SSE stream once its response event arrives), and `BroadcastZombieChaosTests` adds background broadcast/agent-traffic churn.

Follow-ups tracked in the issue: JSONFoundation `SSEStreamHub` should honor the continuation-yield result and reject attaches to continuation-less records; optionally a keep-alive escalation that force-closes streams whose pings go unanswered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
