### PR TITLE
Track and replay resource subscriptions across re-initializes

### DIFF
--- a/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
@@ -69,14 +69,14 @@ extension MCPServerProxy {
     /// Subscribes to update notifications for a resource URI.
     /// Requires a `resourceNotificationHandler` to be set and the server
     /// to advertise `resources.subscribe` capability.
-    /// The URI is recorded locally; after any re-initialize the proxy replays
-    /// all recorded subscriptions automatically.
+    /// The URI is recorded locally only when the server accepts the request;
+    /// after any re-initialize the proxy replays all recorded subscriptions.
     public func subscribeResource(uri: URL) async throws {
-        subscribedResourceURIs.insert(uri)
         try await requestResult(
             method: "resources/subscribe",
             params: ["uri": .string(uri.absoluteString)]
         )
+        subscribedResourceURIs.insert(uri)
     }
 
     /// Unsubscribes from update notifications for a resource URI.

--- a/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
@@ -190,6 +190,21 @@ extension MCPServerProxy {
         }
     }
 
+    internal func replaySubscriptions() async {
+        for uri in subscribedResourceURIs {
+            do {
+                try await requestResult(
+                    method: "resources/subscribe",
+                    params: ["uri": .string(uri.absoluteString)]
+                )
+            } catch {
+                logger.warning(
+                    "[MCP] Failed to replay subscription for \(uri.absoluteString): \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
     /// Invalidates the cached list of tools.
     public func invalidateToolsCache() {
         cachedTools = nil

--- a/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+API.swift
@@ -69,7 +69,10 @@ extension MCPServerProxy {
     /// Subscribes to update notifications for a resource URI.
     /// Requires a `resourceNotificationHandler` to be set and the server
     /// to advertise `resources.subscribe` capability.
+    /// The URI is recorded locally; after any re-initialize the proxy replays
+    /// all recorded subscriptions automatically.
     public func subscribeResource(uri: URL) async throws {
+        subscribedResourceURIs.insert(uri)
         try await requestResult(
             method: "resources/subscribe",
             params: ["uri": .string(uri.absoluteString)]
@@ -77,7 +80,10 @@ extension MCPServerProxy {
     }
 
     /// Unsubscribes from update notifications for a resource URI.
+    /// The URI is removed from the locally-recorded set immediately so it will
+    /// not be replayed after a re-initialize.
     public func unsubscribeResource(uri: URL) async throws {
+        subscribedResourceURIs.remove(uri)
         try await requestResult(
             method: "resources/unsubscribe",
             params: ["uri": .string(uri.absoluteString)]

--- a/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
@@ -173,6 +173,7 @@ extension MCPServerProxy {
         }
 
         sessionID = nil
+        subscribedResourceURIs = []
     }
 
     /// Drives a line-based transport (stdio / TCP / in-process) through the shared
@@ -317,6 +318,21 @@ extension MCPServerProxy {
         // Send the required notifications/initialized to complete the MCP handshake.
         // Servers may ignore subsequent requests until this notification is received.
         try await sendNotification(JSONRPCMessage.notification(method: "notifications/initialized"))
+
+        // Re-subscribe to any URIs recorded from a previous session. Failures are
+        // logged and skipped so a server that dropped a resource never blocks init.
+        for uri in subscribedResourceURIs {
+            do {
+                try await requestResult(
+                    method: "resources/subscribe",
+                    params: ["uri": .string(uri.absoluteString)]
+                )
+            } catch {
+                logger.warning(
+                    "[MCP] Failed to replay subscription for \(uri.absoluteString): \(error.localizedDescription)"
+                )
+            }
+        }
     }
 
     /// Sends a JSON-RPC notification (fire-and-forget, no response expected).

--- a/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
@@ -319,8 +319,10 @@ extension MCPServerProxy {
         // Servers may ignore subsequent requests until this notification is received.
         try await sendNotification(JSONRPCMessage.notification(method: "notifications/initialized"))
 
-        // Re-subscribe to any URIs recorded from a previous session. Failures are
-        // logged and skipped so a server that dropped a resource never blocks init.
+        await replaySubscriptions()
+    }
+
+    private func replaySubscriptions() async {
         for uri in subscribedResourceURIs {
             do {
                 try await requestResult(

--- a/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy+Lifecycle.swift
@@ -322,21 +322,6 @@ extension MCPServerProxy {
         await replaySubscriptions()
     }
 
-    private func replaySubscriptions() async {
-        for uri in subscribedResourceURIs {
-            do {
-                try await requestResult(
-                    method: "resources/subscribe",
-                    params: ["uri": .string(uri.absoluteString)]
-                )
-            } catch {
-                logger.warning(
-                    "[MCP] Failed to replay subscription for \(uri.absoluteString): \(error.localizedDescription)"
-                )
-            }
-        }
-    }
-
     /// Sends a JSON-RPC notification (fire-and-forget, no response expected).
     internal func sendNotification(_ message: JSONRPCMessage) async throws {
         switch config {

--- a/Sources/SwiftMCP/Client/MCPServerProxy.swift
+++ b/Sources/SwiftMCP/Client/MCPServerProxy.swift
@@ -112,6 +112,13 @@ public final actor MCPServerProxy {
 
     internal var notificationHandlers: [String: NotificationHandlerBox] = [:]
 
+    /// The desired set of subscribed resource URIs. `subscribeResource` adds to
+    /// this set and `unsubscribeResource` removes from it. After any successful
+    /// `initialize` the proxy replays all recorded URIs so subscriptions survive
+    /// session resets without every caller having to implement its own reconnect
+    /// dance. Cleared by `disconnect()` — an intentional teardown starts fresh.
+    internal var subscribedResourceURIs: Set<URL> = []
+
     /// Optional handler for log notifications from the server.
     public var logNotificationHandler: (any MCPServerProxyLogNotificationHandling)? {
         didSet {

--- a/Tests/SwiftMCPTests/SubscriptionReplayTests.swift
+++ b/Tests/SwiftMCPTests/SubscriptionReplayTests.swift
@@ -1,0 +1,110 @@
+#if Server
+// Verifies that MCPServerProxy tracks the desired subscription set locally and
+// replays it automatically after any re-initialize, so callers never have to
+// implement their own reconnect-and-resubscribe dance.
+
+import Foundation
+import Testing
+import SwiftCross
+@testable import SwiftMCP
+
+@Suite("Subscription replay after re-initialize", .serialized)
+struct SubscriptionReplayTests {
+
+    // MARK: - Set management
+
+    @Test("subscribeResource adds URI to local set")
+    func subscribeAddsToSet() async throws {
+        let server = PushFixtureServer()
+        let proxy = MCPServerProxy(config: .stdioHandles(server: server))
+        await proxy.setResourceNotificationHandler(PushRecorder())
+
+        try await proxy.connect()
+        let uri = URL(string: "push://status")!
+        try await proxy.subscribeResource(uri: uri)
+
+        let set = await proxy.subscribedResourceURIs
+        #expect(set.contains(uri))
+
+        await proxy.disconnect()
+    }
+
+    @Test("unsubscribeResource removes URI from local set")
+    func unsubscribeRemovesFromSet() async throws {
+        let server = PushFixtureServer()
+        let proxy = MCPServerProxy(config: .stdioHandles(server: server))
+        await proxy.setResourceNotificationHandler(PushRecorder())
+
+        try await proxy.connect()
+        let uri = URL(string: "push://status")!
+        try await proxy.subscribeResource(uri: uri)
+        try await proxy.unsubscribeResource(uri: uri)
+
+        let set = await proxy.subscribedResourceURIs
+        #expect(!set.contains(uri))
+
+        await proxy.disconnect()
+    }
+
+    @Test("disconnect() clears the subscription set")
+    func disconnectClearsSet() async throws {
+        let server = PushFixtureServer()
+        let proxy = MCPServerProxy(config: .stdioHandles(server: server))
+        await proxy.setResourceNotificationHandler(PushRecorder())
+
+        try await proxy.connect()
+        let uri = URL(string: "push://status")!
+        try await proxy.subscribeResource(uri: uri)
+
+        let before = await proxy.subscribedResourceURIs
+        #expect(before.contains(uri))
+
+        await proxy.disconnect()
+
+        let after = await proxy.subscribedResourceURIs
+        #expect(after.isEmpty)
+    }
+
+    // MARK: - Replay on re-initialize (HTTP, macOS only)
+
+    @Test("subscriptions are replayed on re-initialize", .timeLimit(.minutes(2)))
+    func subscriptionsReplayedAfterReconnect() async throws {
+        #if canImport(FoundationNetworking)
+        return
+        #else
+        let (transport, baseURL) = try await HTTPTransportTestHelpers.startTransport(
+            server: PushFixtureServer()
+        )
+        defer { Task { try? await transport.stop() } }
+
+        let mcpURL = baseURL.appendingPathComponent("mcp")
+        let recorder = PushRecorder()
+        let proxy = MCPServerProxy(config: .sse(config: MCPServerSseConfig(url: mcpURL)))
+        await proxy.setResourceNotificationHandler(recorder)
+
+        // First connection + subscribe
+        try await proxy.connect(clientName: "test", clientVersion: "1.0")
+        let uri = URL(string: "push://status")!
+        try await proxy.subscribeResource(uri: uri)
+
+        // Re-connect without disconnect — simulates session recovery
+        try await proxy.connect(clientName: "test", clientVersion: "1.0")
+
+        // Wait for the new session's general stream to establish
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Broadcast: the replayed subscription on the new session delivers it
+        await transport.broadcastResourceUpdated(uri: uri)
+
+        let received = await HTTPTransportTestHelpers.waitForCondition(
+            timeoutNanoseconds: 5_000_000_000
+        ) {
+            recorder.count > 0
+        }
+        #expect(received, "Expected notification after subscription replay on re-initialize")
+
+        await proxy.disconnect()
+        #endif
+    }
+}
+#endif


### PR DESCRIPTION
Resolves #179.