### PR TITLE
Close the test client's socket once, not twice

### DIFF
--- a/Tests/SwiftMCPTests/BroadcastZombieRegressionTests.swift
+++ b/Tests/SwiftMCPTests/BroadcastZombieRegressionTests.swift
@@ -9,10 +9,6 @@
 // instead of dropped silently, (2) registration rejects dead connections and
 // starts the retention clock, and (3) the janitor reclaims never-bound streams
 // after one retention interval so routing heals onto the live stream.
-//
-// One shared transport on purpose: each start/stop spins up (and tears down) a
-// full event-loop group, and phases that need to outwait the retention
-// interval would otherwise multiply that churn.
 
 import Foundation
 import Logging
@@ -78,26 +74,21 @@ struct BroadcastZombieRegressionTests {
         #expect(await manager.undeliverableBroadcastCount == 1)
     }
 
-    @Test(.timeLimit(.minutes(3)))
-    func zombieStreamStatesAreReclaimedCountedAndRejected() async throws {
-        let (transport, baseURL) = try await HTTPTransportTestHelpers.startTransport(
-            server: PushFixtureServer(), retentionInterval: 1.0
-        )
-        let mcpURL = baseURL.appendingPathComponent("mcp")
-        let urlSession = URLSession(configuration: .ephemeral)
+    // MARK: - The zombie stream states
 
-        try await assertUndeliverableBroadcastIsCounted(
-            transport: transport, mcpURL: mcpURL, urlSession: urlSession
-        )
-        try await assertDeadConnectionRegistrationIsRejected(
-            transport: transport, mcpURL: mcpURL, urlSession: urlSession
-        )
-        try await assertNeverBoundStreamIsReclaimedAndRoutingHeals(
-            transport: transport, mcpURL: mcpURL, urlSession: urlSession
-        )
+    @Test("Undeliverable broadcasts are counted, and delivery recovers", .timeLimit(.minutes(3)))
+    func undeliverableBroadcastIsCounted() async throws {
+        try await withPushTransport(assertUndeliverableBroadcastIsCounted)
+    }
 
-        urlSession.invalidateAndCancel()
-        try await transport.stop()
+    @Test("A dead connection is refused and its stream reclaimed", .timeLimit(.minutes(3)))
+    func deadConnectionRegistrationIsRejected() async throws {
+        try await withPushTransport(assertDeadConnectionRegistrationIsRejected)
+    }
+
+    @Test("A never-bound stream is reclaimed and routing heals", .timeLimit(.minutes(3)))
+    func neverBoundStreamIsReclaimedAndRoutingHeals() async throws {
+        try await withPushTransport(assertNeverBoundStreamIsReclaimedAndRoutingHeals)
     }
 
     // MARK: - Phases
@@ -217,6 +208,29 @@ struct BroadcastZombieRegressionTests {
     }
 
     // MARK: - Helpers
+
+    /// Starts a push-fixture transport with a one-second retention interval,
+    /// runs `body` against it, and always tears down both the transport and the
+    /// client session — a failing phase must strand neither.
+    private func withPushTransport(
+        _ body: (HTTPSSETransport, URL, URLSession) async throws -> Void
+    ) async throws {
+        let (transport, baseURL) = try await HTTPTransportTestHelpers.startTransport(
+            server: PushFixtureServer(), retentionInterval: 1.0
+        )
+        let urlSession = URLSession(configuration: .ephemeral)
+
+        do {
+            try await body(transport, baseURL.appendingPathComponent("mcp"), urlSession)
+        } catch {
+            urlSession.invalidateAndCancel()
+            try? await transport.stop()
+            throw error
+        }
+
+        urlSession.invalidateAndCancel()
+        try await transport.stop()
+    }
 
     private func initializeAndSubscribe(
         uri: String,

--- a/Tests/SwiftMCPTests/Connection/TCPTransportFailureTests.swift
+++ b/Tests/SwiftMCPTests/Connection/TCPTransportFailureTests.swift
@@ -130,10 +130,16 @@ struct TCPTransportFailureTests {
         for _ in 0..<3 where !sawIncrease {
             let before = try #require(TCPBonjourTransport.descriptorUsage())
 
+            // Seeded with -1, never 0: a failed `pipe` must not leave the pair
+            // aliasing stdin, or the cleanup below would close descriptor 0
+            // twice and hand a live descriptor number to the second close.
             var pipes: [[Int32]] = []
             for _ in 0..<50 {
-                var fds: [Int32] = [0, 0]
-                #expect(pipe(&fds) == 0)
+                var fds: [Int32] = [-1, -1]
+                guard pipe(&fds) == 0 else {
+                    Issue.record("pipe() failed with errno \(errno)")
+                    break
+                }
                 pipes.append(fds)
             }
             defer {

--- a/Tests/SwiftMCPTests/Connection/TCPTransportTeardownTests.swift
+++ b/Tests/SwiftMCPTests/Connection/TCPTransportTeardownTests.swift
@@ -23,8 +23,17 @@ import Network
 /// Network.framework: the tests need deterministic close semantics (FIN on
 /// `close`, half-close via `shutdown`) and their own descriptors excluded
 /// from what the transport is being measured on.
-private struct TestTCPClient {
+///
+/// A reference type so the descriptor has exactly one owner: tests close the
+/// socket explicitly — the FIN is what the transport under test reacts to —
+/// and keep a `defer` as the cleanup net, so `closeSocket()` is reached twice
+/// on some paths. See `closeSocket()` for why only the first may act.
+private final class TestTCPClient {
     let sock: Int32
+    private var isClosed = false
+    /// How many `close(2)` calls this client has issued. Exactly one, for the
+    /// lifetime of the client, is the invariant `closeSocket()` exists to keep.
+    private(set) var issuedCloseCount = 0
 
     init(port: UInt16) throws {
         sock = socket(AF_INET, SOCK_STREAM, 0)
@@ -82,7 +91,18 @@ private struct TestTCPClient {
         return received.isEmpty ? nil : String(data: received, encoding: .utf8)
     }
 
+    /// Closes the socket, at most once for the lifetime of this client.
+    ///
+    /// The second `close(2)` must never reach the kernel. By then the number
+    /// is free, and the kernel hands freed numbers straight back out: a
+    /// redundant close here landed on the kqueue that a freshly booted NIO
+    /// event-loop group had just been given, and that loop died with `EBADF`
+    /// inside `kevent` — a `precondition` failure that takes the whole test
+    /// process down, in a thread that has nothing to do with this file.
     func closeSocket() {
+        guard !isClosed else { return }
+        isClosed = true
+        issuedCloseCount += 1
         close(sock)
     }
 }
@@ -176,6 +196,32 @@ struct TCPTransportTeardownTests {
                 settled <= baseline + tolerance,
                 "descriptors did not return to baseline: \(baseline) before, \(settled) after"
             )
+        }
+    }
+
+    // MARK: - A redundant close must stay out of the kernel
+
+    /// Several tests close the client explicitly *and* keep a `defer` as the
+    /// cleanup net. The second call must not issue a second `close(2)`: the
+    /// number is free by then, and the kernel immediately hands freed numbers
+    /// back out — so the close would land on whatever has since been given
+    /// that number. It did: a NIO event-loop group booted by another suite got
+    /// the number for a kqueue, and the loop died with `EBADF` inside `kevent`,
+    /// killing the test process from a thread unrelated to this file.
+    ///
+    /// Asserting on the count rather than on the recycled descriptor itself is
+    /// deliberate: reclaiming the released number to watch it survive means
+    /// racing every other thread in the process for it, and losing that race
+    /// is exactly what makes the original defect intermittent.
+    @Test("Closing a client twice issues one close(2)")
+    func redundantCloseNeverReachesTheKernel() async throws {
+        try await withStartedTransport(server: StructCalculator()) { _, port in
+            let client = try TestTCPClient(port: port)
+
+            client.closeSocket()
+            client.closeSocket()
+
+            #expect(client.issuedCloseCount == 1)
         }
     }
 


### PR DESCRIPTION
Fixes the reproducible `kevent` EBADF crash that surfaced while working on #181 — the one that was avoided, not fixed, by consolidating `BroadcastZombieRegressionTests` onto a single shared transport. Rebased onto main now that #181 has landed, and that workaround is removed here.

## What was wrong

`TestTCPClient` was a struct whose `closeSocket()` was a bare `close(sock)`, and `hungFinalLineToolIsReaped` calls it twice: explicitly, because the FIN is what the transport under test reacts to, and again from the `defer` that acts as the cleanup net. Between the two sits `waitUntilCancelled()` — at least the 0.5s `eofDrainTimeout` — and the kernel hands freed descriptor numbers straight back out. Often enough, a `MultiThreadedEventLoopGroup` booted by another suite was given that number for a kqueue in the window, and the deferred close destroyed it. The event loop then died on its very first `kevent`:

```
NIOPosix/System.swift:264: Precondition failed: unacceptable errno 9 Bad file descriptor in kevent(...)
```

on a brand-new `NIO-ELT-<n>-#1` thread, taking the whole test process down.

The crash reads as an HTTP/SSE transport teardown defect only because the victim is whoever happened to be allocating a descriptor in that window — the faulting thread has nothing to do with the guilty code, and the "deterministic placement right after one `stop()` and the next `start()`" was just event-loop-group churn making the window easy to hit. **Nothing in the library is involved; no code under `Sources/` changes here.**

## How it was proven

A temporary three-transport shaker suite reproduced the reported shape, with the client's close path instrumented to remember every number it released and, on a repeat close, ask `fcntl(F_GETFD)` whether the number was live — then name the victim via `proc_pidinfo(PROC_PIDLISTFDS)`. The first run gave the smoking gun, with the crash on the very next line:

```
‼️ STALE CLOSE fd=12 at TCPTransportTeardownTests.swift:271 — LIVE — now a KQUEUE owned by someone else; this close destroys it
NIOPosix/System.swift:264: Precondition failed: unacceptable errno 9 Bad file descriptor in kevent(...)
```

No `DYLD_INSERT_LIBRARIES` interposer was needed, which matters because the toolchain binaries strip it. Both the shaker and the instrumentation were removed before committing.

## What changed

**`Close the test client's socket once, not twice`**

- `TestTCPClient` becomes a `final class` so the descriptor has exactly one owner, and `closeSocket()` acts at most once. Both call sites stay as they are — the explicit close is load-bearing, the `defer` is still the safety net.
- A new test, *Closing a client twice issues one close(2)*, guards the invariant. It asserts on a count of issued `close(2)` calls rather than reclaiming the released number to watch it survive: winning that race against every other thread in the process is exactly what makes the defect intermittent, and a guard that flakes is worse than none.
- The descriptor-accounting test seeds its pipe pair with `-1` instead of `0`, so a failed `pipe()` cannot leave it aliasing stdin and reproduce the same stale close on descriptor 0. (This keeps #181's larger 50-pipe signal; only the seed changes.)

**`Give each zombie-stream phase its own transport again`**

- The three zombie-stream phases go back to being three `@Test`s that each start and stop their own transport, instead of one composite test sharing a single one. That consolidation only existed to dodge this crash; with the cause gone it costs a failure that names which state actually broke.
- `withPushTransport` owns the lifecycle, so a phase that throws strands neither the transport nor its URLSession — something the shared-transport version did not handle.

## Verification

The tree crashed on the first run before the change. Afterwards: fifteen full runs — four of them with the restored three-transport zombie suite, which is the exact configuration that previously crashed 3/3 — produced no crash and no stale close. 643 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)